### PR TITLE
upgrade discord.py to 2.0 + support threads

### DIFF
--- a/duckbot/cogs/formula_one/formula_one.py
+++ b/duckbot/cogs/formula_one/formula_one.py
@@ -1,6 +1,5 @@
 import random
 
-from discord import ChannelType
 from discord.ext import commands
 
 from .phrases import phrases
@@ -17,4 +16,4 @@ class FormulaOne(commands.Cog):
                 await message.add_reaction(letter)
 
     def is_dank_channel(self, channel):
-        return channel.type == ChannelType.text and channel.name == "dank"
+        return channel.name == "dank"

--- a/duckbot/cogs/insights/insights.py
+++ b/duckbot/cogs/insights/insights.py
@@ -3,7 +3,7 @@ import random
 
 from discord import ChannelType
 from discord.ext import commands, tasks
-from discord.utils import get
+from discord.utils import get, utcnow
 
 from .phrases import responses
 
@@ -35,7 +35,7 @@ class Insights(commands.Cog):
             return None
 
     def should_respond(self, message):
-        stamp = datetime.datetime.utcnow() - datetime.timedelta(minutes=23)
+        stamp = utcnow() - datetime.timedelta(minutes=23)
         return message is not None and stamp >= message.created_at and message.author.id == 244629273191645184
 
     @check_should_respond.before_loop

--- a/setup.py
+++ b/setup.py
@@ -42,11 +42,11 @@ if __name__ == "__main__":
             "nltk>=3.6,<4",
             "textblob<1",
         ],
-        dependency_links=[
-            "git+https://github.com/Rapptz/discord.py#egg=discord.py[voice]",
-        ],
+#        dependency_links=[
+#            "git+https://github.com/Rapptz/discord.py#egg=discord.py-2.0.0a",
+#        ],
         install_requires=[
-            "discord.py[voice]==2.0.0a",
+            "discord.py[voice] @ git+https://github.com/Rapptz/discord.py",
             "beautifulsoup4",
             "pytz",
             "timezonefinder>=5.2,<6",

--- a/setup.py
+++ b/setup.py
@@ -42,8 +42,11 @@ if __name__ == "__main__":
             "nltk>=3.6,<4",
             "textblob<1",
         ],
+        dependency_links=[
+            "git+https://github.com/Rapptz/discord.py#egg=discord.py[voice]",
+        ],
         install_requires=[
-            "discord.py[voice]>=1.7,<2",
+            "discord.py[voice]==2.0.0a",
             "beautifulsoup4",
             "pytz",
             "timezonefinder>=5.2,<6",

--- a/setup.py
+++ b/setup.py
@@ -42,9 +42,6 @@ if __name__ == "__main__":
             "nltk>=3.6,<4",
             "textblob<1",
         ],
