### PR TITLE
mock out ffmpeg in tests

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -27,8 +27,6 @@ jobs:
         path: ${{ env.pythonLocation }}
         key: ${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}
         restore-keys: ${{ env.pythonLocation }}-
-    - name: Setup FFmpeg
-      uses: FedericoCarboni/setup-ffmpeg@v1
 
     - name: Install Packages
       run: |

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The `dev` extras will also install development dependencies, like `pytest`. The 
 There are a few additional packages required to be able to run tests locally.
 
 ```sh
-sudo apt-get install -y --no-install-recommends ffmpeg libpq-dev
+sudo apt-get install -y --no-install-recommends libpq-dev
 ```
 
 Then, you can run tests.
@@ -59,4 +59,4 @@ Finally, there's two ways to run DuckBot. For a production-like environment, you
 docker-compose up --build
 ```
 
-If your work doesn't need a full setup, you can just run `python -m duckbot` for less wait time. Depending on what packages you have installed, some features may not work, see the [Dockerfile](https://github.com/Chippers255/duckbot/blob/main/Dockerfile) for what packages you'd need. For testing simple new commands though, this works fine enough.
+If your work doesn't need a full setup, you can just run `python -m duckbot` for less wait time. Depending on what apt packages you have installed, some features may not work, see the [Dockerfile](https://github.com/Chippers255/duckbot/blob/main/Dockerfile) for what packages you'd need. For testing simple new commands though, this works fine enough.

--- a/tests/cogs/audio/test_who_can_it_be_now.py
+++ b/tests/cogs/audio/test_who_can_it_be_now.py
@@ -1,4 +1,5 @@
 import asyncio
+from unittest import mock
 
 import pytest
 from discord.ext.commands import CommandError
@@ -12,7 +13,9 @@ def play(*args, **kwargs):
 
 
 @pytest.mark.asyncio
-async def test_task_loop_once(bot_spy, text_context, voice_client):
+@mock.patch("duckbot.cogs.audio.who_can_it_be_now.FFmpegPCMAudio", autospec=True)
+@mock.patch("duckbot.cogs.audio.who_can_it_be_now.PCMVolumeTransformer", autospec=True)
+async def test_task_loop_once(ffmpeg, vol, bot_spy, text_context, voice_client):
     text_context.voice_client = None
     text_context.author.voice.channel.connect.return_value = async_value(voice_client)
     voice_client.play = play
@@ -30,7 +33,9 @@ async def test_task_loop_once(bot_spy, text_context, voice_client):
 
 
 @pytest.mark.asyncio
-async def test_task_loop_repeats(bot_spy, text_context, voice_client):
+@mock.patch("duckbot.cogs.audio.who_can_it_be_now.FFmpegPCMAudio", autospec=True)
+@mock.patch("duckbot.cogs.audio.who_can_it_be_now.PCMVolumeTransformer", autospec=True)
+async def test_task_loop_repeats(ffmpeg, vol, bot_spy, text_context, voice_client):
     text_context.voice_client = None
     text_context.author.voice.channel.connect.return_value = async_value(voice_client)
 
@@ -99,7 +104,9 @@ async def test_start_already_started(bot, context):
 
 
 @pytest.mark.asyncio
-async def test_stop_disconnects(bot, context, voice_client):
+@mock.patch("duckbot.cogs.audio.who_can_it_be_now.FFmpegPCMAudio", autospec=True)
+@mock.patch("duckbot.cogs.audio.who_can_it_be_now.PCMVolumeTransformer", autospec=True)
+async def test_stop_disconnects(ffmpeg, vol, bot, context, voice_client):
     clazz = WhoCanItBeNow(bot)
     clazz.streaming = True
     clazz.audio_task = asyncio.create_task(clazz.stream_audio())
@@ -127,7 +134,9 @@ async def test_stop_null_context_not_streaming(bot):
 
 
 @pytest.mark.asyncio
-async def test_cog_unload_stops_streaming(bot, voice_client):
+@mock.patch("duckbot.cogs.audio.who_can_it_be_now.FFmpegPCMAudio", autospec=True)
+@mock.patch("duckbot.cogs.audio.who_can_it_be_now.PCMVolumeTransformer", autospec=True)
+async def test_cog_unload_stops_streaming(ffmpeg, vol, bot, voice_client):
     bot.loop = asyncio.get_event_loop()
     clazz = WhoCanItBeNow(bot)
     clazz.voice_client = voice_client


### PR DESCRIPTION
Fixes the ffmpeg part of #211.

Seems the issue I was having previously was related to [where to patch](https://docs.python.org/3/library/unittest.mock.html#where-to-patch) -- tldr is `FFmpegAudio` essentially gets renamed when it is imported by the src class, so we need to mock out what it gets renamed to instead of `discord.FFmpegAudio`.