### PR TITLE
yeet some messages to keep chats a little cleaner

### DIFF
--- a/duckbot/cogs/audio/who_can_it_be_now.py
+++ b/duckbot/cogs/audio/who_can_it_be_now.py
@@ -27,11 +27,11 @@ class WhoCanItBeNow(commands.Cog):
     async def connect_to_voice(self, context):
         if context.voice_client is None:
             if not hasattr(context.author, "voice"):
-                await context.send("Music can only be played in a discord server, not a private channel.")
+                await context.send("Music can only be played in a discord server, not a private channel.", delete_after=30)
             elif context.author.voice:
                 self.voice_client = await context.author.voice.channel.connect()
             else:
-                await context.send("Connect to a voice channel so I know where to `!start`.")
+                await context.send("Connect to a voice channel so I know where to `!start`.", delete_after=30)
                 raise commands.CommandError("`start` invoked when author not in voice channel")
         else:
             context.voice_client.stop()
@@ -74,7 +74,7 @@ class WhoCanItBeNow(commands.Cog):
             self.voice_client = None
             self.streaming = False
         elif context is not None:
-            await context.send("Brother, no :musical_note: :saxophone: is active.")
+            await context.send("Brother, no :musical_note: :saxophone: is active.", delete_after=30)
 
     @start.after_invoke
     @stop.after_invoke

--- a/duckbot/cogs/duck/duck.py
+++ b/duckbot/cogs/duck/duck.py
@@ -3,6 +3,7 @@ import random
 from discord.ext import commands
 
 from duckbot.util.emojis import regional_indicator
+from duckbot.util.messages import try_delete
 
 
 class Duck(commands.Cog):
@@ -23,15 +24,20 @@ class Duck(commands.Cog):
                 await message.add_reaction(regional_indicator(c))
 
     @commands.command(name="duck")
-    async def github(self, context):
-        await self.__github(context)
+    async def duck_command(self, context):
+        await self.github(context)
 
-    async def __github(self, context):
+    async def github(self, context):
         await context.send("https://github.com/Chippers255/duckbot")
 
     @commands.command(name="help")
-    async def wiki(self, context):
-        await self.__wiki(context)
+    async def wiki_command(self, context):
+        await self.wiki(context)
 
-    async def __wiki(self, context):
+    async def wiki(self, context):
         await context.send("https://github.com/Chippers255/duckbot/wiki")
+
+    @duck_command.after_invoke
+    @wiki_command.after_invoke
+    async def delete_command_message(self, context):
+        await try_delete(context.message)

--- a/duckbot/cogs/games/dice.py
+++ b/duckbot/cogs/games/dice.py
@@ -17,9 +17,9 @@ class Dice(commands.Cog):
             text = f"{result.result[:1950]}..." if len(result.result) > 1950 else result.result
             await context.send(f"**Rolls**: {text}\n**Total**: {result.total}")
         except d20.errors.TooManyRolls:
-            await context.send(f"I can only roll up to {roller.context.max_rolls} dice.")
+            await context.send(f"I can only roll up to {roller.context.max_rolls} dice.", delete_after=30)
         except d20.errors.RollError as e:
-            await context.send(f"Oh... :nauseated_face: I don't feel so good... :face_vomiting:\n```{e}```")
+            await context.send(f"Oh... :nauseated_face: I don't feel so good... :face_vomiting:\n```{e}```", delete_after=30)
 
     def make_roller(self, max_rolls: int):
         return d20.Roller(d20.RollContext(max_rolls))

--- a/tests/cogs/audio/test_who_can_it_be_now.py
+++ b/tests/cogs/audio/test_who_can_it_be_now.py
@@ -65,7 +65,7 @@ async def test_connect_to_voice_no_voice(bot, context):
     delattr(context.author, "voice")
     clazz = WhoCanItBeNow(bot)
     await clazz.connect_to_voice(context)
-    context.send.assert_called_once_with("Music can only be played in a discord server, not a private channel.")
+    context.send.assert_called_once_with("Music can only be played in a discord server, not a private channel.", delete_after=30)
 
 
 @pytest.mark.asyncio
@@ -84,7 +84,7 @@ async def test_connect_to_voice_author_not_in_channel(bot, context):
     clazz = WhoCanItBeNow(bot)
     with pytest.raises(CommandError):
         await clazz.connect_to_voice(context)
-    context.send.assert_called_once_with("Connect to a voice channel so I know where to `!start`.")
+    context.send.assert_called_once_with("Connect to a voice channel so I know where to `!start`.", delete_after=30)
 
 
 @pytest.mark.asyncio
@@ -123,7 +123,7 @@ async def test_stop_not_streaming(bot, context):
     clazz = WhoCanItBeNow(bot)
     clazz.streaming = False
     await clazz._WhoCanItBeNow__stop(context)
-    context.send.assert_called_once_with("Brother, no :musical_note: :saxophone: is active.")
+    context.send.assert_called_once_with("Brother, no :musical_note: :saxophone: is active.", delete_after=30)
 
 
 @pytest.mark.asyncio

--- a/tests/cogs/duck/test_duck.py
+++ b/tests/cogs/duck/test_duck.py
@@ -63,12 +63,19 @@ async def test_react_with_duckbot_random_passes(random, bot, message):
 @pytest.mark.asyncio
 async def test_github(bot, context):
     clazz = Duck(bot)
-    await clazz._Duck__github(context)
+    await clazz.github(context)
     context.send.assert_called_once_with("https://github.com/Chippers255/duckbot")
 
 
 @pytest.mark.asyncio
 async def test_wiki(bot, context):
     clazz = Duck(bot)
-    await clazz._Duck__wiki(context)
+    await clazz.wiki(context)
     context.send.assert_called_once_with("https://github.com/Chippers255/duckbot/wiki")
+
+
+@pytest.mark.asyncio
+async def test_delete_command_message(bot, context):
+    clazz = Duck(bot)
+    await clazz.delete_command_message(context)
+    context.message.delete.assert_called()

--- a/tests/cogs/games/test_dice.py
+++ b/tests/cogs/games/test_dice.py
@@ -11,14 +11,14 @@ from duckbot.cogs.games import Dice
 async def test_roll_dice_error(roller, bot, context):
     clazz = Dice(bot)
     await clazz.roll(context, "1d-20")
-    context.send.assert_called_once_with("Oh... :nauseated_face: I don't feel so good... :face_vomiting:\n```ded```")
+    context.send.assert_called_once_with("Oh... :nauseated_face: I don't feel so good... :face_vomiting:\n```ded```", delete_after=30)
 
 
 @pytest.mark.asyncio
 async def test_roll_dice_too_many_dice(bot, context):
     clazz = Dice(bot)
     await clazz.roll(context, "100001d20")
-    context.send.assert_called_once_with("I can only roll up to 100000 dice.")
+    context.send.assert_called_once_with("I can only roll up to 100000 dice.", delete_after=30)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes #147. I opted not to delete most command messages since they kinda serve as documentation. We'd have to change the responses to also include the question and who asked it (like a `!weather` response by itself seems weird).

I did opt to delete some error messages after a short time though.