### PR TITLE
remove backport `mock` library

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,6 @@
 pytest
 pytest-asyncio
 pytest-mock
-mock
 coverage
 
 flake8

--- a/tests/cogs/corrections/test_bitcoin.py
+++ b/tests/cogs/corrections/test_bitcoin.py
@@ -1,5 +1,5 @@
 import pytest
-import mock
+from unittest import mock
 from duckbot.cogs.corrections import Bitcoin
 
 

--- a/tests/cogs/corrections/test_kubernetes.py
+++ b/tests/cogs/corrections/test_kubernetes.py
@@ -1,5 +1,5 @@
 import pytest
-import mock
+from unittest import mock
 from duckbot.cogs.corrections import Kubernetes
 
 

--- a/tests/cogs/corrections/test_typos.py
+++ b/tests/cogs/corrections/test_typos.py
@@ -1,5 +1,5 @@
 import pytest
-import mock
+from unittest import mock
 from asyncio import CancelledError
 from tests.duckmock.urllib import patch_urlopen
 from tests.duckmock.discord import MockAsyncIterator

--- a/tests/cogs/formula_one/test_formula_one.py
+++ b/tests/cogs/formula_one/test_formula_one.py
@@ -1,5 +1,5 @@
 import pytest
-import mock
+from unittest import mock
 from duckbot.cogs.formula_one import FormulaOne
 
 

--- a/tests/cogs/fortune/test_fortune.py
+++ b/tests/cogs/fortune/test_fortune.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 from duckbot.cogs.fortune import Fortune
 
 

--- a/tests/cogs/messages/test_edit_diff.py
+++ b/tests/cogs/messages/test_edit_diff.py
@@ -1,5 +1,5 @@
 import pytest
-import mock
+from unittest import mock
 from duckbot.cogs.messages import EditDiff
 
 

--- a/tests/cogs/test_duck.py
+++ b/tests/cogs/test_duck.py
@@ -1,5 +1,5 @@
 import pytest
-import mock
+from unittest import mock
 from duckbot.cogs import Duck
 
 

--- a/tests/cogs/tito/test_tito.py
+++ b/tests/cogs/tito/test_tito.py
@@ -1,5 +1,5 @@
 import pytest
-import mock
+from unittest import mock
 from tests.async_mock_ext import async_value
 from duckbot.cogs.tito import Tito
 

--- a/tests/cogs/weather/test_weather.py
+++ b/tests/cogs/weather/test_weather.py
@@ -1,5 +1,5 @@
 import pytest
-import mock
+from unittest import mock
 from pyowm.weatherapi25.location import Location
 from pyowm.weatherapi25.one_call import OneCall
 from pyowm.weatherapi25.weather import Weather as pyowmWeather

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,5 @@
 import pytest
-import mock
+from unittest import mock
 import discord
 from discord.ext.commands import Bot, Context
 from discord import TextChannel, VoiceChannel, Guild, Emoji, Message, VoiceClient

--- a/tests/db/test_database.py
+++ b/tests/db/test_database.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 from sqlalchemy.orm import declarative_base
 from duckbot.db import Database
 

--- a/tests/duckmock/datetime/__init__.py
+++ b/tests/duckmock/datetime/__init__.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import datetime
 
 DATETIME = "datetime.datetime"

--- a/tests/duckmock/urllib/__init__.py
+++ b/tests/duckmock/urllib/__init__.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 from .request import MockResponse
 
 URLOPEN = "urllib.request.urlopen"

--- a/tests/health/test_health_check.py
+++ b/tests/health/test_health_check.py
@@ -1,5 +1,5 @@
 import pytest
-import mock
+from unittest import mock
 from duckbot.health import HealthCheck
 
 

--- a/tests/health/test_main.py
+++ b/tests/health/test_main.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import pytest
 from duckbot.health.__main__ import check
 

--- a/tests/server/test_channels.py
+++ b/tests/server/test_channels.py
@@ -1,5 +1,5 @@
 import pytest
-import mock
+from unittest import mock
 from duckbot.server import Channels
 
 

--- a/tests/server/test_emojis.py
+++ b/tests/server/test_emojis.py
@@ -1,5 +1,5 @@
 import pytest
-import mock
+from unittest import mock
 from duckbot.server import Emojis
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,5 +1,5 @@
 import sys
-import mock
+from unittest import mock
 import pytest
 from discord import Intents
 import duckbot


### PR DESCRIPTION
According to you, `mock` is a backport, and it's now built-in to python. So like. Here ya go.