### PR TITLE
add chance to also send a gif during day of the week announcement

### DIFF
--- a/duckbot/cogs/announce_day/announce_day.py
+++ b/duckbot/cogs/announce_day/announce_day.py
@@ -1,4 +1,5 @@
 import datetime
+import logging
 import random
 
 import discord
@@ -9,6 +10,8 @@ from discord.ext import commands, tasks
 from .phrases import days, templates
 from .special_days import SpecialDays
 
+log = logging.getLogger(__name__)
+
 
 class AnnounceDay(commands.Cog):
     def __init__(self, bot, dog_photos):
@@ -16,10 +19,10 @@ class AnnounceDay(commands.Cog):
         self.dog_photos = dog_photos
         self.tz = pytz.timezone("US/Eastern")
         self.holidays = SpecialDays(bot)
-        self.on_hour.start()
+        self.on_hour_loop.start()
 
     def cog_unload(self):
-        self.on_hour.cancel()
+        self.on_hour_loop.cancel()
 
     def should_announce_day(self):
         now = datetime.datetime.now(self.tz)
@@ -38,23 +41,34 @@ class AnnounceDay(commands.Cog):
             return message
 
     @tasks.loop(hours=1.0)
-    async def on_hour(self):
-        await self.__on_hour()
+    async def on_hour_loop(self):
+        await self.on_hour()
 
-    async def __on_hour(self):
+    async def on_hour(self):
         if self.should_announce_day():
             channel = discord.utils.get(self.bot.get_all_channels(), guild__name="Friends Chat", name="general", type=ChannelType.text)
             if channel:
                 message = self.get_message()
                 await channel.send(message)
                 if random.random() < 1.0 / 10.0:
-                    try:
-                        dogs = [":dog:", ":dog2:", ":guide_dog:", ":service_dog:"]
-                        await channel.send(f"Also, here's a dog! {random.choice(dogs)}\n{self.dog_photos.get_dog_image()}")
-                    except Exception:
-                        pass  # ignore failures for sending dog photo
+                    await self.send_dog(channel)
+                elif random.random() < 1.0 / 10.0:
+                    await self.send_gif(channel)
 
-    @on_hour.before_loop
+    async def send_dog(self, channel):
+        try:
+            dogs = [":dog:", ":dog2:", ":guide_dog:", ":service_dog:"]
+            await channel.send(f"Also, here's a dog! {random.choice(dogs)}\n{self.dog_photos.get_dog_image()}")
+        except Exception as e:
+            log.warning(e, exc_info=True)  # ignore failures for sending dog photo
+
+    async def send_gif(self, channel):
+        now = datetime.datetime.now(self.tz)
+        day = now.weekday()
+        if days[day]["gifs"]:
+            await channel.send(random.choice(days[day]["gifs"]))
+
+    @on_hour_loop.before_loop
     async def before_loop(self):
         await self.bot.wait_until_ready()
 

--- a/duckbot/cogs/announce_day/announce_day.py
+++ b/duckbot/cogs/announce_day/announce_day.py
@@ -50,10 +50,11 @@ class AnnounceDay(commands.Cog):
             if channel:
                 message = self.get_message()
                 await channel.send(message)
-                if random.random() < 1.0 / 10.0:
-                    await self.send_dog(channel)
-                elif random.random() < 1.0 / 10.0:
-                    await self.send_gif(channel)
+
+                should_send_dog = random.random() < 1.0 / 10.0
+                should_send_gif = not should_send_dog and random.random() < 1.0 / 10.0
+                await self.send_dog(channel) if should_send_dog else None
+                await self.send_gif(channel) if should_send_gif else None
 
     async def send_dog(self, channel):
         try:

--- a/duckbot/cogs/announce_day/phrases.py
+++ b/duckbot/cogs/announce_day/phrases.py
@@ -8,6 +8,7 @@ days = {
         "templates": [
             "Screw this, it is {0}.",
         ],
+        "gifs": [],
     },
     1: {
         "names": [
@@ -19,6 +20,7 @@ days = {
         "templates": [
             "Yo, one of my favourite days ever: {0}.",
         ],
+        "gifs": [],
     },
     2: {
         "names": [
@@ -30,6 +32,7 @@ days = {
             "https://www.youtube.com/watch?v=du-TY1GUFGk",
         ],
         "templates": [],
+        "gifs": [],
     },
     3: {
         "names": [
@@ -39,6 +42,7 @@ days = {
             "Thursday",
         ],
         "templates": [],
+        "gifs": [],
     },
     4: {
         "names": [
@@ -48,6 +52,9 @@ days = {
             "Friday",
         ],
         "templates": [],
+        "gifs": [
+            "https://tenor.com/view/nicolas-cage-friday-feel-that-friday-feeling-feel-that-thats-friday-gif-12235300",
+        ],
     },
     5: {
         "names": [
@@ -58,6 +65,7 @@ days = {
         "templates": [
             "WEEKEND ALERT: {0}!",
         ],
+        "gifs": [],
     },
     6: {
         "names": [
@@ -68,9 +76,11 @@ days = {
         "templates": [
             "WEEKEND ALERT: {0}!",
         ],
+        "gifs": [],
     },
 }
 
+# {0} is today, {1} is tomorrow
 templates = [
     "Today is {0}.",
     "Today: {0}. Tomorrow: {1}.",


### PR DESCRIPTION
Fixes #35 

Added a 10% chance to send a day of the week specific gif if we don't already send a dog photo. The only gif right right is the one specified in the issue, Nick Cage flow.