### PR TITLE
show word-by-word diff instead of letter-by-letter for message edit diff

### DIFF
--- a/tests/cogs/messages/test_edit_diff.py
+++ b/tests/cogs/messages/test_edit_diff.py
@@ -11,14 +11,15 @@ from duckbot.cogs.messages import EditDiff
 @pytest.mark.parametrize(
     "before_text,after_text,diff",
     [
-        ("a", "ba", "{+b+}a"),
-        ("a", "ab", "a{+b+}"),
-        ("ab", "a", "a[-b-]"),
-        ("ba", "a", "[-b-]a"),
-        ("abc", "dbc", "[-a-]{+d+}bc"),
-        ("abc", "abd", "ab[-c-]{+d+}"),
-        ("abc", "bcd", "[-a-]bc{+d+}"),
-        ("abc", "def", "[-abc-]{+def+}"),
+        ("replace", "word", "[-replace-]{+word+}"),
+        ("add space", "add   space", "add[- -]{+   +}space"),
+        ("add word", "add middle word", "add {+middle +}word"),
+        ("add", "add word", "add{+ word+}"),
+        ("word", "add word", "{+add +}word"),
+        ("remove word", "remove", "remove[- word-]"),
+        ("remove word", "word", "[-remove -]word"),
+        ("two words", "two things", "two [-words-]{+things+}"),
+        ("two words", "full change", "[-two-]{+full+} [-words-]{+change+}"),
     ],
 )
 async def test_show_edit_diff_typical_case(before, after, before_text, after_text, diff, bot):


### PR DESCRIPTION
Title! See test cases for examples.

I figure word level diffs are easier to read. For example, changing `there` to `their` would yield `the{+i+}r[-e-]` when calculated letter by letter, but `[-there-]{+their+}` when word by word.

Maybe not ideal, but I figure we can test it out in the wild. 