### PR TITLE
Add docker-test script, which builds/tests duckbot in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# runs duckbot; requires .env to be available which contains api tokens
 FROM python:3.8
 COPY requirements.txt /
 RUN python -m pip install --upgrade pip

--- a/README.md
+++ b/README.md
@@ -12,18 +12,24 @@ The `scripts/build` directory contains scripts for development.
 
 ### Install Dependencies
 Should be run whenever you pull from `upstream/main`.
-```
+```sh
 . scripts/build/install.sh
 ```
 
 ### Run Tests and Linter
-```
+```sh
 . scripts/build/test.sh
 . scripts/build/lint.sh
 ```
 
+### Containerized Tests
+If you like containers, you can also run all the tests as part of a docker image build. If the docker image is built, all the tests passed. The script deletes the image afterwards, pass or fail.
+```sh
+. scripts/build/docker-test.sh
+```
+
 ### Run DuckBot
 Requires `duckbut/.env` to be present, and the `TOKEN` environment variable to be set therein.
-```
+```sh
 . scripts/duckbot.sh
 ```

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,6 @@
+pytest
+pytest-asyncio
+pytest-mock
+mock
+
+flake8

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,6 @@
-pytest
-pytest-asyncio
-pytest-mock
-mock
 discord.py
 python-dotenv
 validators
 beautifulsoup4
 pytz
 holidays
-
-# for linter
-flake8

--- a/scripts/build/Dockerfile
+++ b/scripts/build/Dockerfile
@@ -1,0 +1,9 @@
+# attempt to build and test duckbot
+# should this docker image build, dockbot *should* be able to run
+FROM python:3.8 as python
+COPY . /duckbot
+WORKDIR /duckbot
+RUN python -m pip install --upgrade pip
+RUN [ "/bin/bash", "-c", ". scripts/build/install.sh" ]
+RUN [ "/bin/bash", "-c", ". scripts/build/compile.sh" ]
+RUN [ "/bin/bash", "-c", ". scripts/build/test.sh" ]

--- a/scripts/build/docker-test.sh
+++ b/scripts/build/docker-test.sh
@@ -1,0 +1,6 @@
+# runs a containerized install/build/test
+. $(git rev-parse --show-toplevel)/scripts/ensure-toplevel.sh && \
+
+docker build . --file scripts/build/Dockerfile --tag duckbot-test:latest
+
+docker rmi duckbot-test:latest

--- a/scripts/build/install.sh
+++ b/scripts/build/install.sh
@@ -1,2 +1,4 @@
 # install package requirements
-python3.8 -m pip install -r "$(git rev-parse --show-toplevel)/requirements.txt"
+python3.8 -m pip install -r "$(git rev-parse --show-toplevel)/requirements.txt" && \
+# install test and build dependencies
+python3.8 -m pip install -r "$(git rev-parse --show-toplevel)/requirements-dev.txt"


### PR DESCRIPTION
The point here is to aid with the deployment side of things. We can run this script (well, the `Dockerfile` at least) before the deployment to ensure duckbot will actually work, and we won't bring it down by performing the deployment.