### PR TITLE
remove github api url with builtin environment variable

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -95,7 +95,7 @@ jobs:
 
     - name: Trigger Deployment
       run: |
-        curl -X POST https://api.github.com/repos/${{ secrets.DEPLOY_REPO }}/dispatches \
+        curl -X POST ${{ env.GITHUB_API_URL }}/repos/${{ secrets.DEPLOY_REPO }}/dispatches \
           -u "${{ secrets.ACCESS_TOKEN }}" \
           -H "Accept: application/vnd.github.everest-preview+json" \
           -H "Content-Type: application/json" \


### PR DESCRIPTION
##### Summary 

In working on the wiki stuff, I found that the github API url is a [builtin environment variable](https://docs.github.com/en/actions/reference/environment-variables#default-environment-variables), so this just opts to use that instead of hardcoding the url.

##### Checklist

* [ ] this is a source code change
  * [ ] run `isort . && black .` in the repository root
  * [ ] run `pytest` in the repository root
  * [ ] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  * [ ] update the wiki documentation if necessary
* [x] or, this is **not** a source code change
