### PR TITLE
change main method name to `run_duckbot`

### DIFF
--- a/duckbot/__main__.py
+++ b/duckbot/__main__.py
@@ -8,7 +8,7 @@ from duckbot.health import HealthCheck
 from duckbot.util import ConnectionTest
 
 
-def duckbot(bot):
+def run_duckbot(bot):
     if "connection-test" in sys.argv:
         bot.add_cog(ConnectionTest(bot))
 
@@ -40,4 +40,4 @@ def duckbot(bot):
 
 if __name__ == "__main__":
     bot = commands.Bot(command_prefix="!", help_command=None)
-    duckbot(bot)
+    run_duckbot(bot)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,23 +1,23 @@
 import sys
 import mock
 from unittest.mock import call
-from duckbot.__main__ import duckbot
+from duckbot.__main__ import run_duckbot
 from duckbot.util import ConnectionTest
 
 
 @mock.patch("discord.ext.commands.Bot")
 @mock.patch("discord.ext.tasks.Loop")
-def test_duckbot_connection_test(bot, loop):
+def test_run_duckbot_connection_test(bot, loop):
     with mock.patch.object(sys, "argv", ["connection-test"]):
-        duckbot(bot)
+        run_duckbot(bot)
         assert_cog_added(bot, ConnectionTest)
         bot.run.assert_called()
 
 
 @mock.patch("discord.ext.commands.Bot")
 @mock.patch("discord.ext.tasks.Loop")
-def test_duckbot_normal_run(bot, loop):
-    duckbot(bot)
+def test_run_duckbot_normal_run(bot, loop):
+    run_duckbot(bot)
     bot.run.assert_called()
 
 


### PR DESCRIPTION
Related to #136, changing the name of the main method to avoid clashing with the name of the module.