### PR TITLE
create `bot` pytest fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,7 +17,7 @@ def async_mock_await_fix():
 
 @pytest.fixture
 async def bot() -> Bot:
-    """Returns a spy discord.ext.commands.Bot instance with a stubbed `run` method. The close is destroyed after use."""
+    """Returns a spy discord.ext.commands.Bot instance with a stubbed `run` method. The bot is closed afterwards."""
     b = mock.Mock(wraps=Bot(command_prefix="!", help_command=None))
     with mock.patch.object(Bot, "run"):  # stub run so it does nothing
         yield b

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 import pytest
 import mock
 from discord.ext.commands import Bot
+from discord import TextChannel, Guild, Emoji
 
 
 @pytest.fixture(autouse=True)
@@ -16,9 +17,19 @@ def async_mock_await_fix():
 
 
 @pytest.fixture
-async def bot() -> Bot:
+async def bot_spy() -> Bot:
     """Returns a spy discord.ext.commands.Bot instance with a stubbed `run` method. The bot is closed afterwards."""
     b = mock.Mock(wraps=Bot(command_prefix="!", help_command=None))
     with mock.patch.object(Bot, "run"):  # stub run so it does nothing
         yield b
     await b.close()
+
+
+@pytest.fixture
+async def bot() -> Bot:
+    return patch_of("discord.ext.commands.Bot")
+
+
+def patch_of(tpye):
+    with mock.patch(tpye) as o:
+        return o

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,7 @@ def async_mock_await_fix():
 
 
 @pytest.fixture
-async def bot():
+async def bot() -> Bot:
     """Returns a spy discord.ext.commands.Bot instance with a stubbed `run` method. The close is destroyed after use."""
     b = mock.Mock(wraps=Bot(command_prefix="!", help_command=None))
     with mock.patch.object(Bot, "run"):  # stub run so it does nothing

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,13 +1,6 @@
-import sys
-import os
 import pytest
 import mock
-
-# allow for importing modules in the tests directory
-sys.path.append(os.path.dirname(__file__))
-
-# unify the module import scheme between src and tst
-sys.path.insert(0, os.path.abspath(os.path.join("..", "duckbot", "duckbot")))
+from discord.ext.commands import Bot
 
 
 @pytest.fixture(autouse=True)
@@ -20,3 +13,12 @@ def async_mock_await_fix():
 
     mock.MagicMock.__await__ = lambda x: async_magic().__await__()
     yield
+
+
+@pytest.fixture
+async def bot():
+    """Returns a spy discord.ext.commands.Bot instance with a stubbed `run` method. The close is destroyed after use."""
+    b = mock.Mock(wraps=Bot(command_prefix="!", help_command=None))
+    with mock.patch.object(Bot, "run"):  # stub run so it does nothing
+        yield b
+    await b.close()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -5,18 +5,14 @@ from duckbot.__main__ import duckbot
 from duckbot.util import ConnectionTest
 
 
-@mock.patch("discord.ext.commands.Bot")
-@mock.patch("discord.ext.tasks.Loop")
-def test_duckbot_connection_test(bot, loop):
+def test_duckbot_connection_test(bot):
     with mock.patch.object(sys, "argv", ["connection-test"]):
         duckbot(bot)
         assert_cog_added(bot, ConnectionTest)
         bot.run.assert_called()
 
 
-@mock.patch("discord.ext.commands.Bot")
-@mock.patch("discord.ext.tasks.Loop")
-def test_duckbot_normal_run(bot, loop):
+def test_duckbot_normal_run(bot):
     duckbot(bot)
     bot.run.assert_called()
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,22 +1,28 @@
 import sys
 import mock
+import pytest
 from unittest.mock import call
 from duckbot.__main__ import duckbot
 from duckbot.util import ConnectionTest
 
+DISCORD_TOKEN = "discord-token"
 
