### PR TITLE
stub asyncio.sleep in eightball tests

### DIFF
--- a/tests/cogs/fortune/test_eightball.py
+++ b/tests/cogs/fortune/test_eightball.py
@@ -27,9 +27,10 @@ async def test_eightball_only_question_marks(bot, context, question):
 
 
 @pytest.mark.asyncio
+@mock.patch("asyncio.sleep", return_value=None)
 @mock.patch("random.choice", return_value="8ball")
 @mock.patch("random.random", return_value=0.5)
-async def test_eightball_gives_response(choice, random, bot, context):
+async def test_eightball_gives_response(sleep, choice, random, bot, context):
     clazz = EightBall(bot)
     await clazz.eightball(context, "will this test pass?")
     embed = Embed(colour=Colour.purple()).add_field(name=f"{context.author.name}, my :crystal_ball: says:", value="_8ball_")
@@ -37,9 +38,10 @@ async def test_eightball_gives_response(choice, random, bot, context):
 
 
 @pytest.mark.asyncio
+@mock.patch("asyncio.sleep", return_value=None)
 @mock.patch("random.choice", side_effect=["joke", "fortune"])
 @mock.patch("random.random", return_value=0.29)
-async def test_eightball_gives_joke_response(choice, random, bot, context):
+async def test_eightball_gives_joke_response(sleep, choice, random, bot, context):
     clazz = EightBall(bot)
     await clazz.eightball(context, "will this test pass?")
     context.send.assert_any_call("joke")


### PR DESCRIPTION
The eightball tests were taking a while, turns out they are just actually sleeping for 5s. Simply stubbing the sleep call to speed up the tests.