### PR TITLE
Change channels, emojis to be dynamically populated

### DIFF
--- a/duckbot/cogs/announce_day.py
+++ b/duckbot/cogs/announce_day.py
@@ -1,6 +1,4 @@
 import random
-import server.channels as channels
-import server.emojis as emojis
 import datetime
 import pytz
 import holidays
@@ -109,7 +107,7 @@ class AnnounceDay(commands.Cog):
     def __init__(self, bot, start_tasks=True):
         self.bot = bot
         self.tz = pytz.timezone("US/Eastern")
-        self.holidays = SpecialDays()
+        self.holidays = SpecialDays(bot)
         if start_tasks:
             self.on_hour.start()
 
@@ -138,7 +136,7 @@ class AnnounceDay(commands.Cog):
 
     async def __on_hour(self):
         if self.should_announce_day():
-            channel = self.bot.get_channel(channels.GENERAL)
+            channel = self.bot.get_cog("channels").get_general_channel()
             message = self.get_message()
             await channel.send(message)
 
@@ -157,6 +155,10 @@ class SpecialDays(holidays.Canada):
     @see https://github.com/dr-prodigy/python-holidays/blob/master/holidays/countries/canada.py
     """
 
+    def __init__(self, bot):
+        holidays.Canada.__init__(self)
+        self.bot = bot
+
     def _populate(self, year):
         holidays.Canada._populate(self, year)
 
@@ -170,7 +172,7 @@ class SpecialDays(holidays.Canada):
         self[datetime.date(year, 3, 25)] = "The Day the One Ring was cast into the fires of Mt. Doom, bringing about the fall of Sauron"
         self[datetime.date(year, 4, 12)] = "National Grilled Cheese Day"
         self[datetime.date(year, 5, 1) + rd(weekday=SU(+2))] = "Mother's Day"
-        self[datetime.date(year, 5, 7)] = f"Bro Tito Day {emojis.TITO}"
+        self[datetime.date(year, 5, 7)] = f"Bro Tito Day {self.bot.get_cog('emojis').get_emoji_by_name('tito')}"
         self[datetime.date(year, 6, 1) + rd(weekday=SU(+3))] = "Father's Day"
         self[datetime.date(year, 6, 21)] = f"Erin's Birthday. She's {year-1991} years old"
         self[datetime.date(year, 9, 8)] = f"Dan's Birthday. He {year-1989} old"

--- a/duckbot/cogs/insights.py
+++ b/duckbot/cogs/insights.py
@@ -1,6 +1,5 @@
 import random
 import datetime
-import server.channels as channels
 from discord.ext import commands, tasks
 
 responses = [
@@ -27,7 +26,7 @@ class Insights(commands.Cog):
         await self.__check_should_respond()
 
     async def __check_should_respond(self):
-        channel = self.bot.get_channel(channels.GENERAL)
+        channel = self.bot.get_cog("channels").get_general_channel()
         message = await self.__get_last_message(channel)
         if self.should_respond(message):
             response = random.choice(responses)

--- a/duckbot/main.py
+++ b/duckbot/main.py
@@ -9,27 +9,18 @@ from cogs.kubernetes import Kubernetes
 from cogs.announce_day import AnnounceDay
 from cogs.thanking_robot import ThankingRobot
 from discord.ext import commands
-
-
-bot = commands.Bot(command_prefix='!', help_command=None)
-
-
-@bot.event
-async def on_ready():
-    guild_count = 0
-
-    for guild in bot.guilds:
-        print(f"- {guild.id} (name: {guild.name})")
-        for channel in guild.channels:
-            print(f"  - channel: {channel.id} (#{channel.name})")
-        for emoji in guild.emojis:
-            print(f"  - emoji: {emoji}")
-        guild_count = guild_count + 1
-
-    print(f"DuckBot is in {guild_count} guilds.")
+from server.channels import Channels
+from server.emojis import Emojis
 
 
 if __name__ == "__main__":
+    bot = commands.Bot(command_prefix='!', help_command=None)
+
+    # server cogs must be loaded first; any references to
+    # them should happen in or after the `on_ready` event
+    bot.add_cog(Channels(bot))
+    bot.add_cog(Emojis(bot))
+
     bot.add_cog(Duck(bot))
     bot.add_cog(Tito(bot))
     bot.add_cog(Typos(bot))

--- a/duckbot/server/channels.py
+++ b/duckbot/server/channels.py
@@ -1,10 +1,49 @@
-GENERAL = 780860661675720765
-GAMES = 780860661675720766
-DJ_BOOTH = 780860661675720767
-MEMES = 780861208051187742
-TOMS_MEMES = 780861255195557889
-GLUTEN = 780863478138798100
-WORK = 781566835669073971
-DUCKBUTT = 786022972153921546
-STONKS = 803628090102120479
-DUCKBOARD = 811275051713298495
+from discord.ext import commands, tasks
+
+
+class Channels(commands.Cog, name="channels"):
+    """Provides access to server channels.
+    Currently assumes that DuckBot is only ever in a single server."""
+
+    def __init__(self, bot, start_tasks=True):
+        self.bot = bot
+        self.guild = 0
+        self.channels = {}
+        if start_tasks:
+            self.refresh.start()
+
+    def cog_unload(self):
+        self.refresh.cancel()
+
+    @commands.Cog.listener('on_ready')
+    async def populate(self):
+        self.__refresh(print_channels=True)
+
+    @tasks.loop(hours=24.0)
+    async def refresh(self):
+        self.__refresh()
+
+    def __refresh(self, print_channels=False):
+        channels = {}
+        gid = 0
+        for guild in self.bot.guilds:
+            gid = guild.id
+            channels[gid] = {}
+            for channel in guild.channels:
+                if print_channels:
+                    print(f"registering channel: {channel.id} (#{channel.name})")
+                channels[gid][channel.id] = channel
+        self.channels = channels
+        self.guild = gid
+
+    def get_channel_by_name(self, name):
+        """Returns the channel with the given name. Throws if it does not exist."""
+        return next(channel for channel in self.channels[self.guild].values() if channel.name == name)
+
+    def get_channel(self, id):
+        """Returns the channel with the given id. Throws if it does not exist."""
+        return self.channels[self.guild][id]
+
+    def get_general_channel(self):
+        """Returns the general channel. Throws if it does not exist."""
+        return self.get_channel_by_name("general")

--- a/duckbot/server/emojis.py
+++ b/duckbot/server/emojis.py
@@ -1,11 +1,45 @@
-TITO = "<:tito:780954015285641276>"
-GOTEM = "<:gotem:780986078772461598>"
-SUPERMAX = "<:supermax:780988112275767337>"
-FACE = "<:face:780988570982023208>"
-BROTHER1 = "<:brother1:781002586365886475>"
-BROTHER2 = "<:brother2:780994002438586418>"
-SAX1 = "<:sax1:781676935671185408>"
-SAX2 = "<:sax2:781677013227405364>"
-SAX3 = "<:sax3:781677043691290624>"
-BRAWNDO = "<:brawndo:790774519559487538>"
-PORKCHOP_SANDWICH = "<:porkchop_sandwich:812018903526014997>"
+from discord.ext import commands, tasks
+
+
+class Emojis(commands.Cog, name="emojis"):
+    """Provides access to server emojis.
+    Currently assumes that DuckBot is only ever in a single server."""
+
+    def __init__(self, bot, start_tasks=True):
+        self.bot = bot
+        self.guild = 0
+        self.emojis = {}
+        if start_tasks:
+            self.refresh.start()
+
+    def cog_unload(self):
+        self.refresh.cancel()
+
+    @commands.Cog.listener('on_ready')
+    async def populate(self):
+        self.__refresh(print_emojis=True)
+
+    @tasks.loop(hours=24.0)
+    async def refresh(self):
+        self.__refresh()
+
+    def __refresh(self, print_emojis=False):
+        emojis = {}
+        gid = 0
+        for guild in self.bot.guilds:
+            gid = guild.id
+            emojis[gid] = {}
+            for emoji in guild.emojis:
+                if print_emojis:
+                    print(f"registering emoji: {emoji}")
+                emojis[gid][emoji.id] = emoji
+        self.emojis = emojis
+        self.guild = gid
+
+    def get_emoji_by_name(self, name):
+        """Returns the emoji with the given name. Throws if it does not exist."""
+        return next(emoji for emoji in self.emojis[self.guild].values() if emoji.name == name)
+
+    def get_emoji(self, id):
+        """Returns the emoji with the given id. Throws if it does not exist."""
+        return self.emojis[self.guild][id]

--- a/tests/cogs/test_announce_day.py
+++ b/tests/cogs/test_announce_day.py
@@ -2,7 +2,6 @@ import pytest
 import mock
 import datetime
 from async_mock_ext import patch_async_mock
-import server.channels as channels
 from cogs.announce_day import AnnounceDay
 from duckmock.datetime import patch_now
 
@@ -10,24 +9,28 @@ from duckmock.datetime import patch_now
 @pytest.mark.asyncio
 @patch_async_mock
 @mock.patch('discord.ext.commands.Bot')
+@mock.patch('server.channels')
 @mock.patch('discord.TextChannel')
-async def test_on_hour_7am_eastern(bot, channel):
+async def test_on_hour_7am_eastern(bot, channels, channel):
     with patch_now(datetime.datetime(2002, 1, 1, hour=7)):
-        bot.get_channel.return_value = channel
+        bot.get_cog.return_value = channels
+        channels.get_general_channel.return_value = channel
         clazz = AnnounceDay(bot, start_tasks=False)
         await clazz._AnnounceDay__on_hour()
-        bot.get_channel.assert_called_once_with(channels.GENERAL)
+        channels.get_general_channel.assert_called()
         channel.send.assert_called()
 
 
 @pytest.mark.asyncio
 @patch_async_mock
 @mock.patch('discord.ext.commands.Bot')
+@mock.patch('server.channels')
 @mock.patch('discord.TextChannel')
-async def test_on_hour_not_7am(bot, channel):
+async def test_on_hour_not_7am(bot, channels, channel):
     with patch_now(datetime.datetime(2002, 1, 1, hour=8)):
-        bot.get_channel.return_value = channel
+        bot.get_cog.return_value = channels
+        channels.get_general_channel.return_value = channel
         clazz = AnnounceDay(bot, start_tasks=False)
         await clazz._AnnounceDay__on_hour()
-        bot.get_channel.assert_not_called()
+        channels.get_general_channel.assert_not_called()
         channel.send.assert_not_called()

--- a/tests/cogs/test_insights.py
+++ b/tests/cogs/test_insights.py
@@ -3,7 +3,6 @@ import mock
 import datetime
 from async_mock_ext import patch_async_mock
 from duckmock.discord import MockAsyncIterator
-import server.channels as channels
 from cogs.insights import Insights
 from duckmock.datetime import patch_utcnow
 
@@ -11,62 +10,70 @@ from duckmock.datetime import patch_utcnow
 @pytest.mark.asyncio
 @patch_async_mock
 @mock.patch('discord.ext.commands.Bot')
+@mock.patch('server.channels')
 @mock.patch('discord.TextChannel')
-async def test_check_should_respond_no_messages(bot, channel):
-    bot.get_channel.return_value = channel
+async def test_check_should_respond_no_messages(bot, channels, channel):
+    bot.get_cog.return_value = channels
+    channels.get_general_channel.return_value = channel
     channel.history.return_value = MockAsyncIterator(None)
     clazz = Insights(bot, start_tasks=False)
     await clazz._Insights__check_should_respond()
-    bot.get_channel.assert_called_once_with(channels.GENERAL)
+    channels.get_general_channel.assert_called()
     channel.send.assert_not_called()
 
 
 @pytest.mark.asyncio
 @patch_async_mock
 @mock.patch('discord.ext.commands.Bot')
+@mock.patch('server.channels')
 @mock.patch('discord.TextChannel')
 @mock.patch('discord.Message')
-async def test_check_should_respond_new_message(bot, channel, message):
+async def test_check_should_respond_new_message(bot, channels, channel, message):
     with patch_utcnow(datetime.datetime(2000, 1, 1, hour=12, minute=00)):
-        bot.get_channel.return_value = channel
+        bot.get_cog.return_value = channels
+        channels.get_general_channel.return_value = channel
         message.created_at = datetime.datetime(2000, 1, 1, hour=11, minute=38)
         message.author.id = 244629273191645184
         channel.history.return_value = MockAsyncIterator(message)
         clazz = Insights(bot, start_tasks=False)
         await clazz._Insights__check_should_respond()
-        bot.get_channel.assert_called_once_with(channels.GENERAL)
+        channels.get_general_channel.assert_called()
         channel.send.assert_not_called()
 
 
 @pytest.mark.asyncio
 @patch_async_mock
 @mock.patch('discord.ext.commands.Bot')
+@mock.patch('server.channels')
 @mock.patch('discord.TextChannel')
 @mock.patch('discord.Message')
-async def test_check_should_respond_not_special_user(bot, channel, message):
+async def test_check_should_respond_not_special_user(bot, channels, channel, message):
     with patch_utcnow(datetime.datetime(2000, 1, 1, hour=12, minute=00)):
-        bot.get_channel.return_value = channel
+        bot.get_cog.return_value = channels
+        channels.get_general_channel.return_value = channel
         message.created_at = datetime.datetime(2000, 1, 1, hour=11, minute=00)
         message.author.id = 0
         channel.history.return_value = MockAsyncIterator(message)
         clazz = Insights(bot, start_tasks=False)
         await clazz._Insights__check_should_respond()
-        bot.get_channel.assert_called_once_with(channels.GENERAL)
+        channels.get_general_channel.assert_called()
         channel.send.assert_not_called()
 
 
 @pytest.mark.asyncio
 @patch_async_mock
 @mock.patch('discord.ext.commands.Bot')
+@mock.patch('server.channels')
 @mock.patch('discord.TextChannel')
 @mock.patch('discord.Message')
-async def test_check_should_respond_old_message_sent_by_special_user(bot, channel, message):
+async def test_check_should_respond_old_message_sent_by_special_user(bot, channels, channel, message):
     with patch_utcnow(datetime.datetime(2000, 1, 1, hour=12, minute=00)):
-        bot.get_channel.return_value = channel
+        bot.get_cog.return_value = channels
+        channels.get_general_channel.return_value = channel
         message.created_at = datetime.datetime(2000, 1, 1, hour=11, minute=00)
         message.author.id = 244629273191645184
         channel.history.return_value = MockAsyncIterator(message)
         clazz = Insights(bot, start_tasks=False)
         await clazz._Insights__check_should_respond()
-        bot.get_channel.assert_called_once_with(channels.GENERAL)
+        channels.get_general_channel.assert_called()
         channel.send.assert_called()

--- a/tests/server/test_channels.py
+++ b/tests/server/test_channels.py
@@ -1,0 +1,88 @@
+import pytest
+import mock
+from async_mock_ext import patch_async_mock
+from server.channels import Channels
+
+
+@pytest.mark.asyncio
+@patch_async_mock
+@mock.patch('discord.ext.commands.Bot')
+@mock.patch('discord.Guild')
+@mock.patch('discord.TextChannel')
+async def test_get_channel_channel_exists(bot, guild, channel):
+    setup_mocks(bot, guild, channel)
+    clazz = Channels(bot, start_tasks=False)
+    clazz._Channels__refresh()
+    assert clazz.get_channel(channel.id) == channel
+
+
+@pytest.mark.asyncio
+@patch_async_mock
+@mock.patch('discord.ext.commands.Bot')
+@mock.patch('discord.Guild')
+@mock.patch('discord.TextChannel')
+async def test_get_channel_not_exists(bot, guild, channel):
+    setup_mocks(bot, guild, channel)
+    clazz = Channels(bot, start_tasks=False)
+    clazz._Channels__refresh()
+    with pytest.raises(KeyError):
+        clazz.get_channel(channel.id + 1)
+
+
+@pytest.mark.asyncio
+@patch_async_mock
+@mock.patch('discord.ext.commands.Bot')
+@mock.patch('discord.Guild')
+@mock.patch('discord.TextChannel')
+async def test_get_channel_by_name_matches(bot, guild, channel):
+    setup_mocks(bot, guild, channel)
+    clazz = Channels(bot, start_tasks=False)
+    clazz._Channels__refresh()
+    assert clazz.get_channel_by_name(channel.name) == channel
+
+
+@pytest.mark.asyncio
+@patch_async_mock
+@mock.patch('discord.ext.commands.Bot')
+@mock.patch('discord.Guild')
+@mock.patch('discord.TextChannel')
+async def test_get_channel_by_name_not_exists(bot, guild, channel):
+    setup_mocks(bot, guild, channel)
+    clazz = Channels(bot, start_tasks=False)
+    clazz._Channels__refresh()
+    with pytest.raises(StopIteration):
+        clazz.get_channel_by_name(channel.name + "dead")
+
+
+@pytest.mark.asyncio
+@patch_async_mock
+@mock.patch('discord.ext.commands.Bot')
+@mock.patch('discord.Guild')
+@mock.patch('discord.TextChannel')
+async def test_get_general_channel_exists(bot, guild, channel):
+    setup_mocks(bot, guild, channel)
+    clazz = Channels(bot, start_tasks=False)
+    clazz._Channels__refresh()
+    assert clazz.get_general_channel() == channel
+
+
+@pytest.mark.asyncio
+@patch_async_mock
+@mock.patch('discord.ext.commands.Bot')
+@mock.patch('discord.Guild')
+@mock.patch('discord.TextChannel')
+async def test_get_general_channel_not_exists(bot, guild, channel):
+    setup_mocks(bot, guild, channel)
+    channel.name = "not general"
+    clazz = Channels(bot, start_tasks=False)
+    clazz._Channels__refresh()
+    with pytest.raises(StopIteration):
+        clazz.get_general_channel()
+
+
+def setup_mocks(bot, guild, channel):
+    bot.guilds = [guild]
+    guild.id = 1
+    guild.channels = [channel]
+    channel.id = 1
+    channel.name = "general"

--- a/tests/server/test_emojis.py
+++ b/tests/server/test_emojis.py
@@ -1,0 +1,62 @@
+import pytest
+import mock
+from async_mock_ext import patch_async_mock
+from server.emojis import Emojis
+
+
+@pytest.mark.asyncio
+@patch_async_mock
+@mock.patch('discord.ext.commands.Bot')
+@mock.patch('discord.Guild')
+@mock.patch('discord.Emoji')
+async def test_get_emoji_emoji_exists(bot, guild, emoji):
+    setup_mocks(bot, guild, emoji)
+    clazz = Emojis(bot, start_tasks=False)
+    clazz._Emojis__refresh()
+    assert clazz.get_emoji(emoji.id) == emoji
+
+
+@pytest.mark.asyncio
+@patch_async_mock
+@mock.patch('discord.ext.commands.Bot')
+@mock.patch('discord.Guild')
+@mock.patch('discord.Emoji')
+async def test_get_emoji_not_exists(bot, guild, emoji):
+    setup_mocks(bot, guild, emoji)
+    clazz = Emojis(bot, start_tasks=False)
+    clazz._Emojis__refresh()
+    with pytest.raises(KeyError):
+        clazz.get_emoji(emoji.id + 1)
+
+
+@pytest.mark.asyncio
+@patch_async_mock
+@mock.patch('discord.ext.commands.Bot')
+@mock.patch('discord.Guild')
+@mock.patch('discord.Emoji')
+async def test_get_emoji_by_name_matches(bot, guild, emoji):
+    setup_mocks(bot, guild, emoji)
+    clazz = Emojis(bot, start_tasks=False)
+    clazz._Emojis__refresh()
+    assert clazz.get_emoji_by_name(emoji.name) == emoji
+
+
+@pytest.mark.asyncio
+@patch_async_mock
+@mock.patch('discord.ext.commands.Bot')
+@mock.patch('discord.Guild')
+@mock.patch('discord.Emoji')
+async def test_get_emoji_by_name_not_exists(bot, guild, emoji):
+    setup_mocks(bot, guild, emoji)
+    clazz = Emojis(bot, start_tasks=False)
+    clazz._Emojis__refresh()
+    with pytest.raises(StopIteration):
+        clazz.get_emoji_by_name(emoji.name + "dead")
+
+
+def setup_mocks(bot, guild, emoji):
+    bot.guilds = [guild]
+    guild.id = 1
+    guild.emojis = [emoji]
+    emoji.id = 1
+    emoji.name = "tito"


### PR DESCRIPTION
Defines `channels` and `emojis` cogs which pull from the server when the bot starts up, and refreshes daily. For now, they include super dumb helper methods to fetch a channel/emoji by it's name.