### PR TITLE
prevent `*` from expanding for message edit diff

### DIFF
--- a/duckbot/cogs/messages/edit_diff.py
+++ b/duckbot/cogs/messages/edit_diff.py
@@ -11,8 +11,8 @@ class EditDiff(commands.Cog):
         if before.author == self.bot.user or after.author == self.bot.user or before.content == after.content:
             return
 
-        before_file = f"echo $BEFORE > {before.id}.before"
-        after_file = f"echo $AFTER > {after.id}.after"
+        before_file = f'echo "$BEFORE" > {before.id}.before'
+        after_file = f'echo "$AFTER" > {after.id}.after'
         diff_cmd = f"git diff --no-index -U10000 --word-diff=plain --word-diff-regex=. {before.id}.before {after.id}.after | tail -n +6"
         cleanup = f"rm -rf {before.id}.before {after.id}.after"
         env = {"BEFORE": before.content, "AFTER": after.content}


### PR DESCRIPTION
Fixes #169 

Tested in DMs. Edited `***` to `***hello`.

```
twentylemon — Today at 7:13 PM
***hello
DuckBot
BOT
 — Today at 7:13 PM
:eyes: @twentylemon.
***{+hello+}
:eyes: @twentylemon.
[-duckbot requirem-]{+***h+}e[-nts.txt res-]{+ll+}o[-urces-]
```