### PR TITLE
Revert "install `libpulse-dev` for matplotlib (#266)"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,6 @@ FROM python:3.8-slim as prod
 RUN apt-get update && apt-get -y install \
     ffmpeg \
     libpq-dev \
-    libpulse-dev \
     fortune-mod fortunes fortunes-off cowsay cowsay-off \
   && apt-get clean && rm -rf /var/lib/apt/lists/*
 ENV PATH "$PATH:/usr/games"


### PR DESCRIPTION
This reverts commit 7c58724f

Doesn't seem like it's needed. Needed for PIs, but docker != pi.
