### PR TITLE
remove `libgeos-dev` from docker image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,9 @@ RUN python -m venv $VIRTUAL_ENV
 ENV PATH "$VIRTUAL_ENV/bin:$PATH"
 WORKDIR /pip-dependencies
 RUN pip install --upgrade pip setuptools wheel
-# install atlas and geos for matplotlib
+# install atlas for numpy (matplotlib dependency)
 RUN apt-get update && apt-get -y install \
-    libatlas-base-dev libgeos-dev \
+    libatlas-base-dev \
   && apt-get clean && rm -rf /var/lib/apt/lists/*
 COPY pyproject.toml .
 COPY setup.py .
@@ -16,13 +16,13 @@ RUN pip install --no-cache-dir --extra-index-url https://www.piwheels.org/simple
 FROM python:3.8-slim as prod
 # ffmpeg: for discord audio
 # libpq-dev: postgres client libraries
-# libatlas-base-dev & libgeos-dev: matplotlib dependencies
+# libatlas-base-dev: matplotlib dependencies
 # fortune/cowsay: for !fortune command
 RUN apt-get update && apt-get -y install \
     ffmpeg \
     libpq-dev \
     libpulse-dev \
-    libatlas-base-dev libgeos-dev \
+    libatlas-base-dev \
     fortune-mod fortunes fortunes-off cowsay cowsay-off \
   && apt-get clean && rm -rf /var/lib/apt/lists/*
 ENV PATH "$PATH:/usr/games"


### PR DESCRIPTION
`libgeos-dev` was required by `shapely`, which is [no longer pulled in](https://github.com/Chippers255/duckbot/runs/2748634214?check_suite_focus=true#step:7:504). Seems it was actually a dependency of [tzwhere](https://github.com/pegler/pytzwhere/blob/master/setup.py#L21), which we replaced by `timezonefinder` (which only uses [numpy](https://github.com/jannikmi/timezonefinder/blob/master/requirements.txt)).