### PR TITLE
Move async magic to it's own module in tests

### DIFF
--- a/tests/async_mock_ext.py
+++ b/tests/async_mock_ext.py
@@ -1,0 +1,11 @@
+import pytest
+import mock
+
+def async_mock(func):
+    async def async_magic():
+        pass
+
+    async def async_wrap(*args, **kwargs):
+        mock.MagicMock.__await__ = lambda x: async_magic().__await__()
+        await func(*args, **kwargs)
+    return async_wrap

--- a/tests/async_mock_ext.py
+++ b/tests/async_mock_ext.py
@@ -1,7 +1,8 @@
 import pytest
 import mock
 
-def async_mock(func):
+def patch_async_mock(func):
+    """A decorator to allow @mock.patch to work for async methods"""
     async def async_magic():
         pass
 

--- a/tests/cogs/test_bitcoin.py
+++ b/tests/cogs/test_bitcoin.py
@@ -1,13 +1,11 @@
 import pytest
 import mock
 import discord
+from async_mock_ext import async_mock
 from duckbot.cogs.bitcoin import Bitcoin
 
-async def async_magic():
-    pass
-mock.MagicMock.__await__ = lambda x: async_magic().__await__()
-
 @pytest.mark.asyncio
+@async_mock
 @mock.patch('discord.Message')
 @mock.patch('discord.ext.commands.Bot')
 async def test_correct_bitcoin_bot_author(message, bot):
@@ -19,6 +17,7 @@ async def test_correct_bitcoin_bot_author(message, bot):
     message.channel.send.assert_not_called()
 
 @pytest.mark.asyncio
+@async_mock
 @mock.patch('discord.Message')
 @mock.patch('discord.ext.commands.Bot')
 async def test_correct_bitcoin_message_is_bitcoin(message, bot):
@@ -31,6 +30,7 @@ async def test_correct_bitcoin_message_is_bitcoin(message, bot):
     message.channel.send.assert_called_once_with("Magic Beans*")
 
 @pytest.mark.asyncio
+@async_mock
 @mock.patch('discord.Message')
 @mock.patch('discord.ext.commands.Bot')
 async def test_correct_bitcoin_message_contains_bitcoin(message, bot):

--- a/tests/cogs/test_bitcoin.py
+++ b/tests/cogs/test_bitcoin.py
@@ -1,11 +1,11 @@
 import pytest
 import mock
 import discord
-from async_mock_ext import async_mock
+from async_mock_ext import patch_async_mock
 from duckbot.cogs.bitcoin import Bitcoin
 
 @pytest.mark.asyncio
-@async_mock
+@patch_async_mock
 @mock.patch('discord.Message')
 @mock.patch('discord.ext.commands.Bot')
 async def test_correct_bitcoin_bot_author(message, bot):
@@ -17,7 +17,7 @@ async def test_correct_bitcoin_bot_author(message, bot):
     message.channel.send.assert_not_called()
 
 @pytest.mark.asyncio
-@async_mock
+@patch_async_mock
 @mock.patch('discord.Message')
 @mock.patch('discord.ext.commands.Bot')
 async def test_correct_bitcoin_message_is_bitcoin(message, bot):
@@ -30,7 +30,7 @@ async def test_correct_bitcoin_message_is_bitcoin(message, bot):
     message.channel.send.assert_called_once_with("Magic Beans*")
 
 @pytest.mark.asyncio
-@async_mock
+@patch_async_mock
 @mock.patch('discord.Message')
 @mock.patch('discord.ext.commands.Bot')
 async def test_correct_bitcoin_message_contains_bitcoin(message, bot):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,3 @@
+import sys
+import os
+sys.path.append(os.path.dirname(__file__))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
 import sys
 import os
+"""Allow for importing modules in the tests directory"""
 sys.path.append(os.path.dirname(__file__))


### PR DESCRIPTION
We have to redefine `await` in `MagicMock` since pytest is kinda lame. This is just some cleanup to move that redefinition to it's own module so easier reuse.

Related to #14 