### PR TITLE
include `voice_states` intent

### DIFF
--- a/duckbot/__main__.py
+++ b/duckbot/__main__.py
@@ -47,7 +47,6 @@ def intents() -> Intents:
     intent.integrations = False
     intent.webhooks = False
     intent.invites = False
-    intent.voice_states = False
     intent.webhooks = False
     intent.typing = False
     return intent

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -12,6 +12,7 @@ def test_intents_has_required_permissions():
     expected.emojis = True
     expected.messages = True
     expected.reactions = True
+    expected.voice_states = True
     assert intents() == expected
 
 


### PR DESCRIPTION
`!start` stopped working after #131, I'm guessing it's missing something to actually use the intent (I can't test manually right now).

[connect](https://discordpy.readthedocs.io/en/stable/api.html#discord.VoiceProtocol.connect) specifies to use `Guild.change_voice_state()` method, so presumably internally the method relies on the `voice_states` intent. The intent affects the [on_voice_state_update](https://discordpy.readthedocs.io/en/stable/api.html#discord.on_voice_state_update) event.