### PR TITLE
add new friday gif and sunday template

### DIFF
--- a/duckbot/cogs/announce_day/phrases.py
+++ b/duckbot/cogs/announce_day/phrases.py
@@ -55,9 +55,7 @@ days = {
             "Friday",
         ],
         "templates": [],
-        "gifs": [
-            "https://tenor.com/view/nicolas-cage-friday-feel-that-friday-feeling-feel-that-thats-friday-gif-12235300",
-        ],
+        "gifs": ["https://tenor.com/view/nicolas-cage-friday-feel-that-friday-feeling-feel-that-thats-friday-gif-12235300", "https://i.redd.it/sp2b24o1e4a71.jpg"],
     },
     5: {
         "names": [
@@ -77,9 +75,7 @@ days = {
             "Sunday, Sunday, Sunday",
             "the first day of the week",
         ],
-        "templates": [
-            "WEEKEND ALERT: {0}!",
-        ],
+        "templates": ["WEEKEND ALERT: {0}!", "It's {0}, but is it RACE DAY?"],
         "gifs": [],
     },
 }

--- a/duckbot/cogs/announce_day/phrases.py
+++ b/duckbot/cogs/announce_day/phrases.py
@@ -55,7 +55,10 @@ days = {
             "Friday",
         ],
         "templates": [],
-        "gifs": ["https://tenor.com/view/nicolas-cage-friday-feel-that-friday-feeling-feel-that-thats-friday-gif-12235300", "https://i.redd.it/sp2b24o1e4a71.jpg"],
+        "gifs": [
+            "https://tenor.com/view/nicolas-cage-friday-feel-that-friday-feeling-feel-that-thats-friday-gif-12235300",
+            "https://i.redd.it/sp2b24o1e4a71.jpg",
+        ],
     },
     5: {
         "names": [
@@ -75,7 +78,10 @@ days = {
             "Sunday, Sunday, Sunday",
             "the first day of the week",
         ],
-        "templates": ["WEEKEND ALERT: {0}!", "It's {0}, but is it RACE DAY?"],
+        "templates": [
+            "WEEKEND ALERT: {0}!",
+            "It's {0}, but is it RACE DAY?",
+        ],
         "gifs": [],
     },
 }


### PR DESCRIPTION
##### Summary 

Adding a new template option for Sunday. This would question if it is race day. Also adding a new gif for Friday to highlight that Friday could be about Freija, the knock-off clone of Frigga.

##### Checklist

* [x] this is a source code change
  * [x] run `isort . && black .` in the repository root
  * [x] run `pytest` in the repository root
  * [x] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  * [x] update the wiki documentation if necessary
* [ ] or, this is **not** a source code change
