### PR TITLE
correct chance to send a gif of the day to 10%

### DIFF
--- a/duckbot/cogs/announce_day/announce_day.py
+++ b/duckbot/cogs/announce_day/announce_day.py
@@ -52,7 +52,7 @@ class AnnounceDay(commands.Cog):
                 await channel.send(message)
 
                 should_send_dog = random.random() < 1.0 / 10.0
-                should_send_gif = not should_send_dog and random.random() < 1.0 / 9.0  # 10%, since relies on not sending dog gif
+                should_send_gif = not should_send_dog and random.random() < 1.0 / 9.0  # 10%, since relies on not sending dog photo
                 await self.send_dog(channel) if should_send_dog else None
                 await self.send_gif(channel) if should_send_gif else None
 

--- a/duckbot/cogs/announce_day/announce_day.py
+++ b/duckbot/cogs/announce_day/announce_day.py
@@ -52,7 +52,7 @@ class AnnounceDay(commands.Cog):
                 await channel.send(message)
 
                 should_send_dog = random.random() < 1.0 / 10.0
-                should_send_gif = not should_send_dog and random.random() < 1.0 / 10.0
+                should_send_gif = not should_send_dog and random.random() < 1.0 / 9.0  # 10%, since relies on not sending dog gif
                 await self.send_dog(channel) if should_send_dog else None
                 await self.send_gif(channel) if should_send_gif else None
 


### PR DESCRIPTION
##### Summary 

I realized today that the current chance to send a gif is actually 9% instead of 10%, since it relies on the dog not being sent. 90% * 10% is only 9%. So, correcting to the indented 10%.

##### Checklist

* [x] this is a source code change
  * [x] run `isort . && black .` in the repository root
  * [x] run `pytest` in the repository root
  * [x] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  * [x] update the wiki documentation if necessary
* [ ] or, this is **not** a source code change