-#        dependency_links=[
-#            "git+https://github.com/Rapptz/discord.py#egg=discord.py-2.0.0a",
-#        ],
         install_requires=[
             "discord.py[voice] @ git+https://github.com/Rapptz/discord.py",
             "beautifulsoup4",

--- a/tests/cogs/announce_day/announce_day_test.py
+++ b/tests/cogs/announce_day/announce_day_test.py
@@ -34,9 +34,7 @@ async def test_before_loop_waits_for_bot(bot, dog_photos):
 async def test_cog_unload_cancels_task(bot, dog_photos):
     clazz = AnnounceDay(bot, dog_photos)
     clazz.cog_unload()
-    with pytest.raises(CancelledError):
-        await clazz.on_hour_loop.get_task()
-    assert not clazz.on_hour_loop.is_running()
+    clazz.on_hour_loop.cancel.assert_called()
 
 
 @pytest.mark.asyncio

--- a/tests/cogs/announce_day/announce_day_test.py
+++ b/tests/cogs/announce_day/announce_day_test.py
@@ -1,5 +1,4 @@
 import datetime
-from asyncio import CancelledError
 from unittest import mock
 
 import pytest

--- a/tests/cogs/audio/who_can_it_be_now_test.py
+++ b/tests/cogs/audio/who_can_it_be_now_test.py
@@ -15,18 +15,18 @@ def play(*args, **kwargs):
 @pytest.mark.asyncio
 @mock.patch("duckbot.cogs.audio.who_can_it_be_now.PCMVolumeTransformer", autospec=True)
 @mock.patch("duckbot.cogs.audio.who_can_it_be_now.FFmpegPCMAudio", autospec=True)
-async def test_task_loop_once(ffmpeg, vol, bot_spy, text_context, voice_client):
-    text_context.voice_client = None
-    text_context.author.voice.channel.connect.return_value = async_value(voice_client)
+async def test_task_loop_once(ffmpeg, vol, bot_spy, guild_context, voice_client):
+    guild_context.voice_client = None
+    guild_context.author.voice.channel.connect.return_value = async_value(voice_client)
     voice_client.play = play
     clazz = WhoCanItBeNow(bot_spy)
-    await clazz.connect_to_voice(text_context)
+    await clazz.connect_to_voice(guild_context)
     assert clazz.voice_client is not None
-    await clazz._WhoCanItBeNow__start(text_context)
+    await clazz._WhoCanItBeNow__start(guild_context)
     assert clazz.audio_task is not None
     assert clazz.streaming is True
     await clazz.stream.wait()
-    await clazz._WhoCanItBeNow__stop(text_context)
+    await clazz._WhoCanItBeNow__stop(guild_context)
     assert clazz.streaming is False
     assert clazz.audio_task is None
     assert clazz.voice_client is None
@@ -35,9 +35,9 @@ async def test_task_loop_once(ffmpeg, vol, bot_spy, text_context, voice_client):
 @pytest.mark.asyncio
 @mock.patch("duckbot.cogs.audio.who_can_it_be_now.PCMVolumeTransformer", autospec=True)
 @mock.patch("duckbot.cogs.audio.who_can_it_be_now.FFmpegPCMAudio", autospec=True)
-async def test_task_loop_repeats(ffmpeg, vol, bot_spy, text_context, voice_client):
-    text_context.voice_client = None
-    text_context.author.voice.channel.connect.return_value = async_value(voice_client)
+async def test_task_loop_repeats(ffmpeg, vol, bot_spy, guild_context, voice_client):
+    guild_context.voice_client = None
+    guild_context.author.voice.channel.connect.return_value = async_value(voice_client)
 
     def loop_first(*args, **kwargs):
         voice_client.play = play
@@ -45,15 +45,15 @@ async def test_task_loop_repeats(ffmpeg, vol, bot_spy, text_context, voice_clien
 
     voice_client.play = loop_first
     clazz = WhoCanItBeNow(bot_spy)
-    await clazz.connect_to_voice(text_context)
+    await clazz.connect_to_voice(guild_context)
     assert clazz.voice_client is not None
-    await clazz._WhoCanItBeNow__start(text_context)
+    await clazz._WhoCanItBeNow__start(guild_context)
     assert clazz.audio_task is not None
     assert clazz.streaming is True
     await clazz.stream.wait()
     await asyncio.sleep(0)
     await clazz.stream.wait()
-    await clazz._WhoCanItBeNow__stop(text_context)
+    await clazz._WhoCanItBeNow__stop(guild_context)
     assert clazz.streaming is False
     assert clazz.audio_task is None
     assert clazz.voice_client is None
@@ -69,11 +69,11 @@ async def test_connect_to_voice_no_voice(bot, context):
 
 
 @pytest.mark.asyncio
-async def test_connect_to_voice_author_in_channel(bot, text_context, voice_client):
-    text_context.voice_client = None
-    text_context.author.voice.channel.connect.return_value = async_value(voice_client)
+async def test_connect_to_voice_author_in_channel(bot, guild_context, voice_client):
+    guild_context.voice_client = None
+    guild_context.author.voice.channel.connect.return_value = async_value(voice_client)
     clazz = WhoCanItBeNow(bot)
-    await clazz.connect_to_voice(text_context)
+    await clazz.connect_to_voice(guild_context)
     assert clazz.voice_client == voice_client
 
 

--- a/tests/cogs/formula_one/formula_one_test.py
+++ b/tests/cogs/formula_one/formula_one_test.py
@@ -1,15 +1,13 @@
 from unittest import mock
 
 import pytest
-from discord import ChannelType
 
 from duckbot.cogs.formula_one import FormulaOne
 
 
 @pytest.mark.asyncio
 async def test_car_do_be_going_fast_though_not_dank_channel(bot, message):
-    if message.channel.type == ChannelType.text:
-        message.channel.name = "general"
+    message.channel.name = "general"
     clazz = FormulaOne(bot)
     await clazz.car_do_be_going_fast_though(message)
     message.add_reaction.assert_not_called()
@@ -17,8 +15,8 @@ async def test_car_do_be_going_fast_though_not_dank_channel(bot, message):
 
 @pytest.mark.asyncio
 @mock.patch("random.choice", return_value=["\U0001F170"])
-async def test_car_do_be_going_fast_though_dank_channel(random, bot, text_message):
-    text_message.channel.name = "dank"
+async def test_car_do_be_going_fast_though_dank_channel(random, bot, guild_message):
+    guild_message.channel.name = "dank"
     clazz = FormulaOne(bot)
-    await clazz.car_do_be_going_fast_though(text_message)
-    text_message.add_reaction.assert_called_once_with("\U0001F170")
+    await clazz.car_do_be_going_fast_though(guild_message)
+    guild_message.add_reaction.assert_called_once_with("\U0001F170")

--- a/tests/cogs/insights/insights_test.py
+++ b/tests/cogs/insights/insights_test.py
@@ -47,8 +47,8 @@ async def test_check_should_respond_no_history(bot, guild, guild_channel):
 
 
 @pytest.mark.asyncio
-@mock.patch("discord.Message", autospec=True)
 @mock.patch("duckbot.cogs.insights.insights.utcnow", return_value=datetime.datetime(2000, 1, 1, hour=12, minute=00, tzinfo=datetime.timezone.utc))
+@mock.patch("discord.Message", autospec=True)
 async def test_check_should_respond_new_message(message, utcnow, bot, text_channel, setup_expected_general_channel):
     message.created_at = datetime.datetime(2000, 1, 1, hour=11, minute=38, tzinfo=datetime.timezone.utc)
     message.author.id = 244629273191645184
@@ -59,8 +59,8 @@ async def test_check_should_respond_new_message(message, utcnow, bot, text_chann
 
 
 @pytest.mark.asyncio
-@mock.patch("discord.Message", autospec=True)
 @mock.patch("duckbot.cogs.insights.insights.utcnow", return_value=datetime.datetime(2000, 1, 1, hour=12, minute=00, tzinfo=datetime.timezone.utc))
+@mock.patch("discord.Message", autospec=True)
 async def test_check_should_respond_not_special_user(message, utcnow, bot, text_channel, setup_expected_general_channel):
     message.created_at = datetime.datetime(2000, 1, 1, hour=11, minute=00, tzinfo=datetime.timezone.utc)
     message.author.id = 0
@@ -71,8 +71,8 @@ async def test_check_should_respond_not_special_user(message, utcnow, bot, text_
 
 
 @pytest.mark.asyncio
-@mock.patch("discord.Message", autospec=True)
 @mock.patch("duckbot.cogs.insights.insights.utcnow", return_value=datetime.datetime(2000, 1, 1, hour=12, minute=00, tzinfo=datetime.timezone.utc))
+@mock.patch("discord.Message", autospec=True)
 async def test_check_should_respond_old_message_sent_by_special_user(message, utcnow, bot, text_channel, setup_expected_general_channel):
     message.created_at = datetime.datetime(2000, 1, 1, hour=11, minute=00, tzinfo=datetime.timezone.utc)
     message.author.id = 244629273191645184

--- a/tests/cogs/insights/insights_test.py
+++ b/tests/cogs/insights/insights_test.py
@@ -28,9 +28,7 @@ async def test_before_loop_waits_for_bot(bot):
 async def test_cog_unload_cancels_task(bot):
     clazz = Insights(bot)
     clazz.cog_unload()
-    with pytest.raises(CancelledError):
-        await clazz.check_should_respond.get_task()
-    assert not clazz.check_should_respond.is_running()
+    clazz.check_should_respond.cancel.assert_called()
 
 
 @pytest.mark.asyncio

--- a/tests/cogs/insights/insights_test.py
+++ b/tests/cogs/insights/insights_test.py
@@ -6,7 +6,6 @@ import pytest
 from discord import ChannelType
 
 from duckbot.cogs.insights import Insights
-from tests.duckmock.datetime import patch_utcnow
 from tests.duckmock.discord import MockAsyncIterator
 
 
@@ -51,39 +50,39 @@ async def test_check_should_respond_no_history(bot, guild, guild_channel):
 
 
 @pytest.mark.asyncio
+@mock.patch("duckbot.cogs.insights.insights.utcnow", return_value=datetime.datetime(2000, 1, 1, hour=12, minute=00, tzinfo=datetime.timezone.utc))
 @mock.patch("discord.Message", autospec=True)
-async def test_check_should_respond_new_message(message, bot, text_channel, setup_general_channel):
-    with patch_utcnow(datetime.datetime(2000, 1, 1, hour=12, minute=00)):
-        message.created_at = datetime.datetime(2000, 1, 1, hour=11, minute=38)
-        message.author.id = 244629273191645184
-        text_channel.history.return_value = MockAsyncIterator(message)
-        clazz = Insights(bot)
-        await clazz._Insights__check_should_respond()
-        text_channel.send.assert_not_called()
+async def test_check_should_respond_new_message(message, utcnow, bot, text_channel, setup_general_channel):
+    message.created_at = datetime.datetime(2000, 1, 1, hour=11, minute=38, tzinfo=datetime.timezone.utc)
+    message.author.id = 244629273191645184
+    text_channel.history.return_value = MockAsyncIterator(message)
+    clazz = Insights(bot)
+    await clazz._Insights__check_should_respond()
+    text_channel.send.assert_not_called()
 
 
 @pytest.mark.asyncio
+@mock.patch("duckbot.cogs.insights.insights.utcnow", return_value=datetime.datetime(2000, 1, 1, hour=12, minute=00, tzinfo=datetime.timezone.utc))
 @mock.patch("discord.Message", autospec=True)
-async def test_check_should_respond_not_special_user(message, bot, text_channel, setup_general_channel):
-    with patch_utcnow(datetime.datetime(2000, 1, 1, hour=12, minute=00)):
-        message.created_at = datetime.datetime(2000, 1, 1, hour=11, minute=00)
-        message.author.id = 0
-        text_channel.history.return_value = MockAsyncIterator(message)
-        clazz = Insights(bot)
-        await clazz._Insights__check_should_respond()
-        text_channel.send.assert_not_called()
+async def test_check_should_respond_not_special_user(message, utcnow, bot, text_channel, setup_general_channel):
+    message.created_at = datetime.datetime(2000, 1, 1, hour=11, minute=00, tzinfo=datetime.timezone.utc)
+    message.author.id = 0
+    text_channel.history.return_value = MockAsyncIterator(message)
+    clazz = Insights(bot)
+    await clazz._Insights__check_should_respond()
+    text_channel.send.assert_not_called()
 
 
 @pytest.mark.asyncio
+@mock.patch("duckbot.cogs.insights.insights.utcnow", return_value=datetime.datetime(2000, 1, 1, hour=12, minute=00, tzinfo=datetime.timezone.utc))
 @mock.patch("discord.Message", autospec=True)
-async def test_check_should_respond_old_message_sent_by_special_user(message, bot, text_channel, setup_general_channel):
-    with patch_utcnow(datetime.datetime(2000, 1, 1, hour=12, minute=00)):
-        message.created_at = datetime.datetime(2000, 1, 1, hour=11, minute=00)
-        message.author.id = 244629273191645184
-        text_channel.history.return_value = MockAsyncIterator(message)
-        clazz = Insights(bot)
-        await clazz._Insights__check_should_respond()
-        text_channel.send.assert_called()
+async def test_check_should_respond_old_message_sent_by_special_user(message, utcnow, bot, text_channel, setup_general_channel):
+    message.created_at = datetime.datetime(2000, 1, 1, hour=11, minute=00, tzinfo=datetime.timezone.utc)
+    message.author.id = 244629273191645184
+    text_channel.history.return_value = MockAsyncIterator(message)
+    clazz = Insights(bot)
+    await clazz._Insights__check_should_respond()
+    text_channel.send.assert_called()
 
 
 @pytest.mark.asyncio

--- a/tests/cogs/insights/insights_test.py
+++ b/tests/cogs/insights/insights_test.py
@@ -47,8 +47,8 @@ async def test_check_should_respond_no_history(bot, guild, guild_channel):
 
 
 @pytest.mark.asyncio
-@mock.patch("duckbot.cogs.insights.insights.utcnow", return_value=datetime.datetime(2000, 1, 1, hour=12, minute=00, tzinfo=datetime.timezone.utc))
 @mock.patch("discord.Message", autospec=True)
+@mock.patch("duckbot.cogs.insights.insights.utcnow", return_value=datetime.datetime(2000, 1, 1, hour=12, minute=00, tzinfo=datetime.timezone.utc))
 async def test_check_should_respond_new_message(message, utcnow, bot, text_channel, setup_expected_general_channel):
     message.created_at = datetime.datetime(2000, 1, 1, hour=11, minute=38, tzinfo=datetime.timezone.utc)
     message.author.id = 244629273191645184
@@ -59,8 +59,8 @@ async def test_check_should_respond_new_message(message, utcnow, bot, text_chann
 
 
 @pytest.mark.asyncio
-@mock.patch("duckbot.cogs.insights.insights.utcnow", return_value=datetime.datetime(2000, 1, 1, hour=12, minute=00, tzinfo=datetime.timezone.utc))
 @mock.patch("discord.Message", autospec=True)
+@mock.patch("duckbot.cogs.insights.insights.utcnow", return_value=datetime.datetime(2000, 1, 1, hour=12, minute=00, tzinfo=datetime.timezone.utc))
 async def test_check_should_respond_not_special_user(message, utcnow, bot, text_channel, setup_expected_general_channel):
     message.created_at = datetime.datetime(2000, 1, 1, hour=11, minute=00, tzinfo=datetime.timezone.utc)
     message.author.id = 0
@@ -71,8 +71,8 @@ async def test_check_should_respond_not_special_user(message, utcnow, bot, text_
 
 
 @pytest.mark.asyncio
-@mock.patch("duckbot.cogs.insights.insights.utcnow", return_value=datetime.datetime(2000, 1, 1, hour=12, minute=00, tzinfo=datetime.timezone.utc))
 @mock.patch("discord.Message", autospec=True)
+@mock.patch("duckbot.cogs.insights.insights.utcnow", return_value=datetime.datetime(2000, 1, 1, hour=12, minute=00, tzinfo=datetime.timezone.utc))
 async def test_check_should_respond_old_message_sent_by_special_user(message, utcnow, bot, text_channel, setup_expected_general_channel):
     message.created_at = datetime.datetime(2000, 1, 1, hour=11, minute=00, tzinfo=datetime.timezone.utc)
     message.author.id = 244629273191645184

--- a/tests/cogs/insights/insights_test.py
+++ b/tests/cogs/insights/insights_test.py
@@ -1,5 +1,4 @@
 import datetime
-from asyncio import CancelledError
 from unittest import mock
 
 import pytest

--- a/tests/cogs/insights/insights_test.py
+++ b/tests/cogs/insights/insights_test.py
@@ -10,7 +10,7 @@ from tests.duckmock.discord import MockAsyncIterator
 
 
 @pytest.fixture
-def setup_general_channel(bot, guild, text_channel):
+def setup_expected_general_channel(bot, guild, text_channel):
     bot.get_all_channels.return_value = [text_channel]
     guild.name = "Friends Chat"
     text_channel.guild = guild
@@ -52,7 +52,7 @@ async def test_check_should_respond_no_history(bot, guild, guild_channel):
 @pytest.mark.asyncio
 @mock.patch("duckbot.cogs.insights.insights.utcnow", return_value=datetime.datetime(2000, 1, 1, hour=12, minute=00, tzinfo=datetime.timezone.utc))
 @mock.patch("discord.Message", autospec=True)
-async def test_check_should_respond_new_message(message, utcnow, bot, text_channel, setup_general_channel):
+async def test_check_should_respond_new_message(message, utcnow, bot, text_channel, setup_expected_general_channel):
     message.created_at = datetime.datetime(2000, 1, 1, hour=11, minute=38, tzinfo=datetime.timezone.utc)
     message.author.id = 244629273191645184
     text_channel.history.return_value = MockAsyncIterator(message)
@@ -64,7 +64,7 @@ async def test_check_should_respond_new_message(message, utcnow, bot, text_chann
 @pytest.mark.asyncio
 @mock.patch("duckbot.cogs.insights.insights.utcnow", return_value=datetime.datetime(2000, 1, 1, hour=12, minute=00, tzinfo=datetime.timezone.utc))
 @mock.patch("discord.Message", autospec=True)
-async def test_check_should_respond_not_special_user(message, utcnow, bot, text_channel, setup_general_channel):
+async def test_check_should_respond_not_special_user(message, utcnow, bot, text_channel, setup_expected_general_channel):
     message.created_at = datetime.datetime(2000, 1, 1, hour=11, minute=00, tzinfo=datetime.timezone.utc)
     message.author.id = 0
     text_channel.history.return_value = MockAsyncIterator(message)
@@ -76,7 +76,7 @@ async def test_check_should_respond_not_special_user(message, utcnow, bot, text_
 @pytest.mark.asyncio
 @mock.patch("duckbot.cogs.insights.insights.utcnow", return_value=datetime.datetime(2000, 1, 1, hour=12, minute=00, tzinfo=datetime.timezone.utc))
 @mock.patch("discord.Message", autospec=True)
-async def test_check_should_respond_old_message_sent_by_special_user(message, utcnow, bot, text_channel, setup_general_channel):
+async def test_check_should_respond_old_message_sent_by_special_user(message, utcnow, bot, text_channel, setup_expected_general_channel):
     message.created_at = datetime.datetime(2000, 1, 1, hour=11, minute=00, tzinfo=datetime.timezone.utc)
     message.author.id = 244629273191645184
     text_channel.history.return_value = MockAsyncIterator(message)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,10 +52,10 @@ async def bot_spy() -> DuckBot:
 
 @pytest.fixture
 @mock.patch("duckbot.DuckBot", autospec=True)
-def bot(b) -> DuckBot:
+def bot(b, monkeypatch) -> DuckBot:
     b.loop = mock.Mock()
-    with mock.patch("discord.ext.tasks.Loop"):  # mock out loop, it uses `asyncio.get_event_loop()` by default
-        return b
+    monkeypatch.setattr(discord.ext.tasks, "Loop", mock.Mock())  # mock out loop, it uses `asyncio.get_event_loop()` by default
+    return b
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -79,11 +79,11 @@ def message(m, channel, user, member) -> discord.Message:
     return m
 
 
-@pytest.fixture
+@pytest.fixture(params=["discord.TextChannel", "discord.Thread"])
 @mock.patch("discord.Message", autospec=True)
-def text_message(m, text_channel, member) -> discord.Message:
-    """Returns a guild TextChannel message with the channel property set."""
-    m.channel = text_channel
+def guild_message(m, request, text_channel, thread, member) -> discord.Message:
+    """Returns a guild TextChannel or Thread message with the channel property set."""
+    m.channel = text_channel if request.param == "discord.TextChannel" else thread
     m.author = member
     return m
 
@@ -100,11 +100,11 @@ def context(c, message) -> discord.ext.commands.Context:
 
 @pytest.fixture
 @mock.patch("discord.ext.commands.Context", autospec=True)
-def text_context(c, text_message) -> discord.ext.commands.Context:
+def guild_context(c, guild_message) -> discord.ext.commands.Context:
     """Returns a guild context with nested properties set."""
-    c.message = text_message
-    c.channel = text_message.channel
-    c.author = text_message.author
+    c.message = guild_message
+    c.channel = guild_message.channel
+    c.author = guild_message.author
     return c
 
 
@@ -120,18 +120,20 @@ def guild(g) -> discord.Guild:
     return g
 
 
-@pytest.fixture(params=["discord.TextChannel", "discord.VoiceChannel"])
-def guild_channel(request, text_channel, voice_channel):
+@pytest.fixture(params=["discord.TextChannel", "discord.VoiceChannel", "discord.Thread"])
+def guild_channel(request, text_channel, voice_channel, thread):
     """Returns a guild TextChannel and a VoiceChannel."""
     if request.param == "discord.TextChannel":
         return text_channel
     elif request.param == "discord.VoiceChannel":
         return voice_channel
+    elif request.param == "discord.Thread":
+        return thread
     raise AssertionError
 
 
-@pytest.fixture(params=["discord.TextChannel", "discord.DMChannel", "discord.GroupChannel"])
-def channel(request, text_channel, dm_channel, group_channel):
+@pytest.fixture(params=["discord.TextChannel", "discord.DMChannel", "discord.GroupChannel", "discord.Thread"])
+def channel(request, text_channel, dm_channel, group_channel, thread):
     """Returns a text based channel."""
     if request.param == "discord.TextChannel":
         return text_channel
@@ -139,6 +141,8 @@ def channel(request, text_channel, dm_channel, group_channel):
         return dm_channel
     elif request.param == "discord.GroupChannel":
         return group_channel
+    elif request.param == "discord.Thread":
+        return thread
     raise AssertionError
 
 
@@ -161,6 +165,13 @@ def dm_channel(dm) -> discord.DMChannel:
 def group_channel(g) -> discord.GroupChannel:
     g.type = discord.ChannelType.group
     return g
+
+
+@pytest.fixture
+@mock.patch("discord.Thread", autospec=True)
+def thread(thrd) -> discord.Thread:
+    thrd.type = discord.ChannelType.public_thread
+    return thrd
 
 
 @pytest.fixture

--- a/tests/duckmock/datetime/__init__.py
+++ b/tests/duckmock/datetime/__init__.py
@@ -9,10 +9,3 @@ def patch_now(now):
     dt = mock.Mock(wraps=datetime.datetime)
     dt.now.return_value = now
     return mock.patch(DATETIME, new=dt)
-
-
-def patch_utcnow(utcnow):
-    """Returns a patched datetime with `utcnow` set to the given time."""
-    dt = mock.Mock(wraps=datetime.datetime)
-    dt.utcnow.return_value = utcnow
-    return mock.patch(DATETIME, new=dt)


### PR DESCRIPTION
##### Summary 

Fixes #302 

There's only one backward incompatible change we had to fix, which is that all `datetime`s returned by messages and such are now timezone aware, which means existing comparisons to non timezone aware objects failed. This only affected the `insights` cog. The only other use of datetime was the day announcement, but it's not related to the discord library.

A minor change, duckbot will react in any `#dank` channel, be it a thread or the existing top level channel. I could do top level channel only, but eh.

I added a `Thread` as a default channel type for all the tests, so using `channel` or `context` will give you a thread in addition to the existing channel types. Also did some renaming, since threads are text channels, `text_context` and `text_message` are changed to `guild_*` instead for clarity.

Ran manual tests in beta. Everything looked good -- I didn't test the insights explicitly, but the first time I boot it up, the task failed due to the timezone issue mentioned above. After fixing, I saw no error messages at least.

Finally, [discord.py](https://github.com/Rapptz/discord.py) is set to read only mode, so building from their source is safe enough, it'll never change. They never published 2.0 to pypi, so we do have to install it from github. 

##### Checklist

* [x] this is a source code change
  * [x] run `isort . && black .` in the repository root
  * [x] run `pytest` in the repository root
  * [x] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  * [x] update the wiki documentation if necessary
* [ ] or, this is **not** a source code change
