### PR TITLE
build amd platform docker image

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -80,7 +80,7 @@ jobs:
     - name: Build and Push Docker Image
       run: |
         docker buildx bake \
-          --set '*.platform=linux/arm/v7' \
+          --set '*.platform=linux/arm/v7,linux/amd64' \
           --push \
           --set '*.cache-from=type=local,src=/tmp/.buildx-cache' \
           --set '*.cache-to=type=local,dest=/tmp/.buildx-cache'


### PR DESCRIPTION
**Try #271 first.**

If we're moving duckbot to a non-pi instance, we'll need a new platform so the new host can actually run it. This just adds the `amd64` platform (read: basically everything) to the docker image build.