### PR TITLE
use display name in kubernetes, thanking robot cogs

### DIFF
--- a/duckbot/cogs/corrections/kubernetes.py
+++ b/duckbot/cogs/corrections/kubernetes.py
@@ -15,8 +15,7 @@ class Kubernetes(commands.Cog):
         kubes = ["koober nets", "kuber nets", "kubernets", "kubernetes"]
         for k in kubes:
             if k in message.content.lower():
-                author = str(message.author).split("#")[0]
-                correction = f"I think {author} means K8s"
+                correction = f"I think {message.author.display_name} means K8s"
                 await message.channel.send(correction)
 
     @commands.Cog.listener("on_message")
@@ -27,6 +26,5 @@ class Kubernetes(commands.Cog):
             return
 
         if "k8" in message.content.lower():
-            author = str(message.author).split("#")[0]
-            correction = f"I think {author} means Kubernetes"
+            correction = f"I think {message.author.display_name} means Kubernetes"
             await message.channel.send(correction)

--- a/duckbot/cogs/robot/thanking_robot.py
+++ b/duckbot/cogs/robot/thanking_robot.py
@@ -7,7 +7,7 @@ class ThankingRobot(commands.Cog):
 
     @commands.Cog.listener("on_message")
     async def correct_giving_thanks(self, message):
-        """Correcting people who thank the robot"""
+        """Correcting people who thank the robot."""
 
         if message.author == self.bot.user:
             return
@@ -15,6 +15,5 @@ class ThankingRobot(commands.Cog):
         thanks = ["thank you duckbot", "thanks duckbot", "thank you duck bot", "thanks duck bot"]
         for t in thanks:
             if t in message.content.lower().replace(",", ""):
-                author = str(message.author).split("#")[0]
-                correction = f"I am just a robot.  Do not personify me, {author}"
+                correction = f"I am just a robot.  Do not personify me, {message.author.display_name}"
                 await message.channel.send(correction)

--- a/tests/cogs/corrections/test_kubernetes.py
+++ b/tests/cogs/corrections/test_kubernetes.py
@@ -15,18 +15,16 @@ async def test_correct_kubernetes_bot_author(bot, message):
 @pytest.mark.parametrize("text", ["koober nets", "kuber nets", "kubernets", "kubernetes"])
 async def test_correct_kubernetes_message_is_kubernetes(bot, message, text):
     bot.user = "but"
-    message.author = "author"
     message.content = text
     clazz = Kubernetes(bot)
     await clazz.correct_kubernetes(message)
-    message.channel.send.assert_called_once_with(f"I think {message.author} means K8s")
+    message.channel.send.assert_called_once_with(f"I think {message.author.display_name} means K8s")
 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("text", ["kuber", "k8s", "duckbot"])
 async def test_correct_kubernetes_message_is_not_kubernetes(bot, message, text):
     bot.user = "but"
-    message.author = "author"
     message.content = text
     clazz = Kubernetes(bot)
     await clazz.correct_kubernetes(message)
@@ -46,18 +44,16 @@ async def test_correct_k8s_bot_author(bot, message):
 @pytest.mark.parametrize("text", ["k8", "k8s", "K8", "K8s", "K8S"])
 async def test_correct_k8s_message_is_k8s(bot, message, text):
     bot.user = "but"
-    message.author = "author"
     message.content = text
     clazz = Kubernetes(bot)
     await clazz.correct_k8s(message)
-    message.channel.send.assert_called_once_with(f"I think {message.author} means Kubernetes")
+    message.channel.send.assert_called_once_with(f"I think {message.author.display_name} means Kubernetes")
 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("text", ["kubernetes", "duckbot"])
 async def test_correct_k8s_message_is_not_k8s(bot, message, text):
     bot.user = "but"
-    message.author = "author"
     message.content = text
     clazz = Kubernetes(bot)
     await clazz.correct_k8s(message)

--- a/tests/cogs/robot/test_thanking_robot.py
+++ b/tests/cogs/robot/test_thanking_robot.py
@@ -16,17 +16,15 @@ async def test_correct_giving_thanks_bot_author(bot, message):
 @pytest.mark.parametrize("text", ["Thank you DuckBot. You're becoming so much more polite.", " tHaNks, DuCK BOt"])
 async def test_correct_giving_thanks_message_is_thanks(bot, message, text):
     bot.user = "but"
-    message.author = "author"
     message.content = text
     clazz = ThankingRobot(bot)
     await clazz.correct_giving_thanks(message)
-    message.channel.send.assert_called_once_with(f"I am just a robot.  Do not personify me, {message.author}")
+    message.channel.send.assert_called_once_with(f"I am just a robot.  Do not personify me, {message.author.display_name}")
 
 
 @pytest.mark.asyncio
 async def test_correct_giving_thanks_message_has_no_thanks(bot, message):
     bot.user = "but"
-    message.author = "author"
     message.content = "you duck, suckbot"
     clazz = ThankingRobot(bot)
     await clazz.correct_giving_thanks(message)


### PR DESCRIPTION
Related to #184, just using the `display_name` throughout the rest of the places the author is used. There are a few places where `mention` is used, but those already display the ...display name.