### PR TITLE
Combine `test` and `build` actions

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -5,9 +5,11 @@ name: DuckBot CI
 
 on:
   push:
-    branches: [ main ]
+    branches:
+    - main
   pull_request:
-    branches: [ main ]
+    branches:
+    - main
 
 jobs:
   test:
@@ -22,17 +24,6 @@ jobs:
       run: . scripts/build/install.sh
     - name: Run Tests
       run: . scripts/build/test.sh
-  build:
-    runs-on: ubuntu-latest
-    needs: test
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v2
-      with:
-        python-version: '3.8'
-    - name: Install Dependencies
-      run: . scripts/build/install.sh
     - name: Ensure main Interprets
       run: . scripts/build/compile.sh
     - name: Run Lint Checks

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -12,7 +12,7 @@ on:
     - main
 
 jobs:
-  test:
+  release:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
This is just to reduce noise in the #duckbutt channel. We get

> [duckbot] test success on branch
> [duckbot] build success on branch

plus the sonarcloud comments, but they're all part of the build. It'll also speed up the actions a bit since `install` takes a while and is performed twice.

The repository settings would also have to be updated, since `test` and `build` are marked as required checks. Now it's just `release`.