### PR TITLE
move wiki contents into this repo; publish wiki on push

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -9,57 +9,81 @@ on:
     - main
 
 jobs:
-#  release:
-  #    runs-on: ubuntu-latest
-  #    steps:
-  #    - uses: actions/checkout@v2
-  #    - name: Set up Python 3.8
-  #      uses: actions/setup-python@v2
-  #      with:
-  #        python-version: '3.8'
-  #
-  #    - name: Setup Virtual Environment Cache
-  #      id: venv
-  #      uses: actions/cache@v2
-  #      with:
-  #        path: venv
-  #        key: ${{ env.pythonLocation }}-venv-${{ hashFiles('setup.py') }}
-  #
-  #    - name: Install Packages
-  #      if: steps.venv.outputs.cache-hit != 'true'
-  #      run: |
-  #        python -m venv --clear venv
-  #        . ./venv/bin/activate
-  #        pip install --upgrade pip setuptools wheel
-  #        pip install --editable .[dev]
-  #    - name: Run Tests
-  #      run: |
-  #        . venv/bin/activate
-  #        pytest
-  #    - name: Report Code Coverage
-  #      if: ${{ always() }}
-  #      uses: codecov/codecov-action@v1
-  #
-  #  sanity:
-  #    runs-on: ubuntu-latest
-  #    steps:
-  #    - uses: actions/checkout@v2
-  #    - name: Test Connection to Discord
-  #      run: |
-  #        docker-compose run --rm \
-  #          -e 'DUCKBOT_ARGS=connection-test' \
-  #          -e "DISCORD_TOKEN=$(cat .github/workflows/test-token.txt | base64 --decode)" \
-  #          duckbot
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.8'
+
+      - name: Setup Virtual Environment Cache
+        id: venv
+        uses: actions/cache@v2
+        with:
+          path: venv
+          key: ${{ env.pythonLocation }}-venv-${{ hashFiles('setup.py') }}
+
+      - name: Install Packages
+        if: steps.venv.outputs.cache-hit != 'true'
+        run: |
+          python -m venv --clear venv
+          . ./venv/bin/activate
+          pip install --upgrade pip setuptools wheel
+          pip install --editable .[dev]
+      - name: Run Tests
+        run: |
+          . venv/bin/activate
+          pytest
+      - name: Report Code Coverage
+        if: ${{ always() }}
+        uses: codecov/codecov-action@v1
+
+  sanity:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Test Connection to Discord
+        run: |
+          docker-compose run --rm \
+            -e 'DUCKBOT_ARGS=connection-test' \
+            -e "DISCORD_TOKEN=$(cat .github/workflows/test-token.txt | base64 --decode)" \
+            duckbot
 
   deploy:
-    #    needs:
-    #    - release
-    #    - sanity
+    needs:
+      - release
+      - sanity
     runs-on: ubuntu-latest
-    #    if: github.event_name == 'push' && github.repository == 'Chippers255/duckbot'
+    if: github.event_name == 'push' && github.repository == 'Chippers255/duckbot'
     concurrency: docker-image-build
     steps:
       - uses: actions/checkout@v2
+
+      - name: Set up QEMU for ARM Platforms
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Set up Docker Build Cache
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-buildx-
+
+      - name: Login to Docker
+        uses: docker/login-action@v1
+        with:
+          username: chippers255
+          password: ${{ secrets.DOCKER_PASS }}
+      - name: Build and Push Docker Image
+        run: |
+          docker buildx bake \
+            --set '*.platform=linux/arm/v7' \
+            --push \
+            --set '*.cache-from=type=local,src=/tmp/.buildx-cache' \
+            --set '*.cache-to=type=local,dest=/tmp/.buildx-cache'
 
       - name: Publish Wiki Documentation
         uses: SwiftDocOrg/github-wiki-publish-action@v1
@@ -68,34 +92,10 @@ jobs:
         env:
           GH_PERSONAL_ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
 
