### PR TITLE
attempt at music loop fix

### DIFF
--- a/tests/cogs/test_who_can_it_be_now.py
+++ b/tests/cogs/test_who_can_it_be_now.py
@@ -16,6 +16,7 @@ def play(*args, **kwargs):
 @mock.patch("discord.VoiceChannel")
 @mock.patch("discord.VoiceClient")
 async def test_task_loop(bot, context, channels, voice, client):
+    bot.loop = asyncio.get_event_loop()
     bot.get_cog.return_value = channels
     channels.get_channel_by_name.return_value = voice
     voice.connect.return_value = async_value(client)


### PR DESCRIPTION
The other night we were using `!start` and at some point, the loop stopped and duckbot kinda froze. This tries jigging some stuff around to hopefully avoid the same issue in the future.

I tested locally with the `bruh` sound bite, the loop seems to be smoother in general. 