### PR TITLE
specify bot intents during construction

### DIFF
--- a/duckbot/__main__.py
+++ b/duckbot/__main__.py
@@ -1,5 +1,6 @@
 import os
 import sys
+from discord import Intents
 from discord.ext import commands
 from duckbot.cogs import Duck, Tito, Typos, Recipe, Bitcoin, Insights, Kubernetes, AnnounceDay, ThankingRobot, WhoCanItBeNow
 from duckbot.server import Channels, Emojis
@@ -8,7 +9,7 @@ from duckbot.health import HealthCheck
 from duckbot.util import ConnectionTest
 
 
-def duckbot(bot):
+def duckbot(bot: commands.Bot):
     if "connection-test" in sys.argv:
         bot.add_cog(ConnectionTest(bot))
 
@@ -35,6 +36,20 @@ def duckbot(bot):
     bot.run(os.getenv("DISCORD_TOKEN"))
 
 
+def intents() -> Intents:
+    intent = Intents.default()
+    intent.members = False
+    intent.presences = False
+    intent.bans = False
+    intent.integrations = False
+    intent.webhooks = False
+    intent.invites = False
+    intent.voice_states = False
+    intent.webhooks = False
+    intent.typing = False
+    return intent
+
+
 if __name__ == "__main__":
-    bot = commands.Bot(command_prefix="!", help_command=None)
+    bot = commands.Bot(command_prefix="!", help_command=None, intents=intents())
     duckbot(bot)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,8 +1,18 @@
 import sys
 import mock
 from unittest.mock import call
-from duckbot.__main__ import duckbot
+from discord import Intents
+from duckbot.__main__ import duckbot, intents
 from duckbot.util import ConnectionTest
+
+
+def test_intents_has_required_permissions():
+    expected = Intents.none()
+    expected.guilds = True
+    expected.emojis = True
+    expected.messages = True
+    expected.reactions = True
+    assert intents() == expected
 
 
 @mock.patch("discord.ext.commands.Bot")


### PR DESCRIPTION
Reading more docs, discord seems to think [intents](https://discordpy.readthedocs.io/en/latest/intents.html) is a crazy new big deal.
> This is a radical change in how bots are written.
> ...
> Each attribute in the Intents class documents what events it corresponds to and what kind of cache it enables.

The radical change is essentially _we ignore some events_, and doesn't affect how the bot is written at all. This basically means we save some memory and wasted cycles when running the bot. Not a big deal, but we might as well.

See also:
* https://discordpy.readthedocs.io/en/latest/intents.html
* https://discordpy.readthedocs.io/en/latest/api.html#discord.Intents <- verify I've specified the correct intents for what we have