-#    - name: Set up QEMU for ARM Platforms
-#      uses: docker/setup-qemu-action@v1
-#    - name: Set up Docker Buildx
-#      uses: docker/setup-buildx-action@v1
-#    - name: Set up Docker Build Cache
-#      uses: actions/cache@v2
-#      with:
-#        path: /tmp/.buildx-cache
-#        key: ${{ runner.os }}-buildx-${{ github.sha }}
-#        restore-keys: ${{ runner.os }}-buildx-
-#
-#    - name: Login to Docker
-#      uses: docker/login-action@v1
-#      with:
-#        username: chippers255
-#        password: ${{ secrets.DOCKER_PASS }}
-#    - name: Build and Push Docker Image
-#      run: |
-#        docker buildx bake \
-#          --set '*.platform=linux/arm/v7' \
-#          --push \
-#          --set '*.cache-from=type=local,src=/tmp/.buildx-cache' \
-#          --set '*.cache-to=type=local,dest=/tmp/.buildx-cache'
-#
-#    - name: Trigger Deployment
-#      run: |
-#        curl -X POST https://api.github.com/repos/${{ secrets.DEPLOY_REPO }}/dispatches \
-#          -u "${{ secrets.ACCESS_TOKEN }}" \
-#          -H "Accept: application/vnd.github.everest-preview+json" \
-#          -H "Content-Type: application/json" \
-#          --data '{"event_type": "deploy-duckbot"}'
+      - name: Trigger Deployment
+        run: |
+          curl -X POST https://api.github.com/repos/${{ secrets.DEPLOY_REPO }}/dispatches \
+            -u "${{ secrets.ACCESS_TOKEN }}" \
+            -H "Accept: application/vnd.github.everest-preview+json" \
+            -H "Content-Type: application/json" \
+            --data '{"event_type": "deploy-duckbot"}'

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -12,90 +12,90 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python 3.8
-        uses: actions/setup-python@v2
-        with:
-          python-version: '3.8'
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.8'
 
-      - name: Setup Virtual Environment Cache
-        id: venv
-        uses: actions/cache@v2
-        with:
-          path: venv
-          key: ${{ env.pythonLocation }}-venv-${{ hashFiles('setup.py') }}
+    - name: Setup Virtual Environment Cache
+      id: venv
+      uses: actions/cache@v2
+      with:
+        path: venv
+        key: ${{ env.pythonLocation }}-venv-${{ hashFiles('setup.py') }}
 
-      - name: Install Packages
-        if: steps.venv.outputs.cache-hit != 'true'
-        run: |
-          python -m venv --clear venv
-          . ./venv/bin/activate
-          pip install --upgrade pip setuptools wheel
-          pip install --editable .[dev]
-      - name: Run Tests
-        run: |
-          . venv/bin/activate
-          pytest
-      - name: Report Code Coverage
-        if: ${{ always() }}
-        uses: codecov/codecov-action@v1
+    - name: Install Packages
+      if: steps.venv.outputs.cache-hit != 'true'
+      run: |
+        python -m venv --clear venv
+        . ./venv/bin/activate
+        pip install --upgrade pip setuptools wheel
+        pip install --editable .[dev]
+    - name: Run Tests
+      run: |
+        . venv/bin/activate
+        pytest
+    - name: Report Code Coverage
+      if: ${{ always() }}
+      uses: codecov/codecov-action@v1
 
   sanity:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Test Connection to Discord
-        run: |
-          docker-compose run --rm \
-            -e 'DUCKBOT_ARGS=connection-test' \
-            -e "DISCORD_TOKEN=$(cat .github/workflows/test-token.txt | base64 --decode)" \
-            duckbot
+    - uses: actions/checkout@v2
+    - name: Test Connection to Discord
+      run: |
+        docker-compose run --rm \
+          -e 'DUCKBOT_ARGS=connection-test' \
+          -e "DISCORD_TOKEN=$(cat .github/workflows/test-token.txt | base64 --decode)" \
+          duckbot
 
   deploy:
     needs:
-      - release
-      - sanity
+    - release
+    - sanity
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && github.repository == 'Chippers255/duckbot'
     concurrency: docker-image-build
     steps:
-      - uses: actions/checkout@v2
+    - uses: actions/checkout@v2
 
