### PR TITLE
install `libatlas-base-dev` and `libgeos-dev` to docker image for matplotlib

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,13 +7,14 @@ WORKDIR /pip-dependencies
 RUN pip install --upgrade pip setuptools wheel
 COPY pyproject.toml .
 COPY setup.py .
-RUN pip install --extra-index-url https://www.piwheels.org/simple .
+RUN pip install --no-cache-dir --extra-index-url https://www.piwheels.org/simple .
 
 FROM python:3.8-slim as prod
 RUN apt-get update && apt-get -y install \
     ffmpeg \
     libpq-dev \
     libpulse-dev \
+    libatlas-base-dev libgeos-dev \
     fortune-mod fortunes fortunes-off cowsay cowsay-off \
   && apt-get clean && rm -rf /var/lib/apt/lists/*
 ENV PATH "$PATH:/usr/games"


### PR DESCRIPTION
Title. I lost the links now, but iirc numpy needed atlas, and shapely needed geos. Both python libraries are pulled in transitively by matplotlib.

Tested locally against a virtual arm platform (took >3h to build the image). Emulation is insanely slow, but it did start and `!weather` actually worked as expected.