### PR TITLE
delete `!start` and `!stop` command messages

### DIFF
--- a/duckbot/cogs/audio/who_can_it_be_now.py
+++ b/duckbot/cogs/audio/who_can_it_be_now.py
@@ -4,6 +4,8 @@ from importlib.resources import path
 from discord import FFmpegPCMAudio, PCMVolumeTransformer, VoiceClient
 from discord.ext import commands
 
+from duckbot.util.messages import try_delete
+
 
 class WhoCanItBeNow(commands.Cog):
     def __init__(self, bot):
@@ -73,3 +75,8 @@ class WhoCanItBeNow(commands.Cog):
             self.streaming = False
         elif context is not None:
             await context.send("Brother, no :musical_note: :saxophone: is active.")
+
+    @start.after_invoke
+    @stop.after_invoke
+    async def delete_command_message(self, context):
+        await try_delete(context.message)

--- a/tests/cogs/audio/test_who_can_it_be_now.py
+++ b/tests/cogs/audio/test_who_can_it_be_now.py
@@ -147,3 +147,10 @@ async def test_cog_unload_stops_streaming(ffmpeg, vol, bot, voice_client):
     assert clazz.streaming is False
     assert clazz.voice_client is None
     assert clazz.audio_task is None
+
+
+@pytest.mark.asyncio
+async def test_delete_command_message(bot, context):
+    clazz = WhoCanItBeNow(bot)
+    await clazz.delete_command_message(context)
+    context.message.delete.assert_called()


### PR DESCRIPTION
Related to #147. Tested in beta as well.