### PR TITLE
avoid accessing `channel.name` for types that don't have a name

### DIFF
--- a/duckbot/cogs/formula_one/formula_one.py
+++ b/duckbot/cogs/formula_one/formula_one.py
@@ -16,4 +16,4 @@ class FormulaOne(commands.Cog):
                 await message.add_reaction(letter)
 
     def is_dank_channel(self, channel):
-        return channel.name == "dank"
+        return hasattr(channel, "name") and channel.name == "dank"

--- a/tests/cogs/formula_one/formula_one_test.py
+++ b/tests/cogs/formula_one/formula_one_test.py
@@ -7,7 +7,6 @@ from duckbot.cogs.formula_one import FormulaOne
 
 @pytest.mark.asyncio
 async def test_car_do_be_going_fast_though_not_dank_channel(bot, message):
-    message.channel.name = "general"
     clazz = FormulaOne(bot)
     await clazz.car_do_be_going_fast_though(message)
     message.add_reaction.assert_not_called()


### PR DESCRIPTION
##### Summary 

Title. Turns out not all discord channel classes have a `name` attribute. This is just some cleanup to avoid the error.

it wasn't captured by tests since the test does `message.channel.name = "general"` which made it so all the channels had the `name` attribute in the test execution.

##### Checklist

* [x] this is a source code change
  * [x] run `isort . && black .` in the repository root
  * [x] run `pytest` in the repository root
  * [x] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  * [x] update the wiki documentation if necessary
* [ ] or, this is **not** a source code change
