### PR TITLE
add codecov config

### DIFF
--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -1,0 +1,20 @@
+codecov:
+  require_ci_to_pass: yes
+
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+
+parsers:
+  gcov:
+    branch_detection:
+      conditional: yes
+      loop: yes
+      method: no
+      macro: no
+
+comment:
+  layout: "reach,diff,flags,files,footer"
+  behavior: default
+  require_changes: no

--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -1,20 +1,6 @@
-codecov:
-  require_ci_to_pass: yes
-
 coverage:
-  precision: 2
-  round: down
-  range: "70...100"
-
-parsers:
-  gcov:
-    branch_detection:
-      conditional: yes
-      loop: yes
-      method: no
-      macro: no
-
-comment:
-  layout: "reach,diff,flags,files,footer"
-  behavior: default
-  require_changes: no
+  status:
+    project:
+      default:
+        target: 85
+        threshold: 10  # allow coverage drops by up to 10%


### PR DESCRIPTION
I think this sets up codecov.io config. Setting the target to 85%, and allowing coverage drops.

* https://docs.codecov.io/docs/commit-status
* https://docs.codecov.io/docs/codecov-yaml