### PR TITLE
run test actions in parallel

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -34,7 +34,10 @@ jobs:
       run: . scripts/build/install.sh actions
     - name: Run Tests
       run: . scripts/build/test.sh
-    
+
+  sanity:
+    runs-on: ubuntu-latest
+    steps:
     - name: Setup Docker Cache
       uses: satackey/action-docker-layer-caching@v0.0.11
       continue-on-error: true
@@ -47,7 +50,9 @@ jobs:
         duckbot
 
   deploy:
-    needs: release
+    needs:
+    - release
+    - sanity
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && github.repository == 'Chippers255/duckbot'
     steps:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -38,6 +38,7 @@ jobs:
   sanity:
     runs-on: ubuntu-latest
     steps:
+    - uses: actions/checkout@v2
     - name: Setup Docker Cache
       uses: satackey/action-docker-layer-caching@v0.0.11
       continue-on-error: true


### PR DESCRIPTION
Split up the `release` step into `release` and `sanity`. The jobs will run in parallel, so we'll save some more time in the actions.

See [build from my branch](https://github.com/twentylemon/duckbot/actions/runs/812041133).

**NOTE** you'll have to add `sanity` to the list of required checks for pull requests. This also means that each pull request will notify 3x instead of 2x to #duckbutt. Let me know your thoughts on that, I'm not super concerned about the time save, or noise. Eventually, I'll run out of stuff to do, so both mean less.