### PR TITLE
avoid accessing `channel.name` if it doesn't exist

### DIFF
--- a/duckbot/cogs/formula_one.py
+++ b/duckbot/cogs/formula_one.py
@@ -45,4 +45,4 @@ class FormulaOne(commands.Cog):
                 await message.add_reaction(letter)
 
     def is_dank_channel(self, channel):
-        return channel.name == "dank"
+        return hasattr(channel, "name") and channel.name == "dank"

--- a/tests/cogs/test_formula_one.py
+++ b/tests/cogs/test_formula_one.py
@@ -15,6 +15,15 @@ async def test_car_do_be_going_fast_though_not_dank_channel(message, channel):
 
 
 @pytest.mark.asyncio
+async def test_car_do_be_going_fast_though_not_named_channel(message):
+    with mock.patch("discord.DMChannel", autospec=True) as channel:
+        message.channel = channel
+        clazz = FormulaOne(None)
+        await clazz.car_do_be_going_fast_though(message)
+    message.add_reaction.assert_not_called()
+
+
+@pytest.mark.asyncio
 @mock.patch("discord.Message")
 @mock.patch("discord.TextChannel")
 @mock.patch("random.choice", return_value=["\U0001F170"])


### PR DESCRIPTION
`channel.name` is not defined for direct messages, this is just avoiding the `AttributeNotDefined` error for the dank cog.