### PR TITLE
install matplotlib dependencies during pip install stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
 # collect pip dependencies into a virtualenv, which we'll copy into the prod stage
 FROM python:3.8 as pip-dependencies
-# install atlas and geos for matplotlib
-RUN apt-get update && apt-get -y install \
-    libatlas-base-dev libgeos-dev \
-  && apt-get clean && rm -rf /var/lib/apt/lists/*
 ENV VIRTUAL_ENV "/opt/venv"
 RUN python -m venv $VIRTUAL_ENV
 ENV PATH "$VIRTUAL_ENV/bin:$PATH"
 WORKDIR /pip-dependencies
 RUN pip install --upgrade pip setuptools wheel
+# install atlas and geos for matplotlib
+RUN apt-get update && apt-get -y install \
+    libatlas-base-dev libgeos-dev \
+  && apt-get clean && rm -rf /var/lib/apt/lists/*
 COPY pyproject.toml .
 COPY setup.py .
 RUN pip install --no-cache-dir --extra-index-url https://www.piwheels.org/simple .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
 # collect pip dependencies into a virtualenv, which we'll copy into the prod stage
 FROM python:3.8 as pip-dependencies
+# install atlas and geos for matplotlib
+RUN apt-get update && apt-get -y install \
+    libatlas-base-dev libgeos-dev \
+  && apt-get clean && rm -rf /var/lib/apt/lists/*
 ENV VIRTUAL_ENV "/opt/venv"
 RUN python -m venv $VIRTUAL_ENV
 ENV PATH "$VIRTUAL_ENV/bin:$PATH"
@@ -10,6 +14,10 @@ COPY setup.py .
 RUN pip install --no-cache-dir --extra-index-url https://www.piwheels.org/simple .
 
 FROM python:3.8-slim as prod
+# ffmpeg: for discord audio
+# libpq-dev: postgres client libraries
+# libatlas-base-dev & libgeos-dev: matplotlib dependencies
+# fortune/cowsay: for !fortune command
 RUN apt-get update && apt-get -y install \
     ffmpeg \
     libpq-dev \


### PR DESCRIPTION
Recent deployment still had some errors during the build, see [action](https://github.com/Chippers255/duckbot/runs/2746153880?check_suite_focus=true#step:7:1865). The specific error is

```
OSError: Could not find library geos_c or load any of its variants ['libgeos_c.so.1', 'libgeos_c.so']
```

That's `libgeos-dev` which is installed, but only installed in the `prod` stage, not in the `pip-dependencies` stage. This simply installs those packages in that stage as well.