### PR TITLE
cache entire python env in github actions

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -26,10 +26,7 @@ jobs:
       with:
         path: ${{ env.pythonLocation }}
         key: ${{ env.pythonLocation }}-${{ hashFiles('**/requirements*.txt') }}
-#       with:
-#         path: ~/.cache/pip
-#         key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements*.txt') }}
-#         restore-keys: ${{ runner.os }}-pip-
+        restore-keys: ${{ env.pythonLocation }}-
     - name: Setup FFmpeg
       uses: FedericoCarboni/setup-ffmpeg@v1
 

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -24,9 +24,12 @@ jobs:
     - name: Setup Pip Cache
       uses: actions/cache@v2
       with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements*.txt') }}
-        restore-keys: ${{ runner.os }}-pip-
+        path: ${{ env.pythonLocation }}
+        key: ${{ env.pythonLocation }}-${{ hashFiles('**/requirements*.txt') }}
+#       with:
+#         path: ~/.cache/pip
+#         key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements*.txt') }}
+#         restore-keys: ${{ runner.os }}-pip-
     - name: Setup FFmpeg
       uses: FedericoCarboni/setup-ffmpeg@v1
 


### PR DESCRIPTION
#174 cached pip dependencies, but we still had to install them, which is most of the time spent during `pip install`. Turns out we can cache the entire python env, ie, the installed packages. See the install step [on this branch](https://github.com/twentylemon/duckbot/runs/2505709039?check_suite_focus=true), specifically that pip is skipping everything because the package is already installed (+ time save compared to [main](https://github.com/Chippers255/duckbot/runs/2505617691?check_suite_focus=true)). The cache is still invalidated when either of the `requirements` files changes, so it'll behave similar to the docker build (which re-installs packages only when the layer needs rebuilding).