### PR TITLE
only run actions against the main repo

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   test:
+    if: github.repository == 'Chippers255/duckbot'
     runs-on: self-hosted
     steps:
     - uses: actions/checkout@v2
@@ -19,6 +20,7 @@ jobs:
     - name: Test with pytest
       run: . scripts/build/test.sh
   build:
+    if: github.repository == 'Chippers255/duckbot'
     needs: test
     runs-on: self-hosted
     steps:
@@ -26,7 +28,7 @@ jobs:
     - name: Lint with flake8
       run: . scripts/build/lint.sh
   deploy:
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' && github.repository == 'Chippers255/duckbot'
     needs: build
     runs-on: self-hosted
     steps:


### PR DESCRIPTION
See twentylemon/duckbot#4 and [actions](https://github.com/twentylemon/duckbot/actions) there, I opened a pr against my own repo to see if it'd run. The actions were skipped there, but they seem to have actually run for the pull request. Huzzah?