### PR TITLE
More day of the week announcement more flexible

### DIFF
--- a/duckbot/cogs/announce_day.py
+++ b/duckbot/cogs/announce_day.py
@@ -7,57 +7,96 @@ from discord.ext import commands, tasks
 
 
 days = {
-    0: [
-        "the day of the moon",
-        "Moonday",
-        "Monday",
-    ],
-    1: [
-        "Tyr's day",
-        "Tuesday",
-        "Dndndndndndndnd"
-    ],
-    2: [
-        "Odin's day",
-        "Wednesday",
-        "Wednesday, my dudes",
-        "hump day",
-        "Ness' wedding day",
-        "https://www.youtube.com/watch?v=du-TY1GUFGk",
-    ],
-    3: [
-        "Thor's day",
-        "Thorsday",
-        "civ day",
-        "Thursday",
-    ],
-    4: [
-        "Frigga's day",
-        "Friday, Friday, gotta get down on Friday",
-        "Friday",
-    ],
-    5: [
-        "Saturn's day",
-        "Saturday",
-    ],
-    6: [
-        "the day of the sun",
-        "Sunday",
-        "Sunday, Sunday, Sunday",
-    ],
+    0: {
+        "names": [
+            "the day of the moon",
+            "Moonday",
+            "Monday",
+        ],
+        "templates": [
+            "Screw this, it is {0}.",
+        ],
+    },
+    1: {
+        "names": [
+            "Tyr's day",
+            "Tuesday",
+            "Dndndndndndndnd"
+        ],
+        "templates": [
+            "Yo, one of my favourite days ever: {0}.",
+        ],
+    },
+    2: {
+        "names": [
+            "Odin's day",
+            "Wednesday",
+            "Wednesday, my dudes",
+            "hump day",
+            "Ness' wedding day",
+            "https://www.youtube.com/watch?v=du-TY1GUFGk",
+        ],
+        "templates": [
+        ],
+    },
+    3: {
+        "names": [
+            "Thor's day",
+            "Thorsday",
+            "civ day",
+            "Thursday",
+        ],
+        "templates": [
+        ],
+    },
+    4: {
+        "names": [
+            "Frigga's day",
+            "Friday, Friday, gotta get down on Friday",
+            "Friday",
+        ],
+        "templates": [
+        ],
+    },
+    5: {
+        "names": [
+            "Saturn's day",
+            "Saturday",
+        ],
+        "templates": [
+            "WEEKEND ALERT: {0}!",
+        ],
+    },
+    6: {
+        "names": [
+            "the day of the sun",
+            "Sunday",
+            "Sunday, Sunday, Sunday",
+        ],
+        "templates": [
+            "WEEKEND ALERT: {0}!",
+        ],
+    },
 }
 
 templates = [
     "Today is {0}.",
+    "Today: {0}. Tomorrow: {1}.",
     "Brothers, the day is {0}.",
     "Yoooooo, today is {0}! Brother.",
     "The day is {0}. Prepare yourself.",
     "What if I said to you that in fact, today is not {0}? I'd be lying.",
+    "What if I said to you that infact, today is not {1}? I'd be right. It's {0}.",
     "Rejoice, for today is {0}.",
+    "Don't get it twisted, it's {0}.",
     "{0}",
     "It {0}.",
     "Today is {0}, I hope you have your pants on.",
     "Gentlemen, it is with great pleasure that I inform you. Today is {0}.",
+    "Huh, it's {0}, but it feels more like {1}.",
+    "The day of the week according to the Gregorian calendar is {0}.",
+    "Beep boop: {0}.",
+    "I take no please in announcing that today is {0}, for I am a robot.",
 ]
 
 
@@ -78,12 +117,9 @@ class AnnounceDay(commands.Cog):
 
     def get_message(self):
         day = datetime.datetime.now(self.tz).weekday()
-        message = random.choice(days[day])
-
-        if validators.url(message):
-            return f"A video to start your {day}: {message}"
-
-        return random.choice(templates).format(message)
+        today = random.choice(days[day]["names"])
+        tomorrow = random.choice(days[(day + 1) % 7]["names"])
+        return random.choice(templates + days[day]["templates"]).format(today, tomorrow)
 
     @tasks.loop(hours=1.0)
     async def on_hour(self):
@@ -97,3 +133,7 @@ class AnnounceDay(commands.Cog):
     @on_hour.before_loop
     async def before_loop(self):
         await self.bot.wait_until_ready()
+
+    @commands.command(name = "day")
+    async def day_command(self, context):
+        await context.send(self.get_message())

--- a/duckbot/cogs/announce_day.py
+++ b/duckbot/cogs/announce_day.py
@@ -55,6 +55,7 @@ templates = [
     "What if I said to you that in fact, today is not {0}? I'd be lying.",
     "Rejoice, for today is {0}.",
     "{0}",
+    "It {0}.",
     "Today is {0}, I hope you have your pants on.",
     "Gentlemen, it is with great pleasure that I inform you. Today is {0}.",
 ]


### PR DESCRIPTION
Fixes #49

I added a `!day` command to run the announcement on demand. Moreso for testing. It just responds with a random message in the same channel.

I've also included several more templates, some of them including _tomorrow_ as a template parameter as well. For fun.