### PR TITLE
add my dudes template to wednesday

### DIFF
--- a/duckbot/cogs/announce_day/phrases.py
+++ b/duckbot/cogs/announce_day/phrases.py
@@ -32,7 +32,9 @@ days = {
             "Ness' wedding day",
             "https://www.youtube.com/watch?v=du-TY1GUFGk",
         ],
-        "templates": [],
+        "templates": [
+            "It is {0}, my dudes.",
+        ],
         "gifs": [],
     },
     3: {


### PR DESCRIPTION
##### Summary 

Adding a new template option for Wednesday's day of the week announcement. It would technically allow for _It is Wednesday, my dudes, my dudes._ which makes no sense, but I like it.

##### Checklist

* [x] this is a source code change
  * [x] run `isort . && black .` in the repository root
  * [x] run `pytest` in the repository root
  * [x] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  * [x] update the wiki documentation if necessary
* [ ] or, this is **not** a source code change
