### PR TITLE
add `14` as a message template for thursday

### DIFF
--- a/duckbot/cogs/announce_day/phrases.py
+++ b/duckbot/cogs/announce_day/phrases.py
@@ -44,7 +44,9 @@ days = {
             "civ day",
             "Thursday",
         ],
-        "templates": [],
+        "templates": [
+            "14",
+        ],
         "gifs": [],
     },
     4: {


### PR DESCRIPTION
##### Summary 

Adds `14` as a message template for Thursday. This will trigger the AOE taunt and get replaced by ["start the game already!"](https://github.com/Chippers255/duckbot/blob/main/duckbot/cogs/games/aoe_phrases.py#L15)

##### Checklist

* [x] this is a source code change
  * [x] run `isort . && black .` in the repository root
  * [x] run `pytest` in the repository root
  * [x] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  * [x] update the wiki documentation if necessary
* [ ] or, this is **not** a source code change
