### PR TITLE
add "today was X" day of the week template

### DIFF
--- a/duckbot/cogs/announce_day/announce_day.py
+++ b/duckbot/cogs/announce_day/announce_day.py
@@ -33,7 +33,8 @@ class AnnounceDay(commands.Cog):
         day = now.weekday()
         today = random.choice(days[day]["names"])
         tomorrow = random.choice(days[(day + 1) % 7]["names"])
-        message = random.choice(templates + days[day]["templates"]).format(today, tomorrow)
+        yesterday = random.choice(days[(day + 6) % 7]["names"])  # +6 instead of -1 since modulo can be negative
+        message = random.choice(templates + days[day]["templates"]).format(today, tomorrow, yesterday)
         if now in self.holidays:
             specials = " and ".join(self.holidays.get_list(now))
             return message + "\n" + "It is also " + specials + "."

--- a/duckbot/cogs/announce_day/phrases.py
+++ b/duckbot/cogs/announce_day/phrases.py
@@ -86,7 +86,7 @@ days = {
     },
 }
 
-# {0} is today, {1} is tomorrow
+# {0} is today, {1} is tomorrow, {2} is yesterday
 templates = [
     "Today is {0}.",
     "Today: {0}. Tomorrow: {1}.",
@@ -106,5 +106,6 @@ templates = [
     "Beep boop: {0}.",
     "I take no pleasure in announcing that today is {0}, for I am a robot.",
     "I take no displeasure in announcing that today is {0}, for I am a robot.",
+    "Today was {2}. But, that's over.",
     "Fek, figure it out.",
 ]

--- a/tests/cogs/announce_day/announce_day_test.py
+++ b/tests/cogs/announce_day/announce_day_test.py
@@ -41,24 +41,26 @@ async def test_cog_unload_cancels_task(bot, dog_photos):
 
 @pytest.mark.asyncio
 @mock.patch("random.random", return_value=0.5)
-async def test_on_hour_7am_eastern_special_day(random, bot, dog_photos, guild_channel, setup_general_channel):
+@mock.patch("random.choice", side_effect=["today", "tomorrow", "yesterday", "{0} {1} {2}"])
+async def test_on_hour_7am_eastern_special_day(random, choice, bot, dog_photos, guild_channel, setup_general_channel):
     with patch_now(datetime.datetime(2002, 1, 1, hour=7)):
         clazz = AnnounceDay(bot, dog_photos)
         await clazz.on_hour()
         if guild_channel.type == ChannelType.text:
-            guild_channel.send.assert_called()
+            guild_channel.send.assert_called_once_with("today tomorrow yesterday\nIt is also New Year's Day.")
         else:
             assert not guild_channel.method_calls
 
 
 @pytest.mark.asyncio
 @mock.patch("random.random", return_value=0.5)
-async def test_on_hour_7am_eastern_not_special_day(random, bot, dog_photos, guild_channel, setup_general_channel):
+@mock.patch("random.choice", side_effect=["today", "tomorrow", "yesterday", "{0} {1} {2}"])
+async def test_on_hour_7am_eastern_not_special_day(random, choice, bot, dog_photos, guild_channel, setup_general_channel):
     with patch_now(datetime.datetime(2002, 1, 21, hour=7)):
         clazz = AnnounceDay(bot, dog_photos)
         await clazz.on_hour()
         if guild_channel.type == ChannelType.text:
-            guild_channel.send.assert_called()
+            guild_channel.send.assert_called_once_with("today tomorrow yesterday")
         else:
             assert not guild_channel.method_calls
 


### PR DESCRIPTION
##### Summary 

Adding "today was yesterday" style template for day of the week. Also improved the tests a bit to also test the template format a little bit.

##### Checklist

* [x] this is a source code change
  * [x] run `isort . && black .` in the repository root
  * [x] run `pytest` in the repository root
  * [x] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  * [x] update the wiki documentation if necessary
* [ ] or, this is **not** a source code change
