### PR TITLE
`docker-compose build` before run in actions

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -41,6 +41,7 @@ jobs:
 
     - name: Test Connection to Discord
       run: |
+        docker-compose build
         docker-compose run --rm \
         -e 'DUCKBOT_ARGS=connection-test' \
         -e "DISCORD_TOKEN=$(cat .github/workflows/test-token.txt | base64 --decode)" \


### PR DESCRIPTION
Title. Looks like #174 is over-caching for the connection test. When running the image, `docker-compose run` will build the image if a local one isn't available. Well, after the caching a local one is available. Doing `docker-compose build` will build the image anew, which will use new source files, but most of the docker layers should still be cached. You can see some of the layers are cache hits in this [release task](https://github.com/Chippers255/duckbot/pull/181/checks?check_run_id=2505639160). Not sure why the pip install was a cache miss (cache invalidation, maybe) -- it shouldn't be a miss in general.