### PR TITLE
add embed str and repr for better assertion failure messages

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -149,6 +149,7 @@ def patch_embed_equals():
 
     def embed_equals(self, other):
         return self.to_dict() == other.to_dict()
+
     def embed_str(self):
         return str(self.to_dict())
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -149,6 +149,10 @@ def patch_embed_equals():
 
     def embed_equals(self, other):
         return self.to_dict() == other.to_dict()
+    def embed_str(self):
+        return str(self.to_dict())
 
     discord.Embed.__eq__ = embed_equals
+    discord.Embed.__str__ = embed_str
+    discord.Embed.__repr__ = embed_str
     yield


### PR DESCRIPTION
I injected a failure into the eightball tests (which assert on an embed object).

```
>       context.send.assert_any_call(embed=embed)
E       AssertionError: send(embed=<discord.embeds.Embed object at 0x7f3925cdf700>) call not found
E       
E       pytest introspection follows:
E       
E       Kwargs:
E       assert equals failed
E         {                                {                               
E           'embed': <discord.embeds.Embe    'embed': <discord.embeds.Embe 
E         d object at 0x7f3925cdf^ca0>,     d object at 0x7f3925cdf^700>,    
E         }  
```

After this change, the error looks like:
```
>       context.send.assert_any_call(embed=embed)
E       AssertionError: send(embed={'fields': [{'inline': True, 'name': "<MagicMock name='Context.author.name' id='140450675442928'>, my :crystal_ball: says:", 'value': '_fortune2_'}], 'color': 10181046, 'type': 'rich'}) call not found
E       
E       pytest introspection follows:
E       
E       Kwargs:
E       assert equals failed
E         {                                {                               
E           'embed': {'fields': [{'inline    'embed': {'fields': [{'inline 
E         ': True, 'name': "<MagicMock na  ': True, 'name': "<MagicMock na 
E         me='Context.author.name' id='14  me='Context.author.name' id='14 
E         0450675442928'>, my :crystal_ba  0450675442928'>, my :crystal_ba 
E         ll: says:", 'value': '_fortune_  ll: says:", 'value': '_fortune+2 
E         '}], 'color': 10181046, 'type':  +_'}], 'color': 10181046, 'type' ...
E         
E         ...Full output truncated (3 lines hidden), use '-vv' to show
```
It's a little hard to see here, but pytest is showing `'value': '_fortune+2+` which shows the actual error I injected.