### PR TITLE
cache entire python virtualenv in actions

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -22,7 +22,7 @@ jobs:
       id: venv
       uses: actions/cache@v2
       with:
-        path: ./venv
+        path: venv
         key: ${{ env.pythonLocation }}-venv-${{ hashFiles('setup.py') }}
 
     - name: Install Packages

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -18,19 +18,24 @@ jobs:
       with:
         python-version: '3.8'
 
-    - name: Setup Pip Cache
+    - name: Setup Virtual Environment Cache
+      id: venv
       uses: actions/cache@v2
       with:
-        path: ${{ env.pythonLocation }}
-        key: ${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}
-        restore-keys: ${{ env.pythonLocation }}-
+        path: ./venv
+        key: ${{ env.pythonLocation }}-venv-${{ hashFiles('setup.py') }}
 
     - name: Install Packages
+      if: steps.venv.outputs.cache-hit != 'true'
       run: |
+        python -m venv --clear venv
+        . ./venv/bin/activate
         pip install --upgrade pip setuptools wheel
         pip install --editable .[dev]
     - name: Run Tests
-      run: pytest
+      run: |
+        . venv/bin/activate
+        pytest
 
   sanity:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Was just fiddling with some more caching, seems like we can cache the whole venv to save some install steps. It's not much, but like 10s for every `release`. See some [actions from my branch](https://github.com/twentylemon/duckbot/actions?query=branch%3Acache-venv).