### PR TITLE
change runtime image to use non-slim python

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ COPY pyproject.toml .
 COPY setup.py .
 RUN pip install --extra-index-url https://www.piwheels.org/simple .
 
-FROM python:3.8-slim as prod
+FROM python:3.8 as prod
 # ffmpeg: for discord audio
 # libpq-dev: postgres client libraries
 # libatlas-base-dev: matplotlib dependencies


### PR DESCRIPTION
##### Summary 

First deployment after upgrading discord.py to 2.0 didn't seem to work. I don't have access to logs, so this is just a stab at a fix.

##### Checklist

* [ ] this is a source code change
  * [ ] run `isort . && black .` in the repository root
  * [ ] run `pytest` in the repository root
  * [ ] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  * [ ] update the wiki documentation if necessary
* [x] or, this is **not** a source code change
