### PR TITLE
use `GITHUB_API_URL` attempt 2

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -96,7 +96,7 @@ jobs:
 
     - name: Trigger Deployment
       run: |
-        curl -X POST ${{ env.GITHUB_API_URL }}/repos/${{ secrets.DEPLOY_REPO }}/dispatches \
+        curl -X POST $GITHUB_API_URL/repos/${{ secrets.DEPLOY_REPO }}/dispatches \
           -u "${{ secrets.ACCESS_TOKEN }}" \
           -H "Accept: application/vnd.github.everest-preview+json" \
           -H "Content-Type: application/json" \


### PR DESCRIPTION
##### Summary 

For some reason #289 failed the [deployment](https://github.com/Chippers255/duckbot/runs/2819702025?check_suite_focus=true), the env var didn't get replaced. It's weird, but I guess that's not how you're supposed to use environment variables? Even though the [docs](https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#env-context) say:

> You can use the env context in the value of any key in a step except for the id and uses keys.

So. Let's just try this. If it fails, I'll revert both instead, since it's being dumb.

##### Checklist

* [ ] this is a source code change
  * [ ] run `isort . && black .` in the repository root
  * [ ] run `pytest` in the repository root
  * [ ] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  * [ ] update the wiki documentation if necessary
* [x] or, this is **not** a source code change
