### PR TITLE
override `GITHUB_ACTOR` in wiki publish

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -92,6 +92,7 @@ jobs:
       env:
         GH_PERSONAL_ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
         WIKI_COMMIT_MESSAGE: ${{ github.event.commits[0].message }}
+        GITHUB_ACTOR: ${{ github.event.commits[0].author.name }}
 
     - name: Trigger Deployment
       run: |


### PR DESCRIPTION
##### Summary 

The wiki push action uses [GITHUB_ACTOR](https://github.com/SwiftDocOrg/github-wiki-publish-action/blob/v1/entrypoint.sh#L50-L51) to determine who to push commits to the wiki as. But, the actor is [the person who initiated the workflow](https://docs.github.com/en/actions/reference/environment-variables#default-environment-variables), which is typically not the author of the commits. Eg, see [Commands history](https://github.com/Chippers255/duckbot/wiki/Commands/_history), I changed the pages, but @jameshughes89 merged it. He caused the workflow to run, so authored the wiki commits, even though I actually authored them.

The [push event](https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#push) includes the author in the commits, so I pull that and override `GITHUB_ACTOR` with that.

##### Checklist

* [ ] this is a source code change
  * [ ] run `isort . && black .` in the repository root
  * [ ] run `pytest` in the repository root
  * [ ] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  * [ ] update the wiki documentation if necessary
* [x] or, this is **not** a source code change