-      - name: Set up QEMU for ARM Platforms
-        uses: docker/setup-qemu-action@v1
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-      - name: Set up Docker Build Cache
-        uses: actions/cache@v2
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: ${{ runner.os }}-buildx-
+    - name: Set up QEMU for ARM Platforms
+      uses: docker/setup-qemu-action@v1
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+    - name: Set up Docker Build Cache
+      uses: actions/cache@v2
+      with:
+        path: /tmp/.buildx-cache
+        key: ${{ runner.os }}-buildx-${{ github.sha }}
+        restore-keys: ${{ runner.os }}-buildx-
 
-      - name: Login to Docker
-        uses: docker/login-action@v1
-        with:
-          username: chippers255
-          password: ${{ secrets.DOCKER_PASS }}
-      - name: Build and Push Docker Image
-        run: |
-          docker buildx bake \
-            --set '*.platform=linux/arm/v7' \
-            --push \
-            --set '*.cache-from=type=local,src=/tmp/.buildx-cache' \
-            --set '*.cache-to=type=local,dest=/tmp/.buildx-cache'
+    - name: Login to Docker
+      uses: docker/login-action@v1
+      with:
+        username: chippers255
+        password: ${{ secrets.DOCKER_PASS }}
+    - name: Build and Push Docker Image
+      run: |
+        docker buildx bake \
+          --set '*.platform=linux/arm/v7' \
+          --push \
+          --set '*.cache-from=type=local,src=/tmp/.buildx-cache' \
+          --set '*.cache-to=type=local,dest=/tmp/.buildx-cache'
 
-      - name: Publish Wiki Documentation
-        uses: SwiftDocOrg/github-wiki-publish-action@v1
-        with:
-          path: wiki
-        env:
-          GH_PERSONAL_ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+    - name: Publish Wiki Documentation
+      uses: SwiftDocOrg/github-wiki-publish-action@v1
+      with:
+        path: wiki
+      env:
+        GH_PERSONAL_ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
 
-      - name: Trigger Deployment
-        run: |
-          curl -X POST https://api.github.com/repos/${{ secrets.DEPLOY_REPO }}/dispatches \
-            -u "${{ secrets.ACCESS_TOKEN }}" \
-            -H "Accept: application/vnd.github.everest-preview+json" \
-            -H "Content-Type: application/json" \
-            --data '{"event_type": "deploy-duckbot"}'
+    - name: Trigger Deployment
+      run: |
+        curl -X POST https://api.github.com/repos/${{ secrets.DEPLOY_REPO }}/dispatches \
+          -u "${{ secrets.ACCESS_TOKEN }}" \
+          -H "Accept: application/vnd.github.everest-preview+json" \
+          -H "Content-Type: application/json" \
+          --data '{"event_type": "deploy-duckbot"}'

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -91,6 +91,7 @@ jobs:
         path: wiki
       env:
         GH_PERSONAL_ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+        WIKI_COMMIT_MESSAGE: ${{ github.event.commits[0].message }}
 
     - name: Trigger Deployment
       run: |

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -9,86 +9,93 @@ on:
     - main
 
 jobs:
