### PR TITLE
use message `clean_content` when calculating edit diff

### DIFF
--- a/duckbot/cogs/messages/edit_diff.py
+++ b/duckbot/cogs/messages/edit_diff.py
@@ -15,7 +15,7 @@ class EditDiff(commands.Cog):
         after_file = f"echo $AFTER > {after.id}.after"
         diff_cmd = f"git diff --no-index -U10000 --word-diff=plain --word-diff-regex=. {before.id}.before {after.id}.after | tail -n +6"
         cleanup = f"rm -rf {before.id}.before {after.id}.after"
-        env = {"BEFORE": before.content, "AFTER": after.content}
+        env = {"BEFORE": before.clean_content, "AFTER": after.clean_content}
 
         process = subprocess.run(f"{before_file} && {after_file} && {diff_cmd} ; {cleanup}", shell=True, capture_output=True, env=env)
         await after.channel.send(f":eyes: {after.author.mention}.\n{process.stdout.decode()}", delete_after=300)

--- a/tests/cogs/messages/test_edit_diff.py
+++ b/tests/cogs/messages/test_edit_diff.py
@@ -8,8 +8,8 @@ from duckbot.cogs.messages import EditDiff
 @mock.patch("discord.Message")
 async def test_show_edit_diff_typical_case(before, after, bot):
     before.id = after.id = 1
-    before.content = "abc"
-    after.content = "abd"
+    before.clean_content = "abc"
+    after.clean_content = "abd"
     clazz = EditDiff(bot)
     await clazz.show_edit_diff(before, after)
     after.channel.send.assert_called_once_with(f":eyes: {after.author.mention}.\nab[-c-]{{+d+}}\n", delete_after=300)


### PR DESCRIPTION
Fixes #132 

Some test results in #duckbutt channel:

```
Taras — Today at 12:19 PM
#duckbutt is #dank
DuckBot
BOT
 — Today at 12:19 PM
:eyes: @Taras.
#duckbutt is [-LAKJSD:LKASJD:L-]{+#dank+}
:eyes: @Taras.
#duckbutt is [-LAKJSD:LKASJD:L-]{+#dank+}
Taras — Today at 12:19 PM
#duckbutt @Taras
DuckBot
BOT
 — Today at 12:19 PM
:eyes: @Taras.
#duckb[-oard @D-]u[-ckBo-]t{+t @Taras+}
:eyes: @Taras.
<#[-8112-]7[-5-]{+86+}0[-51-]{+229+}7{+2+}1{+5+}3[-2984-]9{+21+}5{+46+}> <@!7[-837-]7[-159-]{+66+}0{+7+}9[-233-]8[-6-]{+2472+}9{+2+}1[-1-]{+088+}>
```