### PR TITLE
Change Tiw to the more popular spelling Tyr

### DIFF
--- a/duckbot/cogs/announce_day.py
+++ b/duckbot/cogs/announce_day.py
@@ -13,7 +13,7 @@ days = {
         "Monday",
     ],
     1: [
-        "Tiw's day",
+        "Tyr's day",
         "Tuesday",
         "Dndndndndndndnd"
     ],


### PR DESCRIPTION
https://en.wikipedia.org/wiki/T%C3%BDr
> By way of the process of interpretatio germanica, the deity is the namesake of Tuesday ('Týr's day') in Germanic languages, including English.

Essentially, how we pronounce "Tuesday" is more like Tiw, but the name of the god has been Tyr ever since Old English started being old.