### PR TITLE
improve pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,5 +9,5 @@ Describe what testing you've done other than unit tests.
   * [ ] run `isort . && black .` in the repository root
   * [ ] run `pytest` in the repository root
   * [ ] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
-  * [ ] update the [wiki documentation](https://github.com/Chippers255/duckbot/wiki) if necessary (eg, new commands)
+  * [ ] update the wiki documentation if necessary
 * [ ] or, this is **not** a source code change

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,13 @@
+##### Summary 
 
-To you, the pull request author:
-* ensure you have tests and that they pass. run `pytest`
-* ensure you've formatted the code. run  `isort . && black .`
-* link to the issue you're fixing if one exists. uses a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) to autolink and close the issue once this pull request is merged
-* finally, remove this garbage and write a description
+Describe some nonsense about what and why this is, link to existing issues or pull requests.  
+Describe what testing you've done other than unit tests.
+
+##### Checklist
+
+* [ ] this is a source code change
+  * [ ] run `isort . && black .` in the repository root
+  * [ ] run `pytest` in the repository root
+  * [ ] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
+  * [ ] update the [wiki documentation](https://github.com/Chippers255/duckbot/wiki) if necessary (eg, new commands)
+* [ ] or, this is **not** a source code change


### PR DESCRIPTION
Doesn't work for this PR since the templates are pulled from main.

See the [rendered template](https://github.com/twentylemon/duckbot/blob/pr-template/.github/pull_request_template.md).

See also [task lists](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/about-task-lists), which are technically being used for the checkboxes.