-  release:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v2
-      with:
-        python-version: '3.8'
-
-    - name: Setup Virtual Environment Cache
-      id: venv
-      uses: actions/cache@v2
-      with:
-        path: venv
-        key: ${{ env.pythonLocation }}-venv-${{ hashFiles('setup.py') }}
-
-    - name: Install Packages
-      if: steps.venv.outputs.cache-hit != 'true'
-      run: |
-        python -m venv --clear venv
-        . ./venv/bin/activate
-        pip install --upgrade pip setuptools wheel
-        pip install --editable .[dev]
-    - name: Run Tests
-      run: |
-        . venv/bin/activate
-        pytest
-    - name: Report Code Coverage
-      if: ${{ always() }}
-      uses: codecov/codecov-action@v1
-
-  sanity:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: Test Connection to Discord
-      run: |
-        docker-compose run --rm \
-          -e 'DUCKBOT_ARGS=connection-test' \
-          -e "DISCORD_TOKEN=$(cat .github/workflows/test-token.txt | base64 --decode)" \
-          duckbot
+#  release:
+  #    runs-on: ubuntu-latest
+  #    steps:
+  #    - uses: actions/checkout@v2
+  #    - name: Set up Python 3.8
+  #      uses: actions/setup-python@v2
+  #      with:
+  #        python-version: '3.8'
+  #
+  #    - name: Setup Virtual Environment Cache
+  #      id: venv
+  #      uses: actions/cache@v2
+  #      with:
+  #        path: venv
+  #        key: ${{ env.pythonLocation }}-venv-${{ hashFiles('setup.py') }}
+  #
+  #    - name: Install Packages
+  #      if: steps.venv.outputs.cache-hit != 'true'
+  #      run: |
+  #        python -m venv --clear venv
+  #        . ./venv/bin/activate
+  #        pip install --upgrade pip setuptools wheel
+  #        pip install --editable .[dev]
+  #    - name: Run Tests
+  #      run: |
+  #        . venv/bin/activate
+  #        pytest
+  #    - name: Report Code Coverage
+  #      if: ${{ always() }}
+  #      uses: codecov/codecov-action@v1
+  #
+  #  sanity:
+  #    runs-on: ubuntu-latest
+  #    steps:
+  #    - uses: actions/checkout@v2
+  #    - name: Test Connection to Discord
+  #      run: |
+  #        docker-compose run --rm \
+  #          -e 'DUCKBOT_ARGS=connection-test' \
+  #          -e "DISCORD_TOKEN=$(cat .github/workflows/test-token.txt | base64 --decode)" \
+  #          duckbot
 
   deploy:
-    needs:
-    - release
-    - sanity
+    #    needs:
+    #    - release
+    #    - sanity
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.repository == 'Chippers255/duckbot'
+    #    if: github.event_name == 'push' && github.repository == 'Chippers255/duckbot'
     concurrency: docker-image-build
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - name: Set up QEMU for ARM Platforms
-      uses: docker/setup-qemu-action@v1
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
-    - name: Set up Docker Build Cache
-      uses: actions/cache@v2
-      with:
-        path: /tmp/.buildx-cache
-        key: ${{ runner.os }}-buildx-${{ github.sha }}
-        restore-keys: ${{ runner.os }}-buildx-
+      - name: Publish Wiki Documentation
+        uses: SwiftDocOrg/github-wiki-publish-action@v1
+        with:
+          path: wiki
+        env:
+          GH_PERSONAL_ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
 
-    - name: Login to Docker
-      uses: docker/login-action@v1
-      with:
-        username: chippers255
-        password: ${{ secrets.DOCKER_PASS }}
-    - name: Build and Push Docker Image
-      run: |
-        docker buildx bake \
-          --set '*.platform=linux/arm/v7' \
-          --push \
-          --set '*.cache-from=type=local,src=/tmp/.buildx-cache' \
-          --set '*.cache-to=type=local,dest=/tmp/.buildx-cache'
-
-    - name: Trigger Deployment
-      run: |
-        curl -X POST https://api.github.com/repos/${{ secrets.DEPLOY_REPO }}/dispatches \
-          -u "${{ secrets.ACCESS_TOKEN }}" \
-          -H "Accept: application/vnd.github.everest-preview+json" \
-          -H "Content-Type: application/json" \
-          --data '{"event_type": "deploy-duckbot"}'
+#    - name: Set up QEMU for ARM Platforms
+#      uses: docker/setup-qemu-action@v1
+#    - name: Set up Docker Buildx
+#      uses: docker/setup-buildx-action@v1
+#    - name: Set up Docker Build Cache
+#      uses: actions/cache@v2
+#      with:
+#        path: /tmp/.buildx-cache
+#        key: ${{ runner.os }}-buildx-${{ github.sha }}
+#        restore-keys: ${{ runner.os }}-buildx-
+#
+#    - name: Login to Docker
+#      uses: docker/login-action@v1
+#      with:
+#        username: chippers255
+#        password: ${{ secrets.DOCKER_PASS }}
+#    - name: Build and Push Docker Image
+#      run: |
+#        docker buildx bake \
+#          --set '*.platform=linux/arm/v7' \
+#          --push \
+#          --set '*.cache-from=type=local,src=/tmp/.buildx-cache' \
+#          --set '*.cache-to=type=local,dest=/tmp/.buildx-cache'
+#
+#    - name: Trigger Deployment
+#      run: |
+#        curl -X POST https://api.github.com/repos/${{ secrets.DEPLOY_REPO }}/dispatches \
+#          -u "${{ secrets.ACCESS_TOKEN }}" \
+#          -H "Accept: application/vnd.github.everest-preview+json" \
+#          -H "Content-Type: application/json" \
+#          --data '{"event_type": "deploy-duckbot"}'

