### PR TITLE
add more dog emojis to pick from

### DIFF
--- a/duckbot/cogs/announce_day/announce_day.py
+++ b/duckbot/cogs/announce_day/announce_day.py
@@ -59,7 +59,7 @@ class AnnounceDay(commands.Cog):
 
     async def send_dog(self, channel):
         try:
-            dogs = [":dog:", ":dog2:", ":guide_dog:", ":service_dog:"]
+            dogs = [":dog:", ":dog2:", ":guide_dog:", ":service_dog:", ":hotdog:", ":feet:", ":bone:"]
             await channel.send(f"Also, here's a dog! {random.choice(dogs)}\n{self.dog_photos.get_dog_image()}")
         except Exception as e:
             log.warning(e, exc_info=True)  # ignore failures for sending dog photo


### PR DESCRIPTION
##### Summary 

The comment left by @jameshughes89 on #303 included more dog based emojis than what we currently have to choose from when sending the dog of the day image. This adds some new emojis from that set. `:feet:` = 🐾 , which is also a set of paws on discord.

##### Checklist

* [x] this is a source code change
  * [x] run `isort . && black .` in the repository root
  * [x] run `pytest` in the repository root
  * [x] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  * [x] update the wiki documentation if necessary
* [ ] or, this is **not** a source code change
