### PR TITLE
add `!coin` to flip a coin

### DIFF
--- a/duckbot/cogs/games/__init__.py
+++ b/duckbot/cogs/games/__init__.py
@@ -1,7 +1,9 @@
 from .aoe import AgeOfEmpires
+from .coin_flip import CoinFlip
 from .dice import Dice
 
 
 def setup(bot):
     bot.add_cog(Dice(bot))
     bot.add_cog(AgeOfEmpires(bot))
+    bot.add_cog(CoinFlip(bot))

--- a/duckbot/cogs/games/coin_flip.py
+++ b/duckbot/cogs/games/coin_flip.py
@@ -1,0 +1,16 @@
+import random
+
+from discord.ext import commands
+
+
+class CoinFlip(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+
+    @commands.command(name="coin", aliases=["flop", "toss"])
+    async def coin_command(self, context):
+        await self.coin_flip(context)
+
+    async def coin_flip(self, context):
+        faces = ["Heads!", "Tails"] * 50 + ["The Side"]
+        await context.send(f":coin: :coin: {random.choice(faces)} :coin: :coin:")

--- a/duckbot/cogs/games/coin_flip.py
+++ b/duckbot/cogs/games/coin_flip.py
@@ -7,7 +7,7 @@ class CoinFlip(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
 
-    @commands.command(name="coin", aliases=["flop", "toss"])
+    @commands.command(name="coin", aliases=["flip", "toss"])
     async def coin_command(self, context):
         await self.coin_flip(context)
 

--- a/tests/cogs/games/test_coin_flip.py
+++ b/tests/cogs/games/test_coin_flip.py
@@ -1,0 +1,13 @@
+from unittest import mock
+
+import pytest
+
+from duckbot.cogs.games import CoinFlip
+
+
+@pytest.mark.asyncio
+@mock.patch("random.choice", return_value="some coin flip result")
+async def test_coin_flip_sends_result(random, bot, context):
+    clazz = CoinFlip(bot)
+    await clazz.coin_flip(context)
+    context.send.assert_called_once_with(":coin: :coin: some coin flip result :coin: :coin:")

--- a/tests/cogs/games/test_setup.py
+++ b/tests/cogs/games/test_setup.py
@@ -1,6 +1,6 @@
 import pytest
 
-from duckbot.cogs.games import AgeOfEmpires, Dice
+from duckbot.cogs.games import AgeOfEmpires, CoinFlip, Dice
 from duckbot.cogs.games import setup as extension_setup
 from tests.discord_test_ext import assert_cog_added_of_type
 
@@ -10,3 +10,4 @@ async def test_setup(bot_spy):
     extension_setup(bot_spy)
     assert_cog_added_of_type(bot_spy, Dice)
     assert_cog_added_of_type(bot_spy, AgeOfEmpires)
+    assert_cog_added_of_type(bot_spy, CoinFlip)


### PR DESCRIPTION
A simple `!coin` command to flip a coin. Also as a small chance to land on the side.