### PR TITLE
use display name instead of nickname for `!8ball`

### DIFF
--- a/duckbot/cogs/fortune/eightball.py
+++ b/duckbot/cogs/fortune/eightball.py
@@ -27,4 +27,4 @@ class EightBall(commands.Cog):
                     await context.send(random.choice(joke_phrases))
             async with context.typing():
                 await asyncio.sleep(5.0)
-                await context.send(embed=Embed(colour=Colour.purple()).add_field(name=f"{context.author.nick}, my :crystal_ball: says:", value=f"_{random.choice(phrases)}_"))
+                await context.send(embed=Embed(colour=Colour.purple()).add_field(name=f"{context.author.display_name}, my :crystal_ball: says:", value=f"_{random.choice(phrases)}_"))

--- a/tests/cogs/fortune/test_eightball.py
+++ b/tests/cogs/fortune/test_eightball.py
@@ -32,7 +32,7 @@ async def test_eightball_only_question_marks(bot, context, question):
 async def test_eightball_gives_response(choice, random, bot, context):
     clazz = EightBall(bot)
     await clazz.eightball(context, "will this test pass?")
-    embed = Embed(colour=Colour.purple()).add_field(name=f"{context.author.nick}, my :crystal_ball: says:", value="_8ball_")
+    embed = Embed(colour=Colour.purple()).add_field(name=f"{context.author.display_name}, my :crystal_ball: says:", value="_8ball_")
     context.send.assert_called_once_with(embed=embed)
 
 
@@ -43,5 +43,5 @@ async def test_eightball_gives_joke_response(choice, random, bot, context):
     clazz = EightBall(bot)
     await clazz.eightball(context, "will this test pass?")
     context.send.assert_any_call("joke")
-    embed = Embed(colour=Colour.purple()).add_field(name=f"{context.author.nick}, my :crystal_ball: says:", value="_fortune_")
+    embed = Embed(colour=Colour.purple()).add_field(name=f"{context.author.display_name}, my :crystal_ball: says:", value="_fortune_")
     context.send.assert_any_call(embed=embed)


### PR DESCRIPTION
Turns out, [display_name](https://discordpy.readthedocs.io/en/latest/api.html#discord.abc.User.display_name) is a thing. That's nice. Related to #176 