### PR TITLE
attempt to clean up typing in `!8ball`

### DIFF
--- a/duckbot/cogs/fortune/eightball.py
+++ b/duckbot/cogs/fortune/eightball.py
@@ -21,10 +21,9 @@ class EightBall(commands.Cog):
         elif not question.endswith("?"):
             await context.send("I can't tell if that's a question, brother.")
         else:
-            if random.random() < 3.0 / 10.0:
-                async with context.typing():
+            async with context.typing():
+                if random.random() < 3.0 / 10.0:
                     await asyncio.sleep(3.0)
                     await context.send(random.choice(joke_phrases))
-            async with context.typing():
                 await asyncio.sleep(5.0)
                 await context.send(embed=Embed(colour=Colour.purple()).add_field(name=f"{context.author.display_name}, my :crystal_ball: says:", value=f"_{random.choice(phrases)}_"))


### PR DESCRIPTION
During `!8ball` now, duckbot emits _typing_ even after the response is sent, my guess is that there's two typing events sent by the bot... so this just tries to fix that by emitting _typing_ only once. I tested locally, it does seem to work a little better, but sometimes still says typing even after the message is sent. Meh, it's still better.