### PR TITLE
Add a random `Game` that Duckbot is playing when it starts

### DIFF
--- a/duckbot/duckbot.py
+++ b/duckbot/duckbot.py
@@ -3,8 +3,6 @@ import random
 from discord import Game, Intents
 from discord.ext import commands
 
-from duckbot.cogs import games
-
 
 def intents() -> Intents:
     intent = Intents.default()

--- a/duckbot/duckbot.py
+++ b/duckbot/duckbot.py
@@ -1,5 +1,9 @@
+import random
+
 from discord import Game, Intents
 from discord.ext import commands
+
+from duckbot.cogs import games
 
 
 def intents() -> Intents:
@@ -17,7 +21,8 @@ def intents() -> Intents:
 
 class DuckBot(commands.Bot):
     def __init__(self):
-        super().__init__(command_prefix="!", help_command=None, intents=intents(), activity=Game(name="Duck Game"))
+        game = ["Duck Game", "the Banjo", "Gloomhaven", "with Fire", "with the Boys"]
+        super().__init__(command_prefix="!", help_command=None, intents=intents(), activity=Game(name=random.choice(game)))
         self.add_listener(self.ready, name="on_ready")
 
     async def ready(self):

--- a/tests/test_duckbot.py
+++ b/tests/test_duckbot.py
@@ -20,7 +20,7 @@ async def test_duckbot_constructor():
     assert bot.command_prefix == "!"
     assert bot.help_command is None
     assert bot.intents == intents()
-    assert bot.activity == Game("Duck Game")
+    assert bot.activity in [Game("Duck Game"), Game("the Banjo"), Game("Gloomhaven"), Game("with Fire"), Game("with the Boys")]
     await bot.close()
 
 


### PR DESCRIPTION
When DuckBot is started it will now select a random `Game` to be playing. I have added a few initial choices as well as Gloomhaven to get Dave's rocks off. Duck Game is still an option.