### PR TITLE
correct test argument names when using mock.patch

### DIFF
--- a/tests/cogs/audio/test_who_can_it_be_now.py
+++ b/tests/cogs/audio/test_who_can_it_be_now.py
@@ -13,8 +13,8 @@ def play(*args, **kwargs):
 
 
 @pytest.mark.asyncio
-@mock.patch("duckbot.cogs.audio.who_can_it_be_now.FFmpegPCMAudio", autospec=True)
 @mock.patch("duckbot.cogs.audio.who_can_it_be_now.PCMVolumeTransformer", autospec=True)
+@mock.patch("duckbot.cogs.audio.who_can_it_be_now.FFmpegPCMAudio", autospec=True)
 async def test_task_loop_once(ffmpeg, vol, bot_spy, text_context, voice_client):
     text_context.voice_client = None
     text_context.author.voice.channel.connect.return_value = async_value(voice_client)
@@ -33,8 +33,8 @@ async def test_task_loop_once(ffmpeg, vol, bot_spy, text_context, voice_client):
 
 
 @pytest.mark.asyncio
-@mock.patch("duckbot.cogs.audio.who_can_it_be_now.FFmpegPCMAudio", autospec=True)
 @mock.patch("duckbot.cogs.audio.who_can_it_be_now.PCMVolumeTransformer", autospec=True)
+@mock.patch("duckbot.cogs.audio.who_can_it_be_now.FFmpegPCMAudio", autospec=True)
 async def test_task_loop_repeats(ffmpeg, vol, bot_spy, text_context, voice_client):
     text_context.voice_client = None
     text_context.author.voice.channel.connect.return_value = async_value(voice_client)
@@ -104,8 +104,8 @@ async def test_start_already_started(bot, context):
 
 
 @pytest.mark.asyncio
-@mock.patch("duckbot.cogs.audio.who_can_it_be_now.FFmpegPCMAudio", autospec=True)
 @mock.patch("duckbot.cogs.audio.who_can_it_be_now.PCMVolumeTransformer", autospec=True)
+@mock.patch("duckbot.cogs.audio.who_can_it_be_now.FFmpegPCMAudio", autospec=True)
 async def test_stop_disconnects(ffmpeg, vol, bot, context, voice_client):
     clazz = WhoCanItBeNow(bot)
     clazz.streaming = True
@@ -134,8 +134,8 @@ async def test_stop_null_context_not_streaming(bot):
 
 
 @pytest.mark.asyncio
-@mock.patch("duckbot.cogs.audio.who_can_it_be_now.FFmpegPCMAudio", autospec=True)
 @mock.patch("duckbot.cogs.audio.who_can_it_be_now.PCMVolumeTransformer", autospec=True)
+@mock.patch("duckbot.cogs.audio.who_can_it_be_now.FFmpegPCMAudio", autospec=True)
 async def test_cog_unload_stops_streaming(ffmpeg, vol, bot, voice_client):
     bot.loop = asyncio.get_event_loop()
     clazz = WhoCanItBeNow(bot)

--- a/tests/cogs/fortune/test_eightball.py
+++ b/tests/cogs/fortune/test_eightball.py
@@ -29,9 +29,9 @@ async def test_eightball_only_question_marks(bot, context, question):
 
 
 @pytest.mark.asyncio
-@mock.patch("asyncio.sleep", return_value=None)
-@mock.patch("random.choice", return_value="8ball")
 @mock.patch("random.random", return_value=0.5)
+@mock.patch("random.choice", return_value="8ball")
+@mock.patch("asyncio.sleep", return_value=None)
 async def test_eightball_gives_response(sleep, choice, random, bot, context):
     clazz = EightBall(bot)
     await clazz.eightball(context, "will this test pass?")
@@ -40,9 +40,9 @@ async def test_eightball_gives_response(sleep, choice, random, bot, context):
 
 
 @pytest.mark.asyncio
-@mock.patch("asyncio.sleep", return_value=None)
-@mock.patch("random.choice", side_effect=["joke", "fortune"])
 @mock.patch("random.random", return_value=0.29)
