### PR TITLE
Another shot a fixing `cog_unload` for music cog

### DIFF
--- a/duckbot/cogs/who_can_it_be_now.py
+++ b/duckbot/cogs/who_can_it_be_now.py
@@ -13,7 +13,7 @@ class WhoCanItBeNow(commands.Cog):
         self.streaming = False
 
     def cog_unload(self):
-        self.bot.loop.create_task(self.stop_if_running())
+        asyncio.run(self.stop_if_running())
 
     @commands.Cog.listener("on_error")
     @commands.Cog.listener("on_disconnect")

--- a/duckbot/cogs/who_can_it_be_now.py
+++ b/duckbot/cogs/who_can_it_be_now.py
@@ -12,6 +12,9 @@ class WhoCanItBeNow(commands.Cog):
         self.player = None
         self.streaming = False
 
+    def cog_unload(self):
+        self.bot.loop.create_task(self.stop_if_running())
+
     @commands.Cog.listener("on_error")
     @commands.Cog.listener("on_disconnect")
     async def stop_if_running(self, error=None):

--- a/duckbot/cogs/who_can_it_be_now.py
+++ b/duckbot/cogs/who_can_it_be_now.py
@@ -13,7 +13,8 @@ class WhoCanItBeNow(commands.Cog):
         self.streaming = False
 
     def cog_unload(self):
-        asyncio.run(self.stop_if_running())
+        task = self.bot.loop.create_task(self.__stop(None))
+        self.bot.loop.run_until_complete(task)
 
     @commands.Cog.listener("on_error")
     @commands.Cog.listener("on_disconnect")

--- a/duckbot/cogs/who_can_it_be_now.py
+++ b/duckbot/cogs/who_can_it_be_now.py
@@ -13,8 +13,9 @@ class WhoCanItBeNow(commands.Cog):
         self.streaming = False
 
     def cog_unload(self):
-        task = self.bot.loop.create_task(self.__stop(None))
+        task = self.bot.loop.create_task(self.stop_if_running())
         self.bot.loop.run_until_complete(task)
+        # asyncio.get_event_loop().run_until_complete(self.stop_if_running())
 
     @commands.Cog.listener("on_error")
     @commands.Cog.listener("on_disconnect")

--- a/duckbot/cogs/who_can_it_be_now.py
+++ b/duckbot/cogs/who_can_it_be_now.py
@@ -13,15 +13,9 @@ class WhoCanItBeNow(commands.Cog):
         self.streaming = False
 
     def cog_unload(self):
-        task = self.bot.loop.create_task(self.stop_if_running())
-        self.bot.loop.run_until_complete(task)
-        # asyncio.get_event_loop().run_until_complete(self.stop_if_running())
-
-    @commands.Cog.listener("on_error")
-    @commands.Cog.listener("on_disconnect")
-    async def stop_if_running(self, error=None):
         if self.streaming:
-            await self.__stop(None)
+            task = self.bot.loop.create_task(self.__stop(None))
+            self.bot.loop.run_until_complete(task)
 
     @commands.command("start")
     async def start(self, context):

--- a/duckbot/util/connection_test.py
+++ b/duckbot/util/connection_test.py
@@ -11,5 +11,4 @@ class ConnectionTest(commands.Cog):
     @commands.Cog.listener("on_ready")
     async def connection_success(self):
         print("Connection Successful!")
-        self.bot.loop.stop()
         await self.bot.close()

--- a/tests/cogs/test_who_can_it_be_now.py
+++ b/tests/cogs/test_who_can_it_be_now.py
@@ -66,18 +66,18 @@ async def test_stop_not_streaming(bot, context):
     context.send.assert_called_once_with("Nothing to stop, you fool!")
 
 
+@mock.patch("discord.ext.commands.Bot")
+def test_cog_unload_stops_streaming(bot):
+    clazz = WhoCanItBeNow(bot)
+    clazz.streaming = True
+    clazz.cog_unload()
+    assert clazz.streaming is False
+
+
 @pytest.mark.asyncio
 @mock.patch("discord.ext.commands.Bot")
 async def test_stop_if_running_stops_streaming(bot):
     clazz = WhoCanItBeNow(bot)
     clazz.streaming = True
     await clazz.stop_if_running()
-    assert clazz.streaming is False
-
-
-@mock.patch("discord.ext.commands.Bot")
-def test_cog_unload_stops_streaming(bot):
-    clazz = WhoCanItBeNow(bot)
-    clazz.streaming = True
-    clazz.cog_unload()
     assert clazz.streaming is False

