### PR TITLE
add missing `%` to codecov config

### DIFF
--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -3,4 +3,4 @@ coverage:
     project:
       default:
         target: 85
-        threshold: 10  # allow coverage drops by up to 10%
+        threshold: 10%  # allow coverage drops by up to 10%


### PR DESCRIPTION
See [docs](https://docs.codecov.io/docs/commit-status) -- seems threshold needs a `%` even though the type is listed as `number`.