### PR TITLE
Onboard code formatter

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,5 @@
+
+To you, the pull request author:
+* ensure you've formatted the code. run  `. scripts/build/format.sh` from the repository root.
+* ensure you have tests and they pass. run `. scripts/build/test.sh`
+* link to the issue you're fixing if one exists. uses a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) to autolink and close the issue once this pull request is merged

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,3 +3,4 @@ To you, the pull request author:
 * ensure you've formatted the code. run  `. scripts/build/format.sh` from the repository root.
 * ensure you have tests and they pass. run `. scripts/build/test.sh`
 * link to the issue you're fixing if one exists. uses a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) to autolink and close the issue once this pull request is merged
+* finally, remove this garbage and write a description

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -18,9 +18,9 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: '3.8'
-    - name: Install dependencies
+    - name: Install Dependencies
       run: . scripts/build/install.sh
-    - name: Test with pytest
+    - name: Run Tests
       run: . scripts/build/test.sh
   build:
     runs-on: ubuntu-latest
@@ -31,9 +31,9 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: '3.8'
-    - name: Install dependencies
+    - name: Install Dependencies
       run: . scripts/build/install.sh
-    - name: Ensure main interprets
+    - name: Ensure main Interprets
       run: . scripts/build/compile.sh
-    - name: Lint with flake8
+    - name: Run Lint Checks
       run: . scripts/build/lint.sh

--- a/README.md
+++ b/README.md
@@ -16,8 +16,9 @@ Should be run whenever you pull from `upstream/main`.
 . scripts/build/install.sh
 ```
 
-### Run Tests and Linter
+### Run Formatter, Tests and Linter
 ```sh