--- a/tests/cogs/test_who_can_it_be_now.py
+++ b/tests/cogs/test_who_can_it_be_now.py
@@ -77,8 +77,9 @@ async def test_stop_if_running_stops_streaming(bot):
 
 @mock.patch("discord.ext.commands.Bot")
 def test_cog_unload_stops_streaming(bot):
-    bot.loop = asyncio.get_event_loop()
+    bot.loop = asyncio.new_event_loop()
     clazz = WhoCanItBeNow(bot)
     clazz.streaming = True
     clazz.cog_unload()
+    bot.loop.close()
     assert clazz.streaming is False

--- a/tests/cogs/test_who_can_it_be_now.py
+++ b/tests/cogs/test_who_can_it_be_now.py
@@ -72,12 +72,3 @@ def test_cog_unload_stops_streaming(bot):
     clazz.streaming = True
     clazz.cog_unload()
     assert clazz.streaming is False
-
-
-@pytest.mark.asyncio
-@mock.patch("discord.ext.commands.Bot")
-async def test_stop_if_running_stops_streaming(bot):
-    clazz = WhoCanItBeNow(bot)
-    clazz.streaming = True
-    await clazz.stop_if_running()
-    assert clazz.streaming is False

--- a/tests/cogs/test_who_can_it_be_now.py
+++ b/tests/cogs/test_who_can_it_be_now.py
@@ -77,9 +77,7 @@ async def test_stop_if_running_stops_streaming(bot):
 
 @mock.patch("discord.ext.commands.Bot")
 def test_cog_unload_stops_streaming(bot):
-    bot.loop = asyncio.new_event_loop()
     clazz = WhoCanItBeNow(bot)
     clazz.streaming = True
     clazz.cog_unload()
-    bot.loop.close()
     assert clazz.streaming is False

--- a/tests/cogs/test_who_can_it_be_now.py
+++ b/tests/cogs/test_who_can_it_be_now.py
@@ -68,6 +68,7 @@ async def test_stop_not_streaming(bot, context):
 
 @mock.patch("discord.ext.commands.Bot")
 def test_cog_unload_stops_streaming(bot):
+    bot.loop = asyncio.get_event_loop()
     clazz = WhoCanItBeNow(bot)
     clazz.streaming = True
     clazz.cog_unload()

--- a/tests/cogs/test_who_can_it_be_now.py
+++ b/tests/cogs/test_who_can_it_be_now.py
@@ -73,3 +73,11 @@ async def test_stop_if_running_stops_streaming(bot):
     clazz.streaming = True
     await clazz.stop_if_running()
     assert clazz.streaming is False
+
+
+@mock.patch("discord.ext.commands.Bot")
+def test_cog_unload_stops_streaming(bot):
+    clazz = WhoCanItBeNow(bot)
+    clazz.streaming = True
+    clazz.cog_unload()
+    assert clazz.streaming is False

--- a/tests/cogs/test_who_can_it_be_now.py
+++ b/tests/cogs/test_who_can_it_be_now.py
@@ -77,6 +77,7 @@ async def test_stop_if_running_stops_streaming(bot):
 
 @mock.patch("discord.ext.commands.Bot")
 def test_cog_unload_stops_streaming(bot):
+    bot.loop = asyncio.get_event_loop()
     clazz = WhoCanItBeNow(bot)
     clazz.streaming = True
     clazz.cog_unload()

--- a/tests/util/test_connection_test.py
+++ b/tests/util/test_connection_test.py
@@ -10,5 +10,4 @@ async def test_connection_success_shuts_down_bot(bot, loop):
     bot.loop = loop
     clazz = ConnectionTest(bot)
     await clazz.connection_success()
-    loop.stop.assert_called()
     bot.close.assert_called()


### PR DESCRIPTION
#121 kinda missed the mark, after more reading. It seems the issue is [stopping the event loop](https://github.com/Chippers255/duckbot/blob/main/duckbot/util/connection_test.py#L14) during the connection test. I've removed that, and restored `cog_unload` to disconnect from the voice call if it's connected.

Apparently, `on_disconnect` and `on_error` simply don't work. Disconnect is only called after it actually loses connection, so I can't tell it to close a socket there (it's already dead by the time the event comes in). And error isn't the right kind of event, that'll capture any unhandled exceptions from the bot, seemingly even ones unrelated to the cog it's registered in.