### PR TITLE
remove numba optional from timezonefinder

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ if __name__ == "__main__":
             "discord.py[voice]>=1.7,<2",
             "beautifulsoup4",
             "pytz",
-            "timezonefinder[numba]>=5.2,<6",
+            "timezonefinder>=5.2,<6",
             "holidays>=0.11,<0.12",
             "pyowm>=3.2,<4",  # openweather
             "psycopg2",


### PR DESCRIPTION
Removing the `numba` optional, which seems to introduce a slowdown according to [docs](https://pypi.org/project/timezonefinder/), but I don't see a difference locally.

Numba [failed to build](https://github.com/Chippers255/duckbot/runs/2747863623?check_suite_focus=true#step:7:406) for the arm docker image.