### PR TITLE
export env file into environment before running duckbot

### DIFF
--- a/duckbot/__main__.py
+++ b/duckbot/__main__.py
@@ -1,6 +1,5 @@
 import os
 import sys
-import dotenv
 from discord.ext import commands
 from duckbot.cogs import Duck, Tito, Typos, Recipe, Bitcoin, Insights, Kubernetes, AnnounceDay, ThankingRobot
 from duckbot.server import Channels, Emojis
@@ -25,7 +24,4 @@ if __name__ == "__main__":
     bot.add_cog(ThankingRobot(bot))
 
     if "dry-run" not in sys.argv:
-        # load the token from .env file
-        dotenv_path = os.path.join(os.path.dirname(__file__), ".env")
-        dotenv.load_dotenv(dotenv_path)
-        bot.run(os.environ["DISCORD_TOKEN"])
+        bot.run(os.getenv("DISCORD_TOKEN"))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 discord.py
-python-dotenv
 validators
 beautifulsoup4
 pytz

--- a/scripts/duckbot.sh
+++ b/scripts/duckbot.sh
@@ -2,6 +2,7 @@
 
 # check for .env
 if stat duckbot/.env > /dev/null 2>&1 && grep -q DISCORD_TOKEN duckbot/.env; then
+    export $(cat duckbot/.env | xargs)
     # run duckbot, brother, for a max of 1h
     timeout 1h python3.8 -u -m duckbot || echo "we killed your idle duckbot"
 else


### PR DESCRIPTION
Using tokens from the environment instead of loading from the `.env` file in the python script itself. Allows us to drop a dependency, but requires updated to the deployment scripts.