+. scripts/build/format.sh
 . scripts/build/test.sh
 . scripts/build/lint.sh
 ```

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Build Status](https://img.shields.io/github/workflow/status/Chippers255/duckbot/DuckBot%20CI)](https://github.com/Chippers255/duckbot/actions/workflows/python-package.yml)
 [![Code Smells](https://sonarcloud.io/api/project_badges/measure?project=Chippers255_duckbot&metric=code_smells)](https://sonarcloud.io/dashboard?id=Chippers255_duckbot)
 [![Vulnerabilities](https://sonarcloud.io/api/project_badges/measure?project=Chippers255_duckbot&metric=vulnerabilities)](https://sonarcloud.io/dashboard?id=Chippers255_duckbot)
+[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 
 A Discord bot for personal friend group. If you don't know me personally, consider how freaking weird it'd be to ask for the access token. Feel free to steal the code though.
 

--- a/duckbot/cogs/__init__.py
+++ b/duckbot/cogs/__init__.py
@@ -4,4 +4,4 @@ from os.path import dirname, basename, isfile, join
 
 modules = glob.glob(join(dirname(__file__), "*.py"))
 
-__all__ = [basename(f)[:-3] for f in modules if isfile(f) and not f.endswith('__init__.py')]
+__all__ = [basename(f)[:-3] for f in modules if isfile(f) and not f.endswith("__init__.py")]

--- a/duckbot/cogs/announce_day.py
+++ b/duckbot/cogs/announce_day.py
@@ -19,7 +19,11 @@ days = {
         ],
     },
     1: {
-        "names": ["Tyr's day", "Tuesday", "Dndndndndndndnd"],
+        "names": [
+            "Tyr's day",
+            "Tuesday",
+            "Dndndndndndndnd",
+        ],
         "templates": [
             "Yo, one of my favourite days ever: {0}.",
         ],

--- a/duckbot/cogs/announce_day.py
+++ b/duckbot/cogs/announce_day.py
@@ -19,11 +19,7 @@ days = {
         ],
     },
     1: {
-        "names": [
-            "Tyr's day",
-            "Tuesday",
-            "Dndndndndndndnd"
-        ],
+        "names": ["Tyr's day", "Tuesday", "Dndndndndndndnd"],
         "templates": [
             "Yo, one of my favourite days ever: {0}.",
         ],
@@ -37,8 +33,7 @@ days = {
             "Ness' wedding day",
             "https://www.youtube.com/watch?v=du-TY1GUFGk",
         ],
-        "templates": [
-        ],
+        "templates": [],
     },
     3: {
         "names": [
@@ -47,8 +42,7 @@ days = {
             "civ day",
             "Thursday",
         ],
-        "templates": [
-        ],
+        "templates": [],
     },
     4: {
         "names": [
@@ -56,8 +50,7 @@ days = {
             "Friday, Friday, gotta get down on Friday",
             "Friday",
         ],
-        "templates": [
-        ],
+        "templates": [],
     },
     5: {
         "names": [
@@ -104,7 +97,6 @@ templates = [
 
 
 class AnnounceDay(commands.Cog):
-
     def __init__(self, bot, start_tasks=True):
         self.bot = bot
         self.tz = pytz.timezone("US/Eastern")

--- a/duckbot/cogs/bitcoin.py
+++ b/duckbot/cogs/bitcoin.py
@@ -2,11 +2,10 @@ from discord.ext import commands
 
 
 class Bitcoin(commands.Cog):
-
     def __init__(self, bot):
         self.bot = bot
 
-    @commands.Cog.listener('on_message')
+    @commands.Cog.listener("on_message")
     async def correct_bitcoin(self, message):
         """Corrections for bitcoin"""
 

--- a/duckbot/cogs/duck.py
+++ b/duckbot/cogs/duck.py
@@ -3,11 +3,10 @@ import random
 
 
 class Duck(commands.Cog):
-
     def __init__(self, bot):
         self.bot = bot
 
-    @commands.Cog.listener('on_message')
+    @commands.Cog.listener("on_message")
     async def react_duck(self, message):
         """Tiny chance to react with :duck: to any message."""
         if random.random() < 1.0 / 10_000.0:

--- a/duckbot/cogs/insights.py
+++ b/duckbot/cogs/insights.py
@@ -20,7 +20,6 @@ responses = [
 
 
 class Insights(commands.Cog):
-
     def __init__(self, bot, start_tasks=True):
         self.bot = bot
         if start_tasks:

--- a/duckbot/cogs/kubernetes.py
+++ b/duckbot/cogs/kubernetes.py
@@ -2,11 +2,10 @@ from discord.ext import commands
 
 
 class Kubernetes(commands.Cog):
-
     def __init__(self, bot):
         self.bot = bot
 
-    @commands.Cog.listener('on_message')
+    @commands.Cog.listener("on_message")
     async def correct_kubernets(self, message):
         """Corrections for kubernetes"""
 
@@ -20,7 +19,7 @@ class Kubernetes(commands.Cog):
                 correction = f"I think {author} means K8s"
                 await message.channel.send(correction)
 
-    @commands.Cog.listener('on_message')
+    @commands.Cog.listener("on_message")
     async def correct_k8s(self, message):
         """Corrections for K8s"""
 

--- a/duckbot/cogs/recipe.py
+++ b/duckbot/cogs/recipe.py
@@ -7,7 +7,6 @@ from discord.ext import commands
 
 
 class Recipe(commands.Cog):
-
     def __init__(self, bot):
         self.bot = bot
 
@@ -20,16 +19,16 @@ class Recipe(commands.Cog):
     def parse_recipes(html_content):
         """Parse raw HTML from allrecipes to find a list of recipes."""
         recipe_list = []
-        soup = BeautifulSoup(html_content, 'html.parser')
+        soup = BeautifulSoup(html_content, "html.parser")
 
         articles = soup.findAll("div", {"class": "component card card__recipe card__facetedSearchResult"})
 
         for article in articles:
             data = {}
             try:
-                data["name"] = article.find("h3", {"class": "card__title"}).get_text().strip(' \t\n\r')
-                data["description"] = article.find("div", {"class": "card__summary"}).get_text().strip(' \t\n\r')
-                data["url"] = article.find("a", href=re.compile('^https://www.allrecipes.com/recipe/'))['href']
+                data["name"] = article.find("h3", {"class": "card__title"}).get_text().strip(" \t\n\r")
+                data["description"] = article.find("div", {"class": "card__summary"}).get_text().strip(" \t\n\r")
+                data["url"] = article.find("a", href=re.compile("^https://www.allrecipes.com/recipe/"))["href"]
                 data["rating"] = len(article.findAll("span", {"class": "rating-star active"}))
 
                 recipe_list.append(data)
@@ -48,7 +47,7 @@ class Recipe(commands.Cog):
             query_url = urllib.parse.urlencode(query_dict)
             url = f"https://www.allrecipes.com/element-api/content-proxy/faceted-searches-load-more?{query_url}"
             req = urllib.request.Request(url)
-            req.add_header('Cookie', 'euConsent=true')
+            req.add_header("Cookie", "euConsent=true")
 
             result = json.loads(urllib.request.urlopen(req).read())
             html_content += result.get("html", "")
@@ -60,8 +59,8 @@ class Recipe(commands.Cog):
 
     async def __recipe(self, context, *args):
         # clean up the arguments to make a valid recipe search
-        search_term = ' '.join(args)
-        search_term = re.sub(r'[^\w\s]', '', search_term)
+        search_term = " ".join(args)
+        search_term = re.sub(r"[^\w\s]", "", search_term)
 
         try:
             # search for recipes on allrecipes.com

--- a/duckbot/cogs/thanking_robot.py
+++ b/duckbot/cogs/thanking_robot.py
@@ -2,11 +2,10 @@ from discord.ext import commands
 
 
 class ThankingRobot(commands.Cog):
-
     def __init__(self, bot):
         self.bot = bot
 
-    @commands.Cog.listener('on_message')
+    @commands.Cog.listener("on_message")
     async def correct_giving_thanks(self, message):
         """Correcting people who thank the robot"""
 

--- a/duckbot/cogs/tito.py
+++ b/duckbot/cogs/tito.py
@@ -3,7 +3,6 @@ import asyncio
 
 
 class Tito(commands.Cog):
-
     def __init__(self, bot):
         self.bot = bot
         self.flags = [
@@ -16,13 +15,13 @@ class Tito(commands.Cog):
             "\U0001F1F8\U0001F1EE",  # :flag_si:
         ]
 
-    @commands.Cog.listener('on_message')
+    @commands.Cog.listener("on_message")
     async def react_to_tito_with_yugoslavia(self, message):
         """Adds reactions for all formally Yugoslavian country flags when :tito: is sent."""
         if ":tito:" in message.content:
             await asyncio.wait([message.add_reaction(f) for f in self.flags])
 
-    @commands.Cog.listener('on_raw_reaction_add')
+    @commands.Cog.listener("on_raw_reaction_add")
     async def react_to_tito_reaction(self, payload):
         """Adds reactions for all formally Yugoslavian country flags when :tito: is added as reaction."""
         if payload.emoji.name == "tito":

--- a/duckbot/cogs/typos.py
+++ b/duckbot/cogs/typos.py
@@ -4,7 +4,6 @@ from discord.ext import commands, tasks
 
 
 class Typos(commands.Cog):
-
     def __init__(self, bot, start_tasks=True):
         self.bot = bot
         self.corrections = {}
@@ -17,7 +16,7 @@ class Typos(commands.Cog):
     def get_wiki_corrections(self):
         request = urllib.request.Request("https://en.wikipedia.org/wiki/Wikipedia:Lists_of_common_misspellings/For_machines")
         html_content = urllib.request.urlopen(request).read()
-        soup = BeautifulSoup(html_content, 'html.parser')
+        soup = BeautifulSoup(html_content, "html.parser")
         text = soup.findAll("pre")[-1].get_text()
         return {line[0]: line[1].split(", ") for line in (x.split("->") for x in text.splitlines())}
 
@@ -43,7 +42,7 @@ class Typos(commands.Cog):
         self.corrections = {**self.get_wiki_corrections(), **self.__get_custom_corrections()}
         await self.bot.wait_until_ready()
 
-    @commands.Cog.listener('on_message')
+    @commands.Cog.listener("on_message")
     async def correct_typos(self, message):
         """Try to correct common typos for user's previous message."""
         if message.content.strip().lower() == "fuck":

--- a/duckbot/main.py
+++ b/duckbot/main.py
@@ -16,7 +16,7 @@ from server.emojis import Emojis
 
 
 if __name__ == "__main__":
-    bot = commands.Bot(command_prefix='!', help_command=None)
+    bot = commands.Bot(command_prefix="!", help_command=None)
 
     # server cogs must be loaded first; any references to
     # them should happen in or after the `on_ready` event
@@ -35,6 +35,6 @@ if __name__ == "__main__":
 
     if "dry-run" not in sys.argv:
         # load the token from .env file
-        dotenv_path = os.path.join(os.path.dirname(__file__), '.env')
+        dotenv_path = os.path.join(os.path.dirname(__file__), ".env")
         dotenv.load_dotenv(dotenv_path)
         bot.run(os.environ["TOKEN"])

--- a/duckbot/server/channels.py
+++ b/duckbot/server/channels.py
@@ -15,7 +15,7 @@ class Channels(commands.Cog, name="channels"):
     def cog_unload(self):
         self.refresh.cancel()
 
-    @commands.Cog.listener('on_ready')
+    @commands.Cog.listener("on_ready")
     async def populate(self):
         self.__refresh(print_channels=True)
 

--- a/duckbot/server/emojis.py
+++ b/duckbot/server/emojis.py
@@ -15,7 +15,7 @@ class Emojis(commands.Cog, name="emojis"):
     def cog_unload(self):
         self.refresh.cancel()
 
-    @commands.Cog.listener('on_ready')
+    @commands.Cog.listener("on_ready")
     async def populate(self):
         self.__refresh(print_emojis=True)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,4 @@
+[tool.black]
+line-length = 200
+target-version = ['py38']
+exclude = '\.git'

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,3 +4,4 @@ pytest-mock
 mock
 
 flake8
+black

--- a/scripts/build/Dockerfile
+++ b/scripts/build/Dockerfile
@@ -7,3 +7,4 @@ RUN python -m pip install --upgrade pip
 RUN [ "/bin/bash", "-c", ". scripts/build/install.sh" ]
 RUN [ "/bin/bash", "-c", ". scripts/build/compile.sh" ]
 RUN [ "/bin/bash", "-c", ". scripts/build/test.sh" ]
+RUN [ "/bin/bash", "-c", ". scripts/build/lint.sh" ]

--- a/scripts/build/format.sh
+++ b/scripts/build/format.sh
@@ -1,0 +1,4 @@
+. $(git rev-parse --show-toplevel)/scripts/ensure-toplevel.sh && \
+
+# change format.sh if this is changed!
+python3.8 -m black --line-length 200 duckbot tests

--- a/scripts/build/format.sh
+++ b/scripts/build/format.sh
@@ -1,4 +1,4 @@
 . $(git rev-parse --show-toplevel)/scripts/ensure-toplevel.sh && \
 
-# change lint.sh if this is changed!
-python3.8 -m black --line-length 200 duckbot tests
+# run black formatter on the code
+python3.8 -m black duckbot tests

--- a/scripts/build/format.sh
+++ b/scripts/build/format.sh
@@ -1,4 +1,4 @@
 . $(git rev-parse --show-toplevel)/scripts/ensure-toplevel.sh && \
 
-# change format.sh if this is changed!
+# change lint.sh if this is changed!
 python3.8 -m black --line-length 200 duckbot tests

--- a/scripts/build/lint.sh
+++ b/scripts/build/lint.sh
@@ -6,5 +6,5 @@ python3.8 -m flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics 
 # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
 python3.8 -m flake8 . --count --exit-zero --max-complexity=10 --max-line-length=200 --statistics && \
 
-# check if the formatter ran; change format.sh if this is changed!
-python3.8 -m black --line-length 200 --diff --check duckbot tests
+# check if the format is correct
+python3.8 -m black --diff --check duckbot tests

--- a/scripts/build/lint.sh
+++ b/scripts/build/lint.sh
@@ -1,9 +1,10 @@
 . $(git rev-parse --show-toplevel)/scripts/ensure-toplevel.sh && \
 
 # stop the build if there are Python syntax errors or undefined names
-# python3.8 -m flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics && \
+python3.8 -m flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics && \
 
 # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-# python3.8 -m flake8 . --count --exit-zero --max-complexity=10 --max-line-length=200 --statistics
+python3.8 -m flake8 . --count --exit-zero --max-complexity=10 --max-line-length=200 --statistics && \
 
-python3.8 -m black --line-length 200 duckbot tests
+# check if the formatter ran; change format.sh if this is changed!
+python3.8 -m black --line-length 200 --diff --check duckbot tests

--- a/scripts/build/lint.sh
+++ b/scripts/build/lint.sh
@@ -1,7 +1,9 @@
 . $(git rev-parse --show-toplevel)/scripts/ensure-toplevel.sh && \
 
 # stop the build if there are Python syntax errors or undefined names
-python3.8 -m flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics && \
+# python3.8 -m flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics && \
 
 # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-python3.8 -m flake8 . --count --exit-zero --max-complexity=10 --max-line-length=200 --statistics
+# python3.8 -m flake8 . --count --exit-zero --max-complexity=10 --max-line-length=200 --statistics
+
+python3.8 -m black --line-length 200 duckbot tests

--- a/tests/async_mock_ext.py
+++ b/tests/async_mock_ext.py
@@ -3,6 +3,7 @@ import mock
 
 def patch_async_mock(func):
     """A decorator to allow @mock.patch to work for async methods"""
+
     async def async_magic():
         """This method's __await__ is used to hack mock awaits. No implementation needed."""
         pass
@@ -10,6 +11,7 @@ def patch_async_mock(func):
     async def async_wrap(*args, **kwargs):
         mock.MagicMock.__await__ = lambda x: async_magic().__await__()
         await func(*args, **kwargs)
+
     return async_wrap
 
 

--- a/tests/cogs/test_announce_day.py
+++ b/tests/cogs/test_announce_day.py
@@ -8,9 +8,9 @@ from duckmock.datetime import patch_now
 
 @pytest.mark.asyncio
 @patch_async_mock
-@mock.patch('discord.ext.commands.Bot')
-@mock.patch('server.channels')
-@mock.patch('discord.TextChannel')
+@mock.patch("discord.ext.commands.Bot")
+@mock.patch("server.channels")
+@mock.patch("discord.TextChannel")
 async def test_on_hour_7am_eastern(bot, channels, channel):
     with patch_now(datetime.datetime(2002, 1, 1, hour=7)):
         bot.get_cog.return_value = channels
@@ -23,9 +23,9 @@ async def test_on_hour_7am_eastern(bot, channels, channel):
 
 @pytest.mark.asyncio
 @patch_async_mock
-@mock.patch('discord.ext.commands.Bot')
-@mock.patch('server.channels')
-@mock.patch('discord.TextChannel')
+@mock.patch("discord.ext.commands.Bot")
+@mock.patch("server.channels")
+@mock.patch("discord.TextChannel")
 async def test_on_hour_not_7am(bot, channels, channel):
     with patch_now(datetime.datetime(2002, 1, 1, hour=8)):
         bot.get_cog.return_value = channels

--- a/tests/cogs/test_bitcoin.py
+++ b/tests/cogs/test_bitcoin.py
@@ -6,8 +6,8 @@ from cogs.bitcoin import Bitcoin
 
 @pytest.mark.asyncio
 @patch_async_mock
-@mock.patch('discord.Message')
-@mock.patch('discord.ext.commands.Bot')
+@mock.patch("discord.Message")
+@mock.patch("discord.ext.commands.Bot")
 async def test_correct_bitcoin_bot_author(message, bot):
     bot.user = "THEBOT"
     message.author = bot.user
@@ -19,8 +19,8 @@ async def test_correct_bitcoin_bot_author(message, bot):
 
 @pytest.mark.asyncio
 @patch_async_mock
-@mock.patch('discord.Message')
-@mock.patch('discord.ext.commands.Bot')
+@mock.patch("discord.Message")
+@mock.patch("discord.ext.commands.Bot")
 async def test_correct_bitcoin_message_is_bitcoin(message, bot):
     bot.user = "but"
     message.author = "author"
@@ -33,8 +33,8 @@ async def test_correct_bitcoin_message_is_bitcoin(message, bot):
 
 @pytest.mark.asyncio
 @patch_async_mock
-@mock.patch('discord.Message')
-@mock.patch('discord.ext.commands.Bot')
+@mock.patch("discord.Message")
+@mock.patch("discord.ext.commands.Bot")
 async def test_correct_bitcoin_message_contains_bitcoin(message, bot):
     bot.user = "but"
     message.author = "author"

--- a/tests/cogs/test_duck.py
+++ b/tests/cogs/test_duck.py
@@ -6,8 +6,8 @@ from cogs.duck import Duck
 
 @pytest.mark.asyncio
 @patch_async_mock
-@mock.patch('discord.Message')
-@mock.patch('random.random', return_value=0.0001)
+@mock.patch("discord.Message")
+@mock.patch("random.random", return_value=0.0001)
 async def test_react_duck_random_passes(message, random):
     clazz = Duck(None)
     msg = await clazz.react_duck(message)
@@ -17,8 +17,8 @@ async def test_react_duck_random_passes(message, random):
 
 @pytest.mark.asyncio
 @patch_async_mock
-@mock.patch('discord.Message')
-@mock.patch('random.random', return_value=0.000009)
+@mock.patch("discord.Message")
+@mock.patch("random.random", return_value=0.000009)
 async def test_react_duck_random_fails(message, random):
     clazz = Duck(None)
     msg = await clazz.react_duck(message)
@@ -28,7 +28,7 @@ async def test_react_duck_random_fails(message, random):
 
 @pytest.mark.asyncio
 @patch_async_mock
-@mock.patch('discord.ext.commands.Context')
+@mock.patch("discord.ext.commands.Context")
 async def test_github(context):
     clazz = Duck(None)
     await clazz._Duck__github(context)
@@ -37,7 +37,7 @@ async def test_github(context):
 
 @pytest.mark.asyncio
 @patch_async_mock
-@mock.patch('discord.ext.commands.Context')
+@mock.patch("discord.ext.commands.Context")
 async def test_wiki(context):
     clazz = Duck(None)
     await clazz._Duck__wiki(context)

--- a/tests/cogs/test_insights.py
+++ b/tests/cogs/test_insights.py
@@ -9,9 +9,9 @@ from duckmock.datetime import patch_utcnow
 
 @pytest.mark.asyncio
 @patch_async_mock
-@mock.patch('discord.ext.commands.Bot')
-@mock.patch('server.channels')
-@mock.patch('discord.TextChannel')
+@mock.patch("discord.ext.commands.Bot")
+@mock.patch("server.channels")
+@mock.patch("discord.TextChannel")
 async def test_check_should_respond_no_messages(bot, channels, channel):
     bot.get_cog.return_value = channels
     channels.get_general_channel.return_value = channel
@@ -24,10 +24,10 @@ async def test_check_should_respond_no_messages(bot, channels, channel):
 
 @pytest.mark.asyncio
 @patch_async_mock
-@mock.patch('discord.ext.commands.Bot')
-@mock.patch('server.channels')
-@mock.patch('discord.TextChannel')
-@mock.patch('discord.Message')
+@mock.patch("discord.ext.commands.Bot")
+@mock.patch("server.channels")
+@mock.patch("discord.TextChannel")
+@mock.patch("discord.Message")
 async def test_check_should_respond_new_message(bot, channels, channel, message):
     with patch_utcnow(datetime.datetime(2000, 1, 1, hour=12, minute=00)):
         bot.get_cog.return_value = channels
@@ -43,10 +43,10 @@ async def test_check_should_respond_new_message(bot, channels, channel, message)
 
 @pytest.mark.asyncio
 @patch_async_mock
-@mock.patch('discord.ext.commands.Bot')
-@mock.patch('server.channels')
-@mock.patch('discord.TextChannel')
-@mock.patch('discord.Message')
+@mock.patch("discord.ext.commands.Bot")
+@mock.patch("server.channels")
+@mock.patch("discord.TextChannel")
+@mock.patch("discord.Message")
 async def test_check_should_respond_not_special_user(bot, channels, channel, message):
     with patch_utcnow(datetime.datetime(2000, 1, 1, hour=12, minute=00)):
         bot.get_cog.return_value = channels
@@ -62,10 +62,10 @@ async def test_check_should_respond_not_special_user(bot, channels, channel, mes
 
 @pytest.mark.asyncio
 @patch_async_mock
-@mock.patch('discord.ext.commands.Bot')
-@mock.patch('server.channels')
-@mock.patch('discord.TextChannel')
-@mock.patch('discord.Message')
+@mock.patch("discord.ext.commands.Bot")
+@mock.patch("server.channels")
+@mock.patch("discord.TextChannel")
+@mock.patch("discord.Message")
 async def test_check_should_respond_old_message_sent_by_special_user(bot, channels, channel, message):
     with patch_utcnow(datetime.datetime(2000, 1, 1, hour=12, minute=00)):
         bot.get_cog.return_value = channels
@@ -81,7 +81,7 @@ async def test_check_should_respond_old_message_sent_by_special_user(bot, channe
 
 @pytest.mark.asyncio
 @patch_async_mock
-@mock.patch('discord.ext.commands.Context')
+@mock.patch("discord.ext.commands.Context")
 async def test_insight_command_sends_message(context):
     clazz = Insights(None, start_tasks=False)
     await clazz._Insights__insight(context)

--- a/tests/cogs/test_recipe.py
+++ b/tests/cogs/test_recipe.py
@@ -7,17 +7,12 @@ from cogs.recipe import Recipe
 
 
 def get_mock_data(name, rating):
-    return {
-        "name": name,
-        "description": f"This is the {name} recipe.",
-        "url": f"https://www.allrecipes.com/recipe/10759/{name}/",
-        "rating": rating
-    }
+    return {"name": name, "description": f"This is the {name} recipe.", "url": f"https://www.allrecipes.com/recipe/10759/{name}/", "rating": rating}
 
 
 @pytest.mark.asyncio
 @patch_async_mock
-@mock.patch('discord.ext.commands.Bot')
+@mock.patch("discord.ext.commands.Bot")
 async def test_search_recipes_returns_scraped_html(bot):
     mock_data = get_mock_data("test1", 5)
     with patch_urlopen(with_articles(mock_data)):
@@ -29,7 +24,7 @@ async def test_search_recipes_returns_scraped_html(bot):
 
 @pytest.mark.asyncio
 @patch_async_mock
-@mock.patch('discord.ext.commands.Bot')
+@mock.patch("discord.ext.commands.Bot")
 async def test_parse_recipes_returns_articles(bot):
     mock_data = get_mock_data("test1", 5)
     expected_response = [get_mock_data("test1", 5) for _ in range(5)]
@@ -41,7 +36,7 @@ async def test_parse_recipes_returns_articles(bot):
 
 @pytest.mark.asyncio
 @patch_async_mock
-@mock.patch('discord.ext.commands.Bot')
+@mock.patch("discord.ext.commands.Bot")
 async def test_parse_recipes_returns_empty(bot):
     expected_response = []
     html = without_articles()
@@ -52,7 +47,7 @@ async def test_parse_recipes_returns_empty(bot):
 
 @pytest.mark.asyncio
 @patch_async_mock
-@mock.patch('discord.ext.commands.Bot')
+@mock.patch("discord.ext.commands.Bot")
 async def test_parse_recipes_no_content_returns_empty(bot):
     expected_response = []
     html = without_content()
@@ -63,7 +58,7 @@ async def test_parse_recipes_no_content_returns_empty(bot):
 
 @pytest.mark.asyncio
 @patch_async_mock
-@mock.patch('discord.ext.commands.Bot')
+@mock.patch("discord.ext.commands.Bot")
 async def test_select_recipes_with_one_return_one(bot):
     recipe_list = [get_mock_data("test1", 5)]
     clazz = Recipe(bot)
@@ -73,7 +68,7 @@ async def test_select_recipes_with_one_return_one(bot):
 
 @pytest.mark.asyncio
 @patch_async_mock
-@mock.patch('discord.ext.commands.Bot')
+@mock.patch("discord.ext.commands.Bot")
 async def test_select_recipes_with_many_return_one(bot):
     recipe_list = [get_mock_data("test1", 5), get_mock_data("test2", 4)]
     clazz = Recipe(bot)
@@ -83,8 +78,8 @@ async def test_select_recipes_with_many_return_one(bot):
 
 @pytest.mark.asyncio
 @patch_async_mock
-@mock.patch('discord.ext.commands.Bot')
-@mock.patch('discord.ext.commands.Context')
+@mock.patch("discord.ext.commands.Bot")
+@mock.patch("discord.ext.commands.Context")
 async def test_command_with_content_return_recipe(bot, context):
     mock_data = get_mock_data("test1", 5)
     expected_response = f"How about a nice {mock_data['name']}. {mock_data['description']} This recipe has a {mock_data['rating']}/5 rating! {mock_data['url']}"
@@ -97,8 +92,8 @@ async def test_command_with_content_return_recipe(bot, context):
 
 @pytest.mark.asyncio
 @patch_async_mock
-@mock.patch('discord.ext.commands.Bot')
-@mock.patch('discord.ext.commands.Context')
+@mock.patch("discord.ext.commands.Bot")
+@mock.patch("discord.ext.commands.Context")
 async def test_command_without_articles_return_sorry(bot, context):
     with patch_urlopen(without_articles()):
         search_term = "test1"
@@ -110,8 +105,8 @@ async def test_command_without_articles_return_sorry(bot, context):
 
 @pytest.mark.asyncio
 @patch_async_mock
-@mock.patch('discord.ext.commands.Bot')
-@mock.patch('discord.ext.commands.Context')
+@mock.patch("discord.ext.commands.Bot")
+@mock.patch("discord.ext.commands.Context")
 async def test_command_without_content_return_sorry(bot, context):
     with patch_urlopen(without_content()):
         search_term = "test1"
@@ -215,7 +210,9 @@ def with_articles(*args):
          </div>
       </div>
    </div>
-</div>""".replace("\n", "\\n")
+</div>""".replace(
+            "\n", "\\n"
+        )
     return html + """","hasNext":true,"totalResults":4624}"""
 
 

--- a/tests/cogs/test_thanking_robot.py
+++ b/tests/cogs/test_thanking_robot.py
@@ -6,8 +6,8 @@ from cogs.thanking_robot import ThankingRobot
 
 @pytest.mark.asyncio
 @patch_async_mock
-@mock.patch('discord.Message')
-@mock.patch('discord.ext.commands.Bot')
+@mock.patch("discord.Message")
+@mock.patch("discord.ext.commands.Bot")
 async def test_correct_giving_thanks_bot_author(message, bot):
     bot.user = "THEBOT"
     message.author = bot.user
@@ -19,8 +19,8 @@ async def test_correct_giving_thanks_bot_author(message, bot):
 
 @pytest.mark.asyncio
 @patch_async_mock
-@mock.patch('discord.Message')
-@mock.patch('discord.ext.commands.Bot')
+@mock.patch("discord.Message")
+@mock.patch("discord.ext.commands.Bot")
 async def test_correct_bitcoin_message_is_bitcoin(message, bot):
     bot.user = "but"
     message.author = "author"
@@ -33,8 +33,8 @@ async def test_correct_bitcoin_message_is_bitcoin(message, bot):
 
 @pytest.mark.asyncio
 @patch_async_mock
-@mock.patch('discord.Message')
-@mock.patch('discord.ext.commands.Bot')
+@mock.patch("discord.Message")
+@mock.patch("discord.ext.commands.Bot")
 async def test_correct_bitcoin_message_contains_bitcoin(message, bot):
     bot.user = "but"
     message.author = "author"

--- a/tests/cogs/test_tito.py
+++ b/tests/cogs/test_tito.py
@@ -6,7 +6,7 @@ from cogs.tito import Tito
 
 @pytest.mark.asyncio
 @patch_async_mock
-@mock.patch('discord.Message')
+@mock.patch("discord.Message")
 async def test_react_to_tito_with_yugoslavia_no_tito_emoji(message):
     message.content = "josip bro tito, brother"
     clazz = Tito(None)
@@ -17,7 +17,7 @@ async def test_react_to_tito_with_yugoslavia_no_tito_emoji(message):
 
 @pytest.mark.asyncio
 @patch_async_mock
-@mock.patch('discord.Message')
+@mock.patch("discord.Message")
 async def test_react_to_tito_with_yugoslavia_message_contains_tito_text(message):
     message.content = "josip bro :tito:, brother"
     clazz = Tito(None)
@@ -28,7 +28,7 @@ async def test_react_to_tito_with_yugoslavia_message_contains_tito_text(message)
 
 @pytest.mark.asyncio
 @patch_async_mock
-@mock.patch('discord.Message')
+@mock.patch("discord.Message")
 async def test_react_to_tito_with_yugoslavia_message_contains_tito_emoji(message):
     message.content = "josip bro <:tito:780954015285641276>, brother"
     clazz = Tito(None)
@@ -39,8 +39,8 @@ async def test_react_to_tito_with_yugoslavia_message_contains_tito_emoji(message
 
 @pytest.mark.asyncio
 @patch_async_mock
-@mock.patch('discord.ext.commands.Bot')
-@mock.patch('discord.RawReactionActionEvent')
+@mock.patch("discord.ext.commands.Bot")
+@mock.patch("discord.RawReactionActionEvent")
 async def test_react_to_tito_reaction_no_tito_emoji(bot, payload):
     payload.emoji.name = "not-tito"
     clazz = Tito(bot)
@@ -50,10 +50,10 @@ async def test_react_to_tito_reaction_no_tito_emoji(bot, payload):
 
 @pytest.mark.asyncio
 @patch_async_mock
-@mock.patch('discord.ext.commands.Bot')
-@mock.patch('discord.RawReactionActionEvent')
-@mock.patch('discord.TextChannel')
-@mock.patch('discord.Message')
+@mock.patch("discord.ext.commands.Bot")
+@mock.patch("discord.RawReactionActionEvent")
+@mock.patch("discord.TextChannel")
+@mock.patch("discord.Message")
 async def test_react_to_tito_reaction_tito_emoji(bot, payload, channel, message):
     payload.channel_id = 123
     payload.message_id = 456

--- a/tests/cogs/test_typos.py
+++ b/tests/cogs/test_typos.py
@@ -9,7 +9,7 @@ URLOPEN = "urllib.request.urlopen"
 
 @pytest.mark.asyncio
 @patch_async_mock
-@mock.patch('discord.ext.commands.Bot')
+@mock.patch("discord.ext.commands.Bot")
 async def test_get_wiki_corrections(bot):
     with patch_urlopen(content("poo->oops")):
         clazz = Typos(bot, start_tasks=False)
@@ -19,7 +19,7 @@ async def test_get_wiki_corrections(bot):
 
 @pytest.mark.asyncio
 @patch_async_mock
-@mock.patch('discord.ext.commands.Bot')
+@mock.patch("discord.ext.commands.Bot")
 async def test_correct(bot):
     with patch_urlopen(content("")):
         clazz = Typos(bot, start_tasks=False)
@@ -30,7 +30,7 @@ async def test_correct(bot):
 
 @pytest.mark.asyncio
 @patch_async_mock
-@mock.patch('discord.ext.commands.Bot')
+@mock.patch("discord.ext.commands.Bot")
 async def test_correct_case_insensitive(bot):
     with patch_urlopen(content("")):
         clazz = Typos(bot, start_tasks=False)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import sys
 import os
+
 # allow for importing modules in the tests directory
 sys.path.append(os.path.dirname(__file__))
 

--- a/tests/duckmock/datetime/__init__.py
+++ b/tests/duckmock/datetime/__init__.py
@@ -1,4 +1,3 @@
-
 import mock
 import datetime
 

--- a/tests/duckmock/discord/__init__.py
+++ b/tests/duckmock/discord/__init__.py
@@ -1,2 +1,1 @@
-
 from .async_iterator import MockAsyncIterator

--- a/tests/duckmock/discord/async_iterator.py
+++ b/tests/duckmock/discord/async_iterator.py
@@ -1,7 +1,7 @@
-
 class MockAsyncIterator:
     """A simple mock implementation for `channel.history`
     and other AsyncIterator values."""
+
     # note, impl is minimal, needs expanding for fit other use cases
     def __init__(self, message):
         self.message = message

--- a/tests/duckmock/urllib/request.py
+++ b/tests/duckmock/urllib/request.py
@@ -1,6 +1,6 @@
-
 class MockResponse:
     """A stub implementation for `urllib.request.urlopen`"""
+
     status: int
     data: bytes
 

--- a/tests/server/test_channels.py
+++ b/tests/server/test_channels.py
@@ -6,9 +6,9 @@ from server.channels import Channels
 
 @pytest.mark.asyncio
 @patch_async_mock
-@mock.patch('discord.ext.commands.Bot')
-@mock.patch('discord.Guild')
-@mock.patch('discord.TextChannel')
+@mock.patch("discord.ext.commands.Bot")
+@mock.patch("discord.Guild")
+@mock.patch("discord.TextChannel")
 async def test_get_channel_channel_exists(bot, guild, channel):
     setup_mocks(bot, guild, channel)
     clazz = Channels(bot, start_tasks=False)
@@ -18,9 +18,9 @@ async def test_get_channel_channel_exists(bot, guild, channel):
 
 @pytest.mark.asyncio
 @patch_async_mock
-@mock.patch('discord.ext.commands.Bot')
-@mock.patch('discord.Guild')
-@mock.patch('discord.TextChannel')
+@mock.patch("discord.ext.commands.Bot")
+@mock.patch("discord.Guild")
+@mock.patch("discord.TextChannel")
 async def test_get_channel_not_exists(bot, guild, channel):
     setup_mocks(bot, guild, channel)
     clazz = Channels(bot, start_tasks=False)
@@ -31,9 +31,9 @@ async def test_get_channel_not_exists(bot, guild, channel):
 
 @pytest.mark.asyncio
 @patch_async_mock
-@mock.patch('discord.ext.commands.Bot')
-@mock.patch('discord.Guild')
-@mock.patch('discord.TextChannel')
+@mock.patch("discord.ext.commands.Bot")
+@mock.patch("discord.Guild")
+@mock.patch("discord.TextChannel")
 async def test_get_channel_by_name_matches(bot, guild, channel):
     setup_mocks(bot, guild, channel)
     clazz = Channels(bot, start_tasks=False)
@@ -43,9 +43,9 @@ async def test_get_channel_by_name_matches(bot, guild, channel):
 
 @pytest.mark.asyncio
 @patch_async_mock
-@mock.patch('discord.ext.commands.Bot')
-@mock.patch('discord.Guild')
-@mock.patch('discord.TextChannel')
+@mock.patch("discord.ext.commands.Bot")
+@mock.patch("discord.Guild")
+@mock.patch("discord.TextChannel")
 async def test_get_channel_by_name_not_exists(bot, guild, channel):
     setup_mocks(bot, guild, channel)
     clazz = Channels(bot, start_tasks=False)
@@ -56,9 +56,9 @@ async def test_get_channel_by_name_not_exists(bot, guild, channel):
 
 @pytest.mark.asyncio
 @patch_async_mock
-@mock.patch('discord.ext.commands.Bot')
-@mock.patch('discord.Guild')
-@mock.patch('discord.TextChannel')
+@mock.patch("discord.ext.commands.Bot")
+@mock.patch("discord.Guild")
+@mock.patch("discord.TextChannel")
 async def test_get_general_channel_exists(bot, guild, channel):
     setup_mocks(bot, guild, channel)
     clazz = Channels(bot, start_tasks=False)
@@ -68,9 +68,9 @@ async def test_get_general_channel_exists(bot, guild, channel):
 
 @pytest.mark.asyncio
 @patch_async_mock
-@mock.patch('discord.ext.commands.Bot')
-@mock.patch('discord.Guild')
-@mock.patch('discord.TextChannel')
+@mock.patch("discord.ext.commands.Bot")
+@mock.patch("discord.Guild")
+@mock.patch("discord.TextChannel")
 async def test_get_general_channel_not_exists(bot, guild, channel):
     setup_mocks(bot, guild, channel)
     channel.name = "not general"

--- a/tests/server/test_emojis.py
+++ b/tests/server/test_emojis.py
@@ -6,9 +6,9 @@ from server.emojis import Emojis
 
 @pytest.mark.asyncio
 @patch_async_mock
-@mock.patch('discord.ext.commands.Bot')
-@mock.patch('discord.Guild')
-@mock.patch('discord.Emoji')
+@mock.patch("discord.ext.commands.Bot")
+@mock.patch("discord.Guild")
+@mock.patch("discord.Emoji")
 async def test_get_emoji_emoji_exists(bot, guild, emoji):
     setup_mocks(bot, guild, emoji)
     clazz = Emojis(bot, start_tasks=False)
@@ -18,9 +18,9 @@ async def test_get_emoji_emoji_exists(bot, guild, emoji):
 
 @pytest.mark.asyncio
 @patch_async_mock
-@mock.patch('discord.ext.commands.Bot')
-@mock.patch('discord.Guild')
-@mock.patch('discord.Emoji')
+@mock.patch("discord.ext.commands.Bot")
+@mock.patch("discord.Guild")
+@mock.patch("discord.Emoji")
 async def test_get_emoji_not_exists(bot, guild, emoji):
     setup_mocks(bot, guild, emoji)
     clazz = Emojis(bot, start_tasks=False)
@@ -31,9 +31,9 @@ async def test_get_emoji_not_exists(bot, guild, emoji):
 
 @pytest.mark.asyncio
 @patch_async_mock
-@mock.patch('discord.ext.commands.Bot')
-@mock.patch('discord.Guild')
-@mock.patch('discord.Emoji')
+@mock.patch("discord.ext.commands.Bot")
+@mock.patch("discord.Guild")
+@mock.patch("discord.Emoji")
 async def test_get_emoji_by_name_matches(bot, guild, emoji):
     setup_mocks(bot, guild, emoji)
     clazz = Emojis(bot, start_tasks=False)
@@ -43,9 +43,9 @@ async def test_get_emoji_by_name_matches(bot, guild, emoji):
 
 @pytest.mark.asyncio
 @patch_async_mock
-@mock.patch('discord.ext.commands.Bot')
-@mock.patch('discord.Guild')
-@mock.patch('discord.Emoji')
+@mock.patch("discord.ext.commands.Bot")
+@mock.patch("discord.Guild")
+@mock.patch("discord.Emoji")
 async def test_get_emoji_by_name_not_exists(bot, guild, emoji):
     setup_mocks(bot, guild, emoji)
     clazz = Emojis(bot, start_tasks=False)


### PR DESCRIPTION
Adding a code formatter to the build, [black](https://pypi.org/project/black/).
* added a `format` script to format the code base; black suggests putting this in a pre-commit hook, but I don't like the idea of code being changed on commit, since formatters can break things
    * added configuration for black in `pyproject.toml`. unfortunately, we can't add the files it runs on to there, but it can store line length and some other sharable config
* added lint checks to the `docker-test` script. I'm unsure if this really makes sense (since lint doesn't really break the build), let me know what you think
* [I think I] added a pull request template including info about formatting the code
* minor updates to task names in the actions
* ran the formatter on the code base; no logic changes anywhere else