-def test_duckbot_connection_test(bot, monkeypatch):
-    monkeypatch.setenv("DISCORD_TOKEN", "token")
+
+@pytest.fixture(autouse=True)
+def set_discord_token_env(monkeypatch):
+    monkeypatch.setenv("DISCORD_TOKEN", DISCORD_TOKEN)
+
+
+def test_duckbot_connection_test(bot):
     with mock.patch.object(sys, "argv", ["connection-test"]):
         duckbot(bot)
         assert_cog_added(bot, ConnectionTest)
-        bot.run.assert_called_once_with("token")
+        bot.run.assert_called_once_with(DISCORD_TOKEN)
 
 
-def test_duckbot_normal_run(bot, monkeypatch):
-    monkeypatch.setenv("DISCORD_TOKEN", "token")
+def test_duckbot_normal_run(bot):
     duckbot(bot)
-    bot.run.assert_called_once_with("token")
+    bot.run.assert_called_once_with(DISCORD_TOKEN)
 
 
 def assert_cog_added(bot, typ):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -5,16 +5,18 @@ from duckbot.__main__ import duckbot
 from duckbot.util import ConnectionTest
 
 
-def test_duckbot_connection_test(bot):
+def test_duckbot_connection_test(bot, monkeypatch):
+    monkeypatch.setenv("DISCORD_TOKEN", "token")
     with mock.patch.object(sys, "argv", ["connection-test"]):
         duckbot(bot)
         assert_cog_added(bot, ConnectionTest)
-        bot.run.assert_called()
+        bot.run.assert_called_once_with("token")
 
 
-def test_duckbot_normal_run(bot):
+def test_duckbot_normal_run(bot, monkeypatch):
+    monkeypatch.setenv("DISCORD_TOKEN", "token")
     duckbot(bot)
-    bot.run.assert_called()
+    bot.run.assert_called_once_with("token")
 
 
 def assert_cog_added(bot, typ):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -23,16 +23,16 @@ def test_intents_has_required_permissions():
     assert intents() == expected
 
 
-def test_duckbot_connection_test(bot):
+def test_duckbot_connection_test(bot_spy):
     with mock.patch.object(sys, "argv", ["connection-test"]):
-        duckbot(bot)
-        assert_cog_added(bot, ConnectionTest)
-        bot.run.assert_called_once_with(DISCORD_TOKEN)
+        duckbot(bot_spy)
+        assert_cog_added(bot_spy, ConnectionTest)
+        bot_spy.run.assert_called_once_with(DISCORD_TOKEN)
 
 
-def test_duckbot_normal_run(bot):
-    duckbot(bot)
-    bot.run.assert_called_once_with(DISCORD_TOKEN)
+def test_duckbot_normal_run(bot_spy):
+    duckbot(bot_spy)
+    bot_spy.run.assert_called_once_with(DISCORD_TOKEN)
 
 
 def assert_cog_added(bot, typ):


### PR DESCRIPTION
I am fiddling with converting our code base to use [extensions](https://discordpy.readthedocs.io/en/latest/ext/commands/extensions.html), see [my branch](https://github.com/Chippers255/duckbot/compare/main...twentylemon:extensions). I'll be splitting that branch into several smaller PRs to make it easier to review, and also do some better cleanup in each one without being a commit that rewrites the entire code base.

The extentions groups code a little better than we are now, and allows for a little better code organization. For example, the [weather](https://github.com/Chippers255/duckbot/blob/main/duckbot/cogs/weather.py) cog defines a `SavedLocation` class, which we'd be able to jam into a new `duckbot.cogs.weather` module (as a new file). It's fairly minor, but it organizes code a little better, which can allow for more code re-use, and better abstractions to be created. Plus, merge conflicts should be minimized if several people are adding new cogs.

As for this PR, the fixture (see [their readme](https://docs.pytest.org/en/latest/how-to/fixtures.html)) is defining a global, reusable `bot` instance for our tests. It essentially just saves writing `@mock.patch("discord.ext.commands.Bot")` on the test methods. There's both a spy and mock instance available, though we'd only typically use the mock. The spy is around for when we want to take advantage of the validation the bot class does in tests.