### PR TITLE
use timezonefinder lib instead of tzwhere

### DIFF
--- a/duckbot/cogs/weather/weather.py
+++ b/duckbot/cogs/weather/weather.py
@@ -8,7 +8,7 @@ import matplotlib.dates as mdates
 import matplotlib.pyplot as plt
 import pyowm
 import pytz
-import tzwhere.tzwhere
+import timezonefinder
 from discord.ext import commands
 from pyowm.utils import config
 from pyowm.weatherapi25.location import Location
@@ -141,7 +141,7 @@ class Weather(commands.Cog):
 
     def weather_graph(self, city: Location, weather: OneCall):
         hourly = [weather.forecast_hourly[i] for i in range(24)]
-        tz = pytz.timezone(tzwhere.tzwhere.tzwhere(forceTZ=True).tzNameAt(city.lat, city.lon, forceTZ=True))
+        tz = pytz.timezone(timezonefinder.TimezoneFinder().timezone_at(lat=city.lat, lng=city.lon))
         hours = [w.reference_time("date").astimezone(tz=tz) for w in hourly]
         figure, left_axis = plt.subplots()
         left_axis.set_xlabel("Time")

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ if __name__ == "__main__":
             "discord.py[voice]>=1.7,<2",
             "beautifulsoup4",
             "pytz",
-            "tzwhere>=3.0,<4",
+            "timezonefinder[numba]>=5.2,<6",
             "holidays>=0.11,<0.12",
             "pyowm>=3.2,<4",  # openweather
             "psycopg2",

--- a/tests/cogs/weather/test_weather.py
+++ b/tests/cogs/weather/test_weather.py
@@ -212,9 +212,9 @@ def plt(plot):
     return plot
 
 
-@mock.patch("tzwhere.tzwhere.tzwhere")
-def test_weather_graph_for_code_coverage(tzwhere, clazz, plt):
-    tzwhere.return_value.tzNameAt.return_value = "US/Eastern"
+@mock.patch("timezonefinder.TimezoneFinder")
+def test_weather_graph_for_code_coverage(tzfinder, clazz, plt):
+    tzfinder.return_value.timezone_at.return_value = "US/Eastern"
     img = clazz.weather_graph(make_city("city"), one_call())
     assert img == "weather.png"
 


### PR DESCRIPTION
`tzwhere` is taking a lot of time during `!weather`. In my local tests, `!weather` would take like 5s. After this change, it took about 2s.

See [their docs](https://timezonefinder.readthedocs.io/en/latest/3_about.html#comparison-to-pytzwhere) for a comparison between the two libs.