### PR TITLE
:sweden: Add Freyas frog image for Fridays

### DIFF
--- a/duckbot/cogs/announce_day/phrases.py
+++ b/duckbot/cogs/announce_day/phrases.py
@@ -58,6 +58,7 @@ days = {
         "gifs": [
             "https://tenor.com/view/nicolas-cage-friday-feel-that-friday-feeling-feel-that-thats-friday-gif-12235300",
             "https://i.redd.it/sp2b24o1e4a71.jpg",
+            "https://i.redd.it/sp2b24o1e4a71.jpg",
         ],
     },
     5: {


### PR DESCRIPTION
##### Summary 

[Added a link to the image of the frog freya for friday](https://i.redd.it/sp2b24o1e4a71.jpg)
Testing --- Checked that the url works. 

##### Checklist

* [x] this is a source code change
  * [ ] run `isort . && black .` in the repository root **I did, but when I do it always messes up the phrases file for some reason, so I didn't push that bit.**
  * [ ] run `pytest` in the repository root **couldn't, having issues with psycopg2**
  * [ ] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  * [ ] update the wiki documentation if necessary
* [ ] or, this is **not** a source code change
