### PR TITLE
create `assert_cog_added_of_type` test method

### DIFF
--- a/tests/discord_test_ext.py
+++ b/tests/discord_test_ext.py
@@ -8,4 +8,5 @@ def assert_cog_added_of_type(bot: Bot, tpye):
         if isinstance(invocation[0][0], tpye):
             called = True
     if not called:
+        # this fails with a decent assertion failure message
         bot.add_cog.assert_any_call(tpye)

--- a/tests/discord_test_ext.py
+++ b/tests/discord_test_ext.py
@@ -1,0 +1,11 @@
+from discord.ext.commands import Bot
+
+
+def assert_cog_added_of_type(bot: Bot, tpye):
+    """Asserts a cog of the given type was added to the bot."""
+    called = False
+    for invocation in bot.add_cog.call_args_list:
+        if isinstance(invocation[0][0], tpye):
+            called = True
+    if not called:
+        bot.add_cog.assert_any_call(tpye)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,6 +1,5 @@
 import sys
 import mock
-from unittest.mock import call
 from tests.discord_test_ext import assert_cog_added_of_type
 from duckbot.__main__ import duckbot
 from duckbot.util import ConnectionTest

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,6 +1,7 @@
 import sys
 import mock
 from unittest.mock import call
+from tests.discord_test_ext import assert_cog_added_of_type
 from duckbot.__main__ import duckbot
 from duckbot.util import ConnectionTest
 
@@ -10,7 +11,7 @@ from duckbot.util import ConnectionTest
 def test_duckbot_connection_test(bot, loop):
     with mock.patch.object(sys, "argv", ["connection-test"]):
         duckbot(bot)
-        assert_cog_added(bot, ConnectionTest)
+        assert_cog_added_of_type(bot, ConnectionTest)
         bot.run.assert_called()
 
 
@@ -19,10 +20,3 @@ def test_duckbot_connection_test(bot, loop):
 def test_duckbot_normal_run(bot, loop):
     duckbot(bot)
     bot.run.assert_called()
-
-
-def assert_cog_added(bot, typ):
-    for invocation in bot.add_cog.call_args_list:
-        if isinstance(invocation[0], typ):
-            return True
-    return False


### PR DESCRIPTION
Related to #136, see that pull request for further details. This a simple helper method to test if a cog was added to a bot.