### PR TITLE
add default codecov config

### DIFF
--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -1,6 +1,25 @@
+codecov:
+  require_ci_to_pass: yes
+
 coverage:
+  precision: 2
+  round: down
+  range: "70...100"
   status:
     project:
       default:
         target: 85
         threshold: 10  # allow coverage drops by up to 10%
+
+parsers:
+  gcov:
+    branch_detection:
+      conditional: yes
+      loop: yes
+      method: no
+      macro: no
+
+comment:
+  layout: "reach,diff,flags,files,footer"
+  behavior: default
+  require_changes: no


### PR DESCRIPTION
codecov seems to be broken since [config was added](https://github.com/Chippers255/duckbot/commit/74c26faa3d0aafcac1c66f7ee1f35e72e8b73c8c), not sure why. This is just re-adding the [default config](https://docs.codecov.io/docs/codecov-yaml), in addition to the threshold configs added into mentioned commit.