### PR TITLE
remove unnecessary music `cog_unload` method

### DIFF
--- a/duckbot/cogs/who_can_it_be_now.py
+++ b/duckbot/cogs/who_can_it_be_now.py
@@ -12,9 +12,6 @@ class WhoCanItBeNow(commands.Cog):
         self.player = None
         self.streaming = False
 
-    def cog_unload(self):
-        asyncio.get_event_loop().run_until_complete(self.stop_if_running())
-
     @commands.Cog.listener("on_error")
     @commands.Cog.listener("on_disconnect")
     async def stop_if_running(self, error=None):

--- a/tests/cogs/test_who_can_it_be_now.py
+++ b/tests/cogs/test_who_can_it_be_now.py
@@ -66,14 +66,6 @@ async def test_stop_not_streaming(bot, context):
     context.send.assert_called_once_with("Nothing to stop, you fool!")
 
 
-@mock.patch("discord.ext.commands.Bot")
-def test_cog_unload_stops_streaming(bot):
-    clazz = WhoCanItBeNow(bot)
-    clazz.streaming = True
-    clazz.cog_unload()
-    assert clazz.streaming is False
-
-
 @pytest.mark.asyncio
 @mock.patch("discord.ext.commands.Bot")
 async def test_stop_if_running_stops_streaming(bot):


### PR DESCRIPTION
I noticed that in recent [actions runs](https://github.com/Chippers255/duckbot/runs/2302540526?check_suite_focus=true#step:7:869), we get a warning during the connection test:

```
/usr/local/lib/python3.8/site-packages/discord/ext/commands/cog.py:451: RuntimeWarning: coroutine 'WhoCanItBeNow.stop_if_running' was never awaited
```

It's caused by calling the async stop method from the sync `cog_unload`. The stop is already called when the bot disconnects, so it's not needed during unload. This simply removes `cog_unload` from the music cog