### PR TITLE
install `libpulse-dev` for matplotlib

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ FROM python:3.8-slim as prod
 RUN apt-get update && apt-get -y install \
     ffmpeg \
     libpq-dev \
+    libpulse-dev \
     fortune-mod fortunes fortunes-off cowsay cowsay-off \
   && apt-get clean && rm -rf /var/lib/apt/lists/*
 ENV PATH "$PATH:/usr/games"


### PR DESCRIPTION
Title, since apparently something isn't working when [matplotlib was added](https://github.com/Chippers255/duckbot/commit/3ddc6c5c15cf9c711a4f657b886a9afa4776303e). See https://stackoverflow.com/questions/43613666/pip-install-matplotlib-fails-on-raspbian-jessie-4-4