### PR TITLE
add max message length constant

### DIFF
--- a/duckbot/cogs/fortune/fortune.py
+++ b/duckbot/cogs/fortune/fortune.py
@@ -2,6 +2,8 @@ import subprocess
 
 from discord.ext import commands
 
+from duckbot.util.messages import MAX_MESSAGE_LENGTH
+
 
 class Fortune(commands.Cog):
     def __init__(self, bot):
@@ -13,7 +15,7 @@ class Fortune(commands.Cog):
 
     def get_fortune(self):
         message = self.__get_fortune_output()
-        while len(message) > 1950:  # discord has a 2000 character limit, just leaving a buffer
+        while len(message) > MAX_MESSAGE_LENGTH - 6:  # max-6 for the ``` characters
             message = self.__get_fortune_output()
         return f"```{message}```"
 

--- a/duckbot/cogs/games/dice.py
+++ b/duckbot/cogs/games/dice.py
@@ -1,6 +1,8 @@
 import d20
 from discord.ext import commands
 
+from duckbot.util.messages import MAX_MESSAGE_LENGTH
+
 
 class Dice(commands.Cog):
     def __init__(self, bot):
@@ -11,10 +13,11 @@ class Dice(commands.Cog):
         await self.roll(context, expression)
 
     async def roll(self, context, expression: str):
+        max_length = MAX_MESSAGE_LENGTH - 50  # max-50 as a buffer for the added text
         try:
             roller = self.make_roller(100_000)
             result = roller.roll(expression, allow_comments=True, stringifier=DiceStringifier())
-            text = f"{result.result[:1950]}..." if len(result.result) > 1950 else result.result
+            text = f"{result.result[:max_length]}..." if len(result.result) > max_length else result.result
             await context.send(f"**Rolls**: {text}\n**Total**: {result.total}")
         except d20.errors.TooManyRolls:
             await context.send(f"I can only roll up to {roller.context.max_rolls} dice.", delete_after=30)

--- a/duckbot/cogs/text/ascii_art.py
+++ b/duckbot/cogs/text/ascii_art.py
@@ -1,6 +1,8 @@
 import pyfiglet
 from discord.ext import commands
 
+from duckbot.util.messages import MAX_MESSAGE_LENGTH
+
 
 class AsciiArt(commands.Cog):
     def __init__(self, bot):
@@ -12,7 +14,7 @@ class AsciiArt(commands.Cog):
 
     async def ascii(self, context, text: str):
         art = str(pyfiglet.figlet_format(text.strip()))
-        if len(art) < 1990:
+        if len(art) < MAX_MESSAGE_LENGTH - 6:  # max-6 for the ``` characters
             await context.send(f"```{art}```")
         else:
             art = str(pyfiglet.figlet_format("Happy Birthday!"))

--- a/duckbot/util/messages/__init__.py
+++ b/duckbot/util/messages/__init__.py
@@ -1,1 +1,4 @@
 from .try_delete import try_delete
+
+"""The maximum length a discord message is allowed to be."""
+MAX_MESSAGE_LENGTH = 1999

--- a/tests/cogs/fortune/test_fortune.py
+++ b/tests/cogs/fortune/test_fortune.py
@@ -2,6 +2,7 @@ from subprocess import CompletedProcess
 from unittest import mock
 
 from duckbot.cogs.fortune import Fortune
+from duckbot.util.messages import MAX_MESSAGE_LENGTH
 
 
 @mock.patch("subprocess.run")
@@ -14,7 +15,7 @@ def test_get_fortune_short(run, bot):
 
 @mock.patch("subprocess.run")
 def test_get_fortune_first_is_long(run, bot):
-    long_message = "f" * 1951
+    long_message = "f" * MAX_MESSAGE_LENGTH
     short_message = "f"
     run.side_effect = [CompletedProcess([], 0, long_message.encode()), CompletedProcess([], 0, short_message.encode())]
     clazz = Fortune(bot)

--- a/tests/cogs/games/test_dice.py
+++ b/tests/cogs/games/test_dice.py
@@ -4,6 +4,7 @@ import d20
 import pytest
 
 from duckbot.cogs.games import Dice
+from duckbot.util.messages import MAX_MESSAGE_LENGTH
 
 
 @pytest.mark.asyncio
@@ -24,11 +25,11 @@ async def test_roll_dice_too_many_dice(bot, context):
 @pytest.mark.asyncio
 @mock.patch("d20.Roller")
 async def test_roll_result_too_long_for_message(roller, bot, context):
-    roller.return_value.roll.return_value.result = "x" * 1951
+    roller.return_value.roll.return_value.result = "x" * MAX_MESSAGE_LENGTH
     roller.return_value.roll.return_value.total = 100
     clazz = Dice(bot)
     await clazz.roll(context, "1d20")
-    context.send.assert_called_once_with(f"**Rolls**: {'x' * 1950}...\n**Total**: 100")
+    context.send.assert_called_once_with(f"**Rolls**: {'x' * (MAX_MESSAGE_LENGTH - 50)}...\n**Total**: 100")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Simply introducing a `MAX_MESSAGE_LENGH` value which we can reference in cogs instead of using magic numbers.