### PR TITLE
remove commas from `!weather` arguments

### DIFF
--- a/duckbot/cogs/weather/weather.py
+++ b/duckbot/cogs/weather/weather.py
@@ -60,11 +60,11 @@ class Weather(commands.Cog):
 
     async def search_location(self, context, city: str, country: str, index: int) -> Optional[Location]:
         if city is not None:
-            country = country.upper() if country is not None else None
+            country = country.upper().replace(",", "") if country is not None else None
             if country is not None and len(country) != 2:
                 await context.send("Country must be an ISO country code, such as CA for Canada.")
                 return None
-            locations = self.owm().city_id_registry().locations_for(city, country=country)
+            locations = self.owm().city_id_registry().locations_for(city.replace(",", ""), country=country)
             if not locations:
                 await context.send("No cities found matching search.")
                 return None
@@ -73,7 +73,7 @@ class Weather(commands.Cog):
                     return locations[int(index) - 1]
                 else:
                     message = "Multiple cities found matching search.\nNarrow your search or specify an index to pick one of the following:\n"
-                    options = [f"{i+1}: {self.__location_string(city)}" for i, city in enumerate(locations)]
+                    options = [f"{i+1}: {self.__location_string(c)}" for i, c in enumerate(locations)]
                     await context.send(message + "\n".join(options))
                     return None
             else:

--- a/tests/cogs/weather/test_weather.py
+++ b/tests/cogs/weather/test_weather.py
@@ -76,6 +76,15 @@ async def test_search_location_no_matches(clazz, context, city_id):
 async def test_search_location_single_return_city_only(clazz, context, city_id):
     city_id.locations_for.return_value = [make_city("city")]
     city = await clazz.search_location(context, "city", None, None)
+    city_id.locations_for.assert_called_once_with("city", country=None)
+    assert city.to_dict() == make_city("city").to_dict()
+
+
+@pytest.mark.asyncio
+async def test_search_location_city_name_with_comma_removed(clazz, context, city_id):
+    city_id.locations_for.return_value = [make_city("city")]
+    city = await clazz.search_location(context, "city,", None, None)
+    city_id.locations_for.assert_called_once_with("city", country=None)
     assert city.to_dict() == make_city("city").to_dict()
 
 
@@ -83,6 +92,7 @@ async def test_search_location_single_return_city_only(clazz, context, city_id):
 async def test_search_location_single_return_country_arg(clazz, context, city_id):
     city_id.locations_for.return_value = [make_city("city")]
     city = await clazz.search_location(context, "city", "US", None)
+    city_id.locations_for.assert_called_once_with("city", country="US")
     assert city.to_dict() == make_city("city").to_dict()
 
 

--- a/wiki/Commands.md
+++ b/wiki/Commands.md
@@ -45,6 +45,7 @@ If `location` is omitted, DuckBot will try to use the default location you have 
 The `location` is a little finicky. It takes the form of `city country-code index`.  
 If the city name includes spaces, you have to put it `"in quotes"`.  
 The country code is the two character country code (like CA for Canada), or the two character state code for cities in the USA.  
+Commas will be removed from city and country names.  
 If there's ever ambiguity, DuckBot will respond with all of the cities found for the search, and will number them all. After specifying the city and country code, you can specify the index to select a single city from the list.
 
 Here's an example usage:


### PR DESCRIPTION
##### Summary 

People have included commas in the weather arugments several times, which is natural to do since it's how you write the city name. This simple removes commas from the city/country names. Could be that we'd never be able to find a city name with an actual comma in the name, but let's deal with that when it happens.

##### Checklist

* [x] this is a source code change
  * [x] run `isort . && black .` in the repository root
  * [x] run `pytest` in the repository root
  * [x] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  * [x] update the wiki documentation if necessary
* [ ] or, this is **not** a source code change
