### PR TITLE
check if message exists before trying delete in `try_delete` utility

### DIFF
--- a/duckbot/util/messages/try_delete.py
+++ b/duckbot/util/messages/try_delete.py
@@ -3,4 +3,5 @@ from discord import Message
 
 async def try_delete(message: Message) -> None:
     """Attempts to delete the message, ignoring permission or other errors."""
-    await message.delete(delay=0)  # delay != None, the library already ignores errors
+    if message:
+        await message.delete(delay=0)  # delay != None, the library already ignores errors

--- a/tests/util/messages/test_try_delete.py
+++ b/tests/util/messages/test_try_delete.py
@@ -10,5 +10,5 @@ async def test_try_delete_deletes_message(message):
 
 
 @pytest.mark.asyncio
-async def test_try_delete_message_is_none(message):
+async def test_try_delete_message_is_none():
     await try_delete(None)

--- a/tests/util/messages/test_try_delete.py
+++ b/tests/util/messages/test_try_delete.py
@@ -4,6 +4,11 @@ from duckbot.util.messages import try_delete
 
 
 @pytest.mark.asyncio
-async def test_try_delete_only_use_case(message):
+async def test_try_delete_deletes_message(message):
     await try_delete(message)
     message.delete.assert_called_once_with(delay=0)
+
+
+@pytest.mark.asyncio
+async def test_try_delete_message_is_none(message):
+    await try_delete(None)


### PR DESCRIPTION
Title. Related to #246 and #248. `InteractionContext` doesn't have a message to delete, so just adding some safety checks to this utility function. Haven't decided how to handle it in slash commands yet, but this seems just sensical to add.