+@mock.patch("random.choice", side_effect=["joke", "fortune"])
+@mock.patch("asyncio.sleep", return_value=None)
 async def test_eightball_gives_joke_response(sleep, choice, random, bot, context):
     clazz = EightBall(bot)
     await clazz.eightball(context, "will this test pass?")

--- a/tests/health/test_health_check.py
+++ b/tests/health/test_health_check.py
@@ -5,10 +5,9 @@ import pytest
 from duckbot.health import HealthCheck
 
 
-@mock.patch("discord.ext.commands.Bot")
-@mock.patch("asyncio.StreamReader")
 @mock.patch("asyncio.StreamWriter")
-def test_healthcheck_bot_user_is_none(bot, reader, writer):
+@mock.patch("asyncio.StreamReader")
+def test_healthcheck_bot_user_is_none(reader, writer, bot):
     bot.user = None
     clazz = HealthCheck(bot)
     clazz.healthcheck(reader, writer)
@@ -16,10 +15,9 @@ def test_healthcheck_bot_user_is_none(bot, reader, writer):
     writer.close.assert_called()
 
 
-@mock.patch("discord.ext.commands.Bot")
-@mock.patch("asyncio.StreamReader")
 @mock.patch("asyncio.StreamWriter")
-def test_healthcheck_bot_is_not_ready(bot, reader, writer):
+@mock.patch("asyncio.StreamReader")
+def test_healthcheck_bot_is_not_ready(reader, writer, bot):
     bot.user = "user"
     bot.is_ready.return_value = False
     clazz = HealthCheck(bot)
@@ -28,10 +26,9 @@ def test_healthcheck_bot_is_not_ready(bot, reader, writer):
     writer.close.assert_called()
 
 
-@mock.patch("discord.ext.commands.Bot")
-@mock.patch("asyncio.StreamReader")
 @mock.patch("asyncio.StreamWriter")
-def test_healthcheck_bot_is_closed(bot, reader, writer):
+@mock.patch("asyncio.StreamReader")
+def test_healthcheck_bot_is_closed(reader, writer, bot):
     bot.user = "user"
     bot.is_ready.return_value = True
     bot.is_closed.return_value = True
@@ -41,10 +38,9 @@ def test_healthcheck_bot_is_closed(bot, reader, writer):
     writer.close.assert_called()
 
 
-@mock.patch("discord.ext.commands.Bot")
-@mock.patch("asyncio.StreamReader")
 @mock.patch("asyncio.StreamWriter")
-def test_healthcheck_bot_is_slow(bot, reader, writer):
+@mock.patch("asyncio.StreamReader")
+def test_healthcheck_bot_is_slow(reader, writer, bot):
     bot.user = "user"
     bot.is_ready.return_value = True
     bot.is_closed.return_value = False
@@ -55,10 +51,9 @@ def test_healthcheck_bot_is_slow(bot, reader, writer):
     writer.close.assert_called()
 
 
-@mock.patch("discord.ext.commands.Bot")
-@mock.patch("asyncio.StreamReader")
 @mock.patch("asyncio.StreamWriter")
-def test_healthcheck_healthy(bot, reader, writer):
+@mock.patch("asyncio.StreamReader")
+def test_healthcheck_healthy(reader, writer, bot):
     bot.user = "user"
     bot.is_ready.return_value = True
     bot.is_closed.return_value = False
@@ -70,8 +65,7 @@ def test_healthcheck_healthy(bot, reader, writer):
 
 
 @pytest.mark.asyncio
-@mock.patch("discord.ext.commands.Bot")
 @mock.patch("asyncio.start_server", return_value=None)
-async def test_start_health_check_tasks(bot, server):
+async def test_start_health_check_tasks(server, bot):
     clazz = HealthCheck(bot)
     await clazz.start_health_check_tasks()


### PR DESCRIPTION
As @jameshughes89  pointed out in #223, mock.patch decorators apply in reverse-ish order. This just corrects test argument names through all the tests. No behaviour was broken before, since we either didn't use the patched class directly, or added the behaviour we wanted to the mock anyways. This is essentially just for correctness, to prevent confusion in the future.

For finding this, I just did `grep -rn 'mock.patch' *` and looked for two mock.patches on consecutive lines. There's surprisingly few, probably because we use fixtures for most mocks.