### PR TITLE
add "first day of week" phrases

### DIFF
--- a/duckbot/cogs/announce_day/phrases.py
+++ b/duckbot/cogs/announce_day/phrases.py
@@ -4,6 +4,7 @@ days = {
             "the day of the moon",
             "Moonday",
             "Monday",
+            "the first day of the week according to the ISO 8601 standard",
         ],
         "templates": [
             "Screw this, it is {0}.",
@@ -72,6 +73,7 @@ days = {
             "the day of the sun",
             "Sunday",
             "Sunday, Sunday, Sunday",
+            "the first day of the week",
         ],
         "templates": [
             "WEEKEND ALERT: {0}!",


### PR DESCRIPTION
##### Summary 

Adding two contradictory day of the week names for Sunday and Monday.

##### Checklist

* [x] this is a source code change
  * [x] run `isort . && black .` in the repository root
  * [x] run `pytest` in the repository root
  * [x] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  * [x] update the wiki documentation if necessary
* [ ] or, this is **not** a source code change
