### PR TITLE
only send edit messages if the content is actually different

### DIFF
--- a/duckbot/cogs/message_modified.py
+++ b/duckbot/cogs/message_modified.py
@@ -8,6 +8,9 @@ class MessageModified(commands.Cog):
 
     @commands.Cog.listener("on_message_edit")
     async def show_edit_diff(self, before, after):
+        if before.author == self.bot.user or after.author == self.bot.user or before.content == after.content:
+            return
+
         before_file = f"echo $BEFORE > {before.id}.before"
         after_file = f"echo $AFTER > {after.id}.after"
         diff_cmd = f"git diff --no-index -U10000 --word-diff=plain --word-diff-regex=. {before.id}.before {after.id}.after | tail -n +6"

--- a/tests/cogs/test_message_modified.py
+++ b/tests/cogs/test_message_modified.py
@@ -7,10 +7,43 @@ from duckbot.cogs import MessageModified
 @mock.patch("discord.Message")
 @mock.patch("discord.Message")
 @mock.patch("discord.ext.commands.Bot")
-async def test_show_edit_diff(before, after, bot):
+async def test_show_edit_diff_typical_case(before, after, bot):
     before.id = after.id = 1
     before.content = "abc"
     after.content = "abd"
     clazz = MessageModified(bot)
     await clazz.show_edit_diff(before, after)
     after.channel.send.assert_called_once_with(f":eyes: {after.author.mention}.\nab[-c-]{{+d+}}\n")
+
+
+@pytest.mark.asyncio
+@mock.patch("discord.Message")
+@mock.patch("discord.Message")
+@mock.patch("discord.ext.commands.Bot")
+async def test_show_edit_diff_bot_author_before(before, after, bot):
+    before.author = bot.user
+    clazz = MessageModified(bot)
+    await clazz.show_edit_diff(before, after)
+    after.channel.send.assert_not_called()
+
+
+@pytest.mark.asyncio
+@mock.patch("discord.Message")
+@mock.patch("discord.Message")
+@mock.patch("discord.ext.commands.Bot")
+async def test_show_edit_diff_bot_author_after(before, after, bot):
+    after.author = bot.user
+    clazz = MessageModified(bot)
+    await clazz.show_edit_diff(before, after)
+    after.channel.send.assert_not_called()
+
+
+@pytest.mark.asyncio
+@mock.patch("discord.Message")
+@mock.patch("discord.Message")
+@mock.patch("discord.ext.commands.Bot")
+async def test_show_edit_diff_bot_content_same(before, after, bot):
+    before.content = after.content = "embeds trigger this for some reason, who knows"
+    clazz = MessageModified(bot)
+    await clazz.show_edit_diff(before, after)
+    after.channel.send.assert_not_called()


### PR DESCRIPTION
It seems [on_message_edit](https://discordpy.readthedocs.io/en/latest/api.html#discord.on_message_edit) is also triggered when the message has an embed, discord modifies it after the fact for _performance reasons_. https://github.com/Rapptz/discord.py/issues/2476 mentions that the content will be the same in those cases, so we can avoid those pretty easily.

While I was here, I tacked on detecting the bot's own messages, 'cause why not.