### PR TITLE
have duckbot call you out for editing messages

### DIFF
--- a/duckbot/__main__.py
+++ b/duckbot/__main__.py
@@ -1,7 +1,7 @@
 import os
 import sys
 from discord.ext import commands
-from duckbot.cogs import Duck, Tito, Typos, Recipe, Bitcoin, Insights, Kubernetes, AnnounceDay, ThankingRobot, WhoCanItBeNow
+from duckbot.cogs import Duck, Tito, Typos, Recipe, Bitcoin, Insights, Kubernetes, AnnounceDay, ThankingRobot, WhoCanItBeNow, MessageModified
 from duckbot.server import Channels, Emojis
 from duckbot.db import Database
 from duckbot.health import HealthCheck
@@ -31,6 +31,7 @@ def duckbot(bot):
     bot.add_cog(AnnounceDay(bot))
     bot.add_cog(ThankingRobot(bot))
     bot.add_cog(WhoCanItBeNow(bot))
+    bot.add_cog(MessageModified(bot))
 
     bot.run(os.getenv("DISCORD_TOKEN"))
 

--- a/duckbot/cogs/__init__.py
+++ b/duckbot/cogs/__init__.py
@@ -8,3 +8,4 @@ from .thanking_robot import ThankingRobot
 from .tito import Tito
 from .typos import Typos
 from .who_can_it_be_now import WhoCanItBeNow
+from .message_modified import MessageModified

--- a/duckbot/cogs/message_modified.py
+++ b/duckbot/cogs/message_modified.py
@@ -1,7 +1,5 @@
-from discord import Embed
 from discord.ext import commands
 import subprocess
-import difflib
 
 
 class MessageModified(commands.Cog):

--- a/duckbot/cogs/message_modified.py
+++ b/duckbot/cogs/message_modified.py
@@ -1,0 +1,20 @@
+from discord import Embed
+from discord.ext import commands
+import subprocess
+import difflib
+
+
+class MessageModified(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+
+    @commands.Cog.listener("on_message_edit")
+    async def show_edit_diff(self, before, after):
+        before_file = f"echo $BEFORE > {before.id}.before"
+        after_file = f"echo $AFTER > {after.id}.after"
+        diff_cmd = f"git diff --no-index -U10000 --word-diff=plain --word-diff-regex=. {before.id}.before {after.id}.after | tail -n +6"
+        cleanup = f"rm -rf {before.id}.before {after.id}.after"
+        env = {"BEFORE": before.content, "AFTER": after.content}
+
+        process = subprocess.run(f"{before_file} && {after_file} && {diff_cmd} ; {cleanup}", shell=True, capture_output=True, env=env)
+        await after.channel.send(f":eyes: {after.author.mention}.\n{process.stdout.decode()}")

--- a/tests/cogs/test_message_modified.py
+++ b/tests/cogs/test_message_modified.py
@@ -1,0 +1,16 @@
+import pytest
+import mock
+from duckbot.cogs import MessageModified
+
+
+@pytest.mark.asyncio
+@mock.patch("discord.Message")
+@mock.patch("discord.Message")
+@mock.patch("discord.ext.commands.Bot")
+async def test_show_edit_diff(before, after, bot):
+    before.id = after.id = 1
+    before.content = "abc"
+    after.content = "abd"
+    clazz = MessageModified(bot)
+    await clazz.show_edit_diff(before, after)
+    after.channel.send.assert_called_once_with(f":eyes: {after.author.mention}.\nab[-c-]{{+d+}}\n")


### PR DESCRIPTION
DuckBot will show a diff when you edit a recent message. The message has to be in the bot's message cache for the event to trigger, which defaults to [1000](https://discordpy.readthedocs.io/en/latest/api.html?highlight=cache#discord.Client) messages, so should be most reasonable cases. It also doesn't cover messages from before the bot was started, but meh.

I ended up using `git diff` to do the diff, and invoking that using a [subprocess](https://docs.python.org/3/library/subprocess.html). I tested locally, the docker image has `git` available to it. I tested with some messages that include quotes and such, seems ok.

Python does have some [diff library things](https://docs.python.org/3/library/difflib.html) built in, but it requires a lot of processing to get something usable, `git diff` just does all the work for me.

As for the message itself, I wanted to do some colour coding, but discord doesn't really support it. Right now, the diff is displayed like (changing _abc_ to _abd_):
> ab[-c-]{+d+}

Discord does support `diff` code blocks, so you'd get something like:
```diff
    ab
-c
+d
```

It's easy to change (just the `word-diff` arg to `git diff`). Let me know what you think would be better.