### PR TITLE
Allow reacting to :tito: for the bot's own messages

### DIFF
--- a/duckbot/cogs/tito.py
+++ b/duckbot/cogs/tito.py
@@ -19,8 +19,5 @@ class Tito(commands.Cog):
     async def react_to_tito_with_yugoslavia(self, message):
         """Adds reactions for all formally Yugoslavian country flags when :tito: is sent."""
 
-        if message.author == self.bot.user:
-            return
-
         if ":tito:" in message.content:
             await asyncio.wait([message.add_reaction(f) for f in self.flags])

--- a/tests/cogs/test_tito.py
+++ b/tests/cogs/test_tito.py
@@ -7,6 +7,16 @@ from cogs.tito import Tito
 @patch_async_mock
 @mock.patch('discord.Message')
 async def test_react_to_tito_with_yugoslavia_message_contains_tito_text(message):
+    message.content = "josip bro tito, brother"
+    clazz = Tito(None)
+    msg = await clazz.react_to_tito_with_yugoslavia(message)
+    assert msg == None
+    message.add_reaction.assert_not_called()
+
+@pytest.mark.asyncio
+@patch_async_mock
+@mock.patch('discord.Message')
+async def test_react_to_tito_with_yugoslavia_message_contains_tito_text(message):
     message.content = "josip bro :tito:, brother"
     clazz = Tito(None)
     msg = await clazz.react_to_tito_with_yugoslavia(message)

--- a/tests/cogs/test_tito.py
+++ b/tests/cogs/test_tito.py
@@ -6,24 +6,9 @@ from cogs.tito import Tito
 @pytest.mark.asyncio
 @patch_async_mock
 @mock.patch('discord.Message')
-@mock.patch('discord.ext.commands.Bot')
-async def test_react_to_tito_with_yugoslavia_bot_author(message, bot):
-    bot.user = "THEBOT"
-    message.author = bot.user
-    clazz = Tito(bot)
-    msg = await clazz.react_to_tito_with_yugoslavia(message)
-    assert msg == None
-    message.add_reaction.assert_not_called()
-
-@pytest.mark.asyncio
-@patch_async_mock
-@mock.patch('discord.Message')
-@mock.patch('discord.ext.commands.Bot')
-async def test_react_to_tito_with_yugoslavia_message_contains_tito_text(message, bot):
-    bot.user = "but"
-    message.author = "author"
+async def test_react_to_tito_with_yugoslavia_message_contains_tito_text(message):
     message.content = "josip bro :tito:, brother"
-    clazz = Tito(bot)
+    clazz = Tito(None)
     msg = await clazz.react_to_tito_with_yugoslavia(message)
     assert msg == None
     assert_flags_sent(message)
@@ -31,12 +16,9 @@ async def test_react_to_tito_with_yugoslavia_message_contains_tito_text(message,
 @pytest.mark.asyncio
 @patch_async_mock
 @mock.patch('discord.Message')
-@mock.patch('discord.ext.commands.Bot')
-async def test_react_to_tito_with_yugoslavia_message_contains_tito_emoji(message, bot):
-    bot.user = "but"
-    message.author = "author"
+async def test_react_to_tito_with_yugoslavia_message_contains_tito_emoji(message):
     message.content = "josip bro <:tito:780954015285641276>, brother"
-    clazz = Tito(bot)
+    clazz = Tito(None)
     msg = await clazz.react_to_tito_with_yugoslavia(message)
     assert msg == None
     assert_flags_sent(message)

--- a/tests/cogs/test_tito.py
+++ b/tests/cogs/test_tito.py
@@ -6,7 +6,7 @@ from cogs.tito import Tito
 @pytest.mark.asyncio
 @patch_async_mock
 @mock.patch('discord.Message')
-async def test_react_to_tito_with_yugoslavia_message_contains_tito_text(message):
+async def test_react_to_tito_with_yugoslavia_no_tito_emoji(message):
     message.content = "josip bro tito, brother"
     clazz = Tito(None)
     msg = await clazz.react_to_tito_with_yugoslavia(message)


### PR DESCRIPTION
~~Build currently failing due to #62, will update after fix merged in. Running the test module alone passes.~~ Now working after merge.

```
tarasmy@me:~/git/duckbot$ pytest -s tests/cogs/test_tito.py 
============================================================================= test session starts ==============================================================================
platform linux -- Python 3.8.0, pytest-6.2.2, py-1.10.0, pluggy-0.13.1
rootdir: /home/ANT.AMAZON.COM/tarasmy/git/duckbot
plugins: repeat-0.9.1, mock-3.5.1, asyncio-0.14.0
collected 3 items                                                                                                                                                              

tests/cogs/test_tito.py ...

============================================================================== 3 passed in 0.14s ===============================================================================
tarasmy@me:~/git/duckbot$
```