### PR TITLE
copy .env file to correct location for deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,8 @@
-# runs duckbot; requires .env to be available which contains api tokens
+# runs duckbot; requires duckbot/.env to be available which contains api tokens
 FROM python:3.8
 COPY requirements.txt /
 RUN python -m pip install --upgrade pip
 RUN python -m pip install -r /requirements.txt
 COPY duckbot/ /duckbot/duckbot
-COPY .env /duckbot/duckbot/.env
 WORKDIR /duckbot
 CMD [ "python", "-m", "duckbot" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,6 @@ COPY requirements.txt /
 RUN python -m pip install --upgrade pip
 RUN python -m pip install -r /requirements.txt
 COPY duckbot/ /duckbot/duckbot
-COPY .env /duckbot/.env
+COPY .env /duckbot/duckbot/.env
 WORKDIR /duckbot
 CMD [ "python", "-m", "duckbot" ]


### PR DESCRIPTION
Deployment failed this morning, deploying #101. I tested the docker stuff locally and it always worked, so I'm not 100% what went wrong with the deployment. I don't have access to logs either, so this is just a guess.

This changed the dockerfile to assume `.env` to be alongside `__main__`, which [seems to be what it's looking for](https://github.com/Chippers255/duckbot/blob/main/duckbot/__main__.py#L29).