### PR TITLE
say DuckBot is typing during `!recipe`

### DIFF
--- a/duckbot/cogs/recipe.py
+++ b/duckbot/cogs/recipe.py
@@ -81,4 +81,5 @@ class Recipe(commands.Cog):
 
     @commands.command(name="recipe")
     async def recipe(self, context, *args):
-        await self.__recipe(context, *args)
+        async with context.typing():
+            await self.__recipe(context, *args)


### PR DESCRIPTION
Title! I was looking through the docs earlier today and saw this. While DuckBot is searching in longer running tasks, like `!recipe`, we can say it is typing. Pretty nice.