--- a/wiki/Commands.md
+++ b/wiki/Commands.md
@@ -1,0 +1,75 @@
+Command Overview
+----------------
+
+| Command | Summary |
+|:-:|-|
+| [`!day`](#day-announcements) | announces the current day of the week |
+| [`!recipe`](#recipe-search) | search for a random recipe |
+| [`!start`, `!stop`](#music) | start or stop playing music |
+| [`!weather`](#weather) | retrieve weather information |
+| `!8ball` | get a magic eight ball style fortune |
+| `!fortune` | get a random fortune told to you by a cow |
+| `!dog` | displays a random dog photo |
+| `!ascii` | renders text as ascii art |
+| `!mock` | converts text into MoCkInG tExT |
+| [`!roll`](#dice) | rolls Dungeons and Dragons style dice |
+| `!coin` | flips a coin. in real life |
+| `!help` | gives a link to this wiki |
+| `!duck` | gives a link to this repo |
+
+Day Announcements
+-----------------
+Every day in the 7am hour, DuckBot will announce to the general channel the current day of the week. If the day is also a statutory holiday, or an otherwise special day, DuckBot will announce that at the same time. You can run this on demand using the `!day` command.
+
+Recipe Search
+-------------
+Do you crave a particular food but want an arbitrary recipe?
+* Run the `!recipe` command with an argument to search for a specific recipe with a random result.
+* Run the `!recipe` command with no argument to blindly return any recipe.
+
+Music
+-----
+DuckBot plays everyone's favourite background noise inside whatever voice channel you're in. Use `!start` to summon the bot, and `!stop` to dismiss it.
+
+Weather
+-------
+DuckBot can give you basic weather information for a given location, sourced from [OpenWeather](https://openweathermap.org/). The command takes the form of:
+```
+!weather [location]
+```
+If `location` is omitted, DuckBot will try to use the default location you have set. You can set your default location using:
+```
+!weather set location
+```
+
+The `location` is a little finicky. It takes the form of `city country-code index`.  
+If the city name includes spaces, you have to put it `"in quotes"`.  
+The country code is the two character country code (like CA for Canada), or the two character state code for cities in the USA.  
+If there's ever ambiguity, DuckBot will respond with all of the cities found for the search, and will number them all. After specifying the city and country code, you can specify the index to select a single city from the list.
+
+Here's an example usage:
+> Human: !weather set london  
+> DuckBot: Multiple cities found matching search.  
+> Narrow your search or specify an index to pick one of the following:  
+> 1: London, GB, geolocation = (51.50853, -0.12574)  
+> 2: London, AR, geolocation = (35.328972, -93.25296)  
+> 3: London, KY, geolocation = (37.128979, -84.08326)  
+> 4: London, OH, geolocation = (39.886452, -83.44825)  
+> 5: London, MO, geolocation = (40.445, -95.234978)  
+> 6: London, CA, geolocation = (36.476059, -119.443176)  
+> 7: London, CA, geolocation = (42.983391, -81.23304)  
+> Human: !weather set london ca  
+> DuckBot: Multiple cities found matching search.  
+> Narrow your search or specify an index to pick one of the following:  
+> 1: London, CA, geolocation = (36.476059, -119.443176)  
+> 2: London, CA, geolocation = (42.983391, -81.23304)  
+> Human: !weather set london ca 2  
+> DuckBot: Location saved! London, CA, geolocation = (42.983391, -81.23304)
+
+Dice
+----
+DuckBot will roll Dungeons and Dragons style dice for you. See [dice syntax](https://d20.readthedocs.io/en/latest/start.html#dice-syntax) for the full list of what is possible.
+
+> Human: !roll 1d20  
+> DuckBot: Rolls: 1d20 (3)  
+> Total: 3

--- a/wiki/Events.md
+++ b/wiki/Events.md
@@ -1,0 +1,73 @@
+* [Message Responses](#message-responses)
+* [Scheduled Tasks](#scheduled-tasks)
+
+Message Responses
+=================
+
+Message Edits
+-------------
+If you edit a message, DuckBot will give you a helpful diff of the changes.
+
+> Human: I hate you.
+
+Say that's edited to:
+
+> Human: I don't hate you.
+
+Then DuckBot will respond with the following message (it is deleted after a short period).
+> DuckBot: :eyes: @Human  
+> I {+don't +}hate you.
+
+Haiku
+-----
+DuckBot will let you know if a message is a 5/7/5 haiku.
+
+Bitcoin
+-------
+DuckBot kindly corrects the spelling of _bitcoin_ to _magic beans_.
+
+Kubernetes
+----------
+DuckBot kindly corrects the spelling of _k8s_ to _kubernetes_. Additionally, DuckBot corrects the spelling of _kubernetes_ to _k8s_.
+
+Formula One
+-----------
+DuckBot gets HYPED UP over posts to the F1 related `#dank` channel, so it reacts to every single message there.
+
+Age of Empires
+--------------
+DuckBot will replace any [Age of Empires II taunts](https://ageofempires.fandom.com/wiki/Taunts#Full_list_of_taunts) with their text expansion. For example,
+
+> Human: 2  
+> DuckBot: @Human > 2: No.
+
+Josip Broz Tito
+---------------
+Heeeyyyy Mr. Tito! DuckBot will react to messages containing the custom `:tito:` emoji with all the country flags of the formally Yugoslavian countries. DuckBot will do the same when someone reacts with `:tito:`.
+
+Typo Correction
+---------------
+DuckBot will attempt to correct typos a user's previous message when they send _fuck_. For example,
+
+> Human: I wanted to eat teh duck wiht thier creamy sauce.  
+> Human: fuck  
+> DuckBot:
+>    > I wanted to eat the duck with their creamy sauce.
+>
+> There, I fixed it for you, @Human!
+
+DuckBoard
+-----
+DuckBot has a very small chance to react to any message with 🦆 .
+
+Robot
+-----
+DuckBot is a robot, and as such does not like being humanized. DuckBot tells people to stop thanking a robot when they explicitly thank the robot.
+
+
+Scheduled Tasks
+===============
+
+Day Announcements
+-----------------
+Every day in the 7am hour, DuckBot will announce to the general channel the current day of the week. If the day is also a statutory holiday, or an otherwise special day, DuckBot will announce that at the same time. You can run this on demand using the `!day` command.

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -1,0 +1,7 @@
+DuckBot
+=======
+
+DuckBot is many things. :duck:
+
+* [Commands](Commands) - responds to `!` commands
+* [Events/Tasks](Events) - respond to message events or scheduled tasks

--- a/wiki/Logs.md
+++ b/wiki/Logs.md
@@ -1,0 +1,6 @@
+Command Overview
+----------------
+
+| Command | Description |
+|:-:|-|
+| `!logs` | attaches an archive of logs files to a discord message |


### PR DESCRIPTION
Moving the wiki pages to be part of this repo so they have a chance of staying up to date with the repo itself!

The wikis are taken directly from the existing wiki. No changes there.

The wiki publish uses [a third party action](https://github.com/SwiftDocOrg/github-wiki-publish-action). It requires a github access token with `repo` access, we already have one for triggering the deployment in the deployment repo, the permissions required are the same. I ended up re-using that one.  
I debated updating the wiki repo manually (ie `git@github.com:Chippers255/duckbot.wiki.git`), but it's a little annoying with potential merge conflicts and stuff. Action was pain free, so eh, going with that.

`WIKI_COMMIT_MESSAGE` is [undocumented](https://github.com/SwiftDocOrg/github-wiki-publish-action/blob/v1/entrypoint.sh#L38) but would be the commit message. If not provided, it gives the useless message "Automatically publish wiki." I jam in the same commit message from the push to duckbot instead. See [push event docs](https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#push).

See a [pared down action](https://github.com/twentylemon/duckbot/runs/2768961827?check_suite_focus=true) I ran against my repo and the [wiki results](https://github.com/twentylemon/duckbot/wiki) from that. Commit messages didn't work there because the pull request event doesn't include the commits.