### PR TITLE
use pytest `-ra` instead of `-s`

### DIFF
--- a/scripts/build/test.sh
+++ b/scripts/build/test.sh
@@ -1,7 +1,7 @@
 . $(git rev-parse --show-toplevel)/scripts/ensure-toplevel.sh && \
 
 # test with pytest and gather code coverage
-python -m coverage run --source=duckbot/ -m pytest -s && \
+python -m coverage run --source=duckbot/ -m pytest -ra && \
 
 # when tests pass, output coverage report
 python -m coverage report --show-missing --skip-empty --skip-covered --fail-under=80 && \


### PR DESCRIPTION
See [pytest invocation docs](https://docs.pytest.org/en/stable/usage.html#detailed-summary-report). `-s` dumps stdout and such to the console as it's happening, whereas `-r` captures output and groups it at the end. It's easier to parse. The docs link has some example outputs.