### PR TITLE
add `!fortune` command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,5 +13,3 @@ COPY resources/ ./resources
 COPY duckbot/ ./duckbot
 ENV DUCKBOT_ARGS ""
 CMD [ "sh", "-c", "python -u -m duckbot $DUCKBOT_ARGS" ]
-
-# fortune -a | cowsay -f $(ls /usr/share/cowsay/cows/ | shuf -n1)

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,16 @@
 FROM python:3.8
 RUN apt-get update && apt-get -y install \
     ffmpeg \
+    fortune-mod fortunes fortunes-off cowsay cowsay-off \
   && apt-get clean && rm -rf /var/lib/apt/lists/*
+ENV PATH "$PATH:/usr/games"
 RUN python -m pip install --upgrade pip
-COPY requirements.txt /
-RUN python -m pip install -r /requirements.txt
-COPY resources/ /duckbot/resources
-COPY duckbot/ /duckbot/duckbot
 WORKDIR /duckbot
+COPY requirements.txt .
+RUN python -m pip install -r ./requirements.txt
+COPY resources/ ./resources
+COPY duckbot/ ./duckbot
 ENV DUCKBOT_ARGS ""
 CMD [ "sh", "-c", "python -u -m duckbot $DUCKBOT_ARGS" ]
+
+# fortune -a | cowsay -f $(ls /usr/share/cowsay/cows/ | shuf -n1)

--- a/duckbot/__main__.py
+++ b/duckbot/__main__.py
@@ -1,7 +1,7 @@
 import os
 import sys
 from discord.ext import commands
-from duckbot.cogs import Duck, Tito, Typos, Recipe, Bitcoin, Insights, Kubernetes, AnnounceDay, ThankingRobot, WhoCanItBeNow
+from duckbot.cogs import Duck, Tito, Typos, Recipe, Bitcoin, Insights, Kubernetes, AnnounceDay, ThankingRobot, WhoCanItBeNow, Fortune
 from duckbot.server import Channels, Emojis
 from duckbot.db import Database
 from duckbot.health import HealthCheck
@@ -25,6 +25,7 @@ def duckbot(bot):
     bot.add_cog(Tito(bot))
     bot.add_cog(Typos(bot))
     bot.add_cog(Recipe(bot))
+    bot.add_cog(Fortune(bot))
     bot.add_cog(Bitcoin(bot))
     bot.add_cog(Insights(bot))
     bot.add_cog(Kubernetes(bot))

--- a/duckbot/cogs/__init__.py
+++ b/duckbot/cogs/__init__.py
@@ -8,3 +8,4 @@ from .thanking_robot import ThankingRobot
 from .tito import Tito
 from .typos import Typos
 from .who_can_it_be_now import WhoCanItBeNow
+from .fortune import Fortune

--- a/duckbot/cogs/fortune.py
+++ b/duckbot/cogs/fortune.py
@@ -12,7 +12,7 @@ class Fortune(commands.Cog):
 
     def get_fortune(self):
         message = self.__get_fortune_output()
-        while len(message) > 1900:
+        while len(message) > 1950:  # discord has a 2000 character limit, just leaving a buffer
             message = self.__get_fortune_output()
         return f"```{message}```"
 

--- a/duckbot/cogs/fortune.py
+++ b/duckbot/cogs/fortune.py
@@ -1,0 +1,21 @@
+from discord.ext import commands
+import subprocess
+
+
+class Fortune(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+
+    @commands.command(name="fortune")
+    async def fortune(self, context):
+        await context.send(self.get_fortune())
+
+    def get_fortune(self):
+        message = self.__get_fortune_output()
+        while len(message) > 1900:
+            message = self.__get_fortune_output()
+        return f"```{message}```"
+
+    def __get_fortune_output(self):
+        process = subprocess.run(f"fortune -a | cowsay -f $(ls /usr/share/cowsay/cows/ | shuf -n1)", shell=True, capture_output=True)
+        return process.stdout.decode()

--- a/scripts/build/install.sh
+++ b/scripts/build/install.sh
@@ -2,6 +2,7 @@
 sudo apt-get update && sudo apt-get install -y \
     ffmpeg \
     postgresql libpq-dev \
+    fortune-mod cowsay \
     && \
 
 # upgrade venv pip

--- a/tests/cogs/test_fortune.py
+++ b/tests/cogs/test_fortune.py
@@ -1,0 +1,12 @@
+import pytest
+import mock
+from duckbot.cogs import Fortune
+
+
+@mock.patch("discord.ext.commands.Bot")
+def test_get_fortune(bot):
+    clazz = Fortune(bot)
+    message = clazz.get_fortune()
+    assert message.startswith("```")
+    assert message.endswith("```")
+    assert len(message) < 2000


### PR DESCRIPTION
More or less just screwing around at this point. I don't really like having the `!fortune` being a command, there's gotta be a better way to display it. I feel like it loses it's punch when a user explicitly requests a fortune. While we think of a better way to use it, this change at least makes the fortune available in the image, and allows people to get one if they want.

I did some minor additional changes to the `Dockerfile` past installing `fortune`, moved `WORKDIR` further up and made subsequent `COPY` and such relative to them, instead of only the `CMD` relative to it.