### PR TITLE
remove docker image cache from actions

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -34,10 +34,6 @@ jobs:
       run: . scripts/build/install.sh actions
     - name: Run Tests
       run: . scripts/build/test.sh
-    
-    - name: Setup Docker Cache
-      uses: satackey/action-docker-layer-caching@v0.0.11
-      continue-on-error: true
 
     - name: Test Connection to Discord
       run: |

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -51,6 +51,7 @@ jobs:
         context: .
         tags: chippers255/duckbot:latest
         push: false
+        load: true
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new
 

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -34,26 +34,6 @@ jobs:
       run: . scripts/build/install.sh actions
     - name: Run Tests
       run: . scripts/build/test.sh
-    
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
-    - name: Set up Docker Cache
-      uses: actions/cache@v2
-      with:
-        path: /tmp/.buildx-cache
-        key: ${{ runner.os }}-buildx-${{ github.sha }}
-        restore-keys: |
-          ${{ runner.os }}-buildx-
-
-    - name: Build DuckBot Docker Image
-      uses: docker/build-push-action@v2
-      with:
-        context: .
-        tags: chippers255/duckbot:latest
-        push: false
-        load: true
-        cache-from: type=local,src=/tmp/.buildx-cache
-        cache-to: type=local,dest=/tmp/.buildx-cache-new
 
     - name: Test Connection to Discord
       run: |
@@ -61,12 +41,6 @@ jobs:
         -e 'DUCKBOT_ARGS=connection-test' \
         -e "DISCORD_TOKEN=$(cat .github/workflows/test-token.txt | base64 --decode)" \
         duckbot
-
-    # see https://github.com/docker/build-push-action/blob/master/docs/advanced/cache.md
-    - name: Move Docker Cache
-      run: |
-        rm -rf /tmp/.buildx-cache
-        mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
   deploy:
     needs: release

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -34,14 +34,37 @@ jobs:
       run: . scripts/build/install.sh actions
     - name: Run Tests
       run: . scripts/build/test.sh
+    
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+    - name: Cache Docker layers
+      uses: actions/cache@v2
+      with:
+        path: /tmp/.buildx-cache
+        key: ${{ runner.os }}-buildx-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-buildx-
+
+    - name: Build DuckBot Docker Image
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        push: false
+        cache-from: type=local,src=/tmp/.buildx-cache
+        cache-to: type=local,dest=/tmp/.buildx-cache-new
 
     - name: Test Connection to Discord
       run: |
-        docker-compose build
         docker-compose run --rm \
         -e 'DUCKBOT_ARGS=connection-test' \
         -e "DISCORD_TOKEN=$(cat .github/workflows/test-token.txt | base64 --decode)" \
         duckbot
+
+    # see https://github.com/docker/build-push-action/blob/master/docs/advanced/cache.md
+    - name: Move Docker Cache
+      run: |
+        rm -rf /tmp/.buildx-cache
+        mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
   deploy:
     needs: release

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -37,7 +37,7 @@ jobs:
     
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
-    - name: Cache Docker layers
+    - name: Set up Docker Cache
       uses: actions/cache@v2
       with:
         path: /tmp/.buildx-cache

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -49,6 +49,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: .
+        tags: chippers255/duckbot:latest
         push: false
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new

--- a/scripts/build/install.sh
+++ b/scripts/build/install.sh
@@ -9,7 +9,7 @@ fi && \
 python -m pip install --upgrade pip && \
 
 # install package requirements
-python -m pip install -r "$(git rev-parse --show-toplevel)/requirements.txt" && \
+python -m pip install --upgrade -r "$(git rev-parse --show-toplevel)/requirements.txt" && \
 
 # install test and build dependencies
 python -m pip install -r "$(git rev-parse --show-toplevel)/requirements-dev.txt"


### PR DESCRIPTION
Fixes #186 

I tested a new caching strategy as well ([here](https://github.com/docker/build-push-action/blob/master/docs/advanced/cache.md)), but it ended up not being too different from just building the image from scratch each time. Since we have limited cache space, I figure it's just not worth it.

See:
* [different cache strategy](https://github.com/twentylemon/duckbot/runs/2511890469?check_suite_focus=true); build ~ 85s
* [this pr build](https://github.com/twentylemon/duckbot/runs/2511966176?check_suite_focus=true); build ~ 95s
* [recent main build](https://github.com/Chippers255/duckbot/runs/2511772661?check_suite_focus=true); build ~ 110s
* [old main build](https://github.com/Chippers255/duckbot/runs/2495426313?check_suite_focus=true); build ~ 65s

The old build there was Monday morning, so less traffic on docker/github servers. Either way, it shows that just building the image can still be comparable to building + caching.