### PR TITLE
`!mock` command to write mOcKiNg TeXt

### DIFF
--- a/duckbot/cogs/text/__init__.py
+++ b/duckbot/cogs/text/__init__.py
@@ -1,5 +1,7 @@
 from .ascii_art import AsciiArt
+from .mock_text import MockText
 
 
 def setup(bot):
     bot.add_cog(AsciiArt(bot))
+    bot.add_cog(MockText(bot))

--- a/duckbot/cogs/text/mock_text.py
+++ b/duckbot/cogs/text/mock_text.py
@@ -13,14 +13,12 @@ class MockText(commands.Cog):
 
     async def mock_text(self, context, text: str):
         if text == "":
-            mocked_text = await self.mockify("based on this, I should mock you... I need text dude.")
-            await context.send(f"{context.message.author.display_name}, {mocked_text}")
+            mocked_text = await self.mockify(f"{context.message.author.display_name}, based on this, I should mock you... I need text dude.")
         elif len(text) > 1990:
-            mocked_text = await self.mockify("that's too much letters and stuff dude.")
-            await context.send(f"{mocked_text}")
+            mocked_text = await self.mockify("that's too much letters and stuff guy.")
         else:
             mocked_text = await self.mockify(text.strip())
-            await context.send(f"{mocked_text}")
+        await context.send(f"{mocked_text}")
         await try_delete(context.message)
 
     async def mockify(self, text: str):

--- a/duckbot/cogs/text/mock_text.py
+++ b/duckbot/cogs/text/mock_text.py
@@ -14,8 +14,6 @@ class MockText(commands.Cog):
     async def mock_text(self, context, text: str):
         if text == "":
             mocked_text = await self.mockify(f"{context.message.author.display_name}, based on this, I should mock you... I need text dude.")
-        elif len(text) > 1990:
-            mocked_text = await self.mockify("that's too much letters and stuff guy.")
         else:
             mocked_text = await self.mockify(text.strip())
         await context.send(f"{mocked_text}")

--- a/duckbot/cogs/text/mock_text.py
+++ b/duckbot/cogs/text/mock_text.py
@@ -1,0 +1,29 @@
+from discord.ext import commands
+
+
+class MockText(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+
+    @commands.command(name="mock")
+    async def mock_text_command(self, context, *, text: str = "Based on this, I should mock you... I need text dude."):
+        await self.mock_text(context, text)
+
+    async def mock_text(self, context, text: str):
+        mocked_text = await self.mockify(text.strip())
+        if len(mocked_text) < 1990:
+            await context.send(f"{mocked_text}")
+        else:
+            mocked_text = await self.mockify("that's too much letters and stuff dude.")
+            await context.send(f"{mocked_text}")
+
+    async def mockify(self, text: str):
+        counter = 0
+        char_list = []
+        for char in text.lower():
+            if char.isalpha():
+                if counter % 2 == 0:
+                    char = char.upper()
+                counter += 1
+            char_list.append(char)
+        return "".join(char_list)

--- a/duckbot/cogs/text/mock_text.py
+++ b/duckbot/cogs/text/mock_text.py
@@ -1,21 +1,27 @@
 from discord.ext import commands
 
+from duckbot.util.messages import try_delete
+
 
 class MockText(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
 
     @commands.command(name="mock")
-    async def mock_text_command(self, context, *, text: str = "Based on this, I should mock you... I need text dude."):
+    async def mock_text_command(self, context, *, text: str = ""):
         await self.mock_text(context, text)
 
     async def mock_text(self, context, text: str):
-        mocked_text = await self.mockify(text.strip())
-        if len(mocked_text) < 1990:
-            await context.send(f"{mocked_text}")
-        else:
+        if text == "":
+            mocked_text = await self.mockify("based on this, I should mock you... I need text dude.")
+            await context.send(f"{context.message.author.display_name}, {mocked_text}")
+        elif len(text) > 1990:
             mocked_text = await self.mockify("that's too much letters and stuff dude.")
             await context.send(f"{mocked_text}")
+        else:
+            mocked_text = await self.mockify(text.strip())
+            await context.send(f"{mocked_text}")
+        await try_delete(context.message)
 
     async def mockify(self, text: str):
         counter = 0

--- a/tests/cogs/text/test_mock_text.py
+++ b/tests/cogs/text/test_mock_text.py
@@ -18,11 +18,3 @@ async def test_mock_text_no_message(bot, context):
     await clazz.mock_text(context, "")
     context.send.assert_called_once_with("BoB, bAsEd On ThIs, I sHoUlD mOcK yOu... I nEeD tExT dUdE.")
     context.message.delete.assert_called()
-
-
-@pytest.mark.asyncio
-async def test_mock_text_message_too_long(bot, context):
-    clazz = MockText(bot)
-    await clazz.mock_text(context, "a " * 999)
-    context.send.assert_called_once_with("ThAt'S tOo MuCh LeTtErS aNd StUfF gUy.")
-    context.message.delete.assert_called()

--- a/tests/cogs/text/test_mock_text.py
+++ b/tests/cogs/text/test_mock_text.py
@@ -12,8 +12,17 @@ async def test_mock_text_mocks_message(bot, context):
 
 
 @pytest.mark.asyncio
+async def test_mock_text_no_message(bot, context):
+    context.message.author.display_name = "bob"
+    clazz = MockText(bot)
+    await clazz.mock_text(context, "")
+    context.send.assert_called_once_with("BoB, bAsEd On ThIs, I sHoUlD mOcK yOu... I nEeD tExT dUdE.")
+    context.message.delete.assert_called()
+
+
+@pytest.mark.asyncio
 async def test_mock_text_message_too_long(bot, context):
     clazz = MockText(bot)
     await clazz.mock_text(context, "a " * 999)
-    context.send.assert_called_once_with("ThAt'S tOo MuCh LeTtErS aNd StUfF dUdE.")
+    context.send.assert_called_once_with("ThAt'S tOo MuCh LeTtErS aNd StUfF gUy.")
     context.message.delete.assert_called()

--- a/tests/cogs/text/test_mock_text.py
+++ b/tests/cogs/text/test_mock_text.py
@@ -8,6 +8,7 @@ async def test_mock_text_mocks_message(bot, context):
     clazz = MockText(bot)
     await clazz.mock_text(context, "some' message% asd")
     context.send.assert_called_once_with("SoMe' MeSsAgE% aSd")
+    context.message.delete.assert_called()
 
 
 @pytest.mark.asyncio
@@ -15,3 +16,4 @@ async def test_mock_text_message_too_long(bot, context):
     clazz = MockText(bot)
     await clazz.mock_text(context, "a " * 999)
     context.send.assert_called_once_with("ThAt'S tOo MuCh LeTtErS aNd StUfF dUdE.")
+    context.message.delete.assert_called()

--- a/tests/cogs/text/test_mock_text.py
+++ b/tests/cogs/text/test_mock_text.py
@@ -1,0 +1,17 @@
+import pytest
+
+from duckbot.cogs.text import MockText
+
+
+@pytest.mark.asyncio
+async def test_mock_text_mocks_message(bot, context):
+    clazz = MockText(bot)
+    await clazz.mock_text(context, "some' message% asd")
+    context.send.assert_called_once_with("SoMe' MeSsAgE% aSd")
+
+
+@pytest.mark.asyncio
+async def test_mock_text_message_too_long(bot, context):
+    clazz = MockText(bot)
+    await clazz.mock_text(context, "a " * 999)
+    context.send.assert_called_once_with("ThAt'S tOo MuCh LeTtErS aNd StUfF dUdE.")

--- a/tests/cogs/text/test_setup.py
+++ b/tests/cogs/text/test_setup.py
@@ -1,6 +1,7 @@
 import pytest
 
 from duckbot.cogs.text import AsciiArt
+from duckbot.cogs.text import MockText
 from duckbot.cogs.text import setup as extension_setup
 from tests.discord_test_ext import assert_cog_added_of_type
 
@@ -9,3 +10,4 @@ from tests.discord_test_ext import assert_cog_added_of_type
 async def test_setup(bot_spy):
     extension_setup(bot_spy)
     assert_cog_added_of_type(bot_spy, AsciiArt)
+    assert_cog_added_of_type(bot_spy, MockText)

--- a/tests/cogs/text/test_setup.py
+++ b/tests/cogs/text/test_setup.py
@@ -1,7 +1,6 @@
 import pytest
 
-from duckbot.cogs.text import AsciiArt
-from duckbot.cogs.text import MockText
+from duckbot.cogs.text import AsciiArt, MockText
 from duckbot.cogs.text import setup as extension_setup
 from tests.discord_test_ext import assert_cog_added_of_type
 


### PR DESCRIPTION
Can now use `!mock` to turn text into MoCkiFiEd StUfF. 
`!mock` with no message mocks the called
`!mock` with too much text lets us know it's got too much stuff

This is about #247, but as of now there is no _italics_ or **bold** implemented because testing seems too hard. 