### PR TITLE
automatically disconnect music stream after ~4h

### DIFF
--- a/tests/cogs/audio/who_can_it_be_now_test.py
+++ b/tests/cogs/audio/who_can_it_be_now_test.py
@@ -75,8 +75,8 @@ async def test_task_loop_repeats_max_times(ffmpeg, vol, bot_spy, context, voice_
     for i in range(76):
         await clazz.stream.wait()
         await asyncio.sleep(0)
+        assert clazz.streaming is (i < 75)  # should be streaming 75 times only
     # stop() is called after song is played 75 times
-    assert clazz.streaming is False
     assert clazz.audio_task is None
     assert clazz.voice_client is None
 

--- a/tests/cogs/audio/who_can_it_be_now_test.py
+++ b/tests/cogs/audio/who_can_it_be_now_test.py
@@ -18,15 +18,15 @@ def play(*args, **kwargs):
 async def test_task_loop_once(ffmpeg, vol, bot_spy, context, voice_client, skip_if_private_channel):
     context.voice_client = None
     context.author.voice.channel.connect.return_value = async_value(voice_client)
-    voice_client.play = play
+    voice_client.play.side_effect = play
     clazz = WhoCanItBeNow(bot_spy)
     await clazz.connect_to_voice(context)
     assert clazz.voice_client is not None
-    await clazz._WhoCanItBeNow__start(context)
+    await clazz.start(context)
     assert clazz.audio_task is not None
     assert clazz.streaming is True
     await clazz.stream.wait()
-    await clazz._WhoCanItBeNow__stop(context)
+    await clazz.stop(context)
     assert clazz.streaming is False
     assert clazz.audio_task is None
     assert clazz.voice_client is None
@@ -40,20 +40,42 @@ async def test_task_loop_repeats(ffmpeg, vol, bot_spy, context, voice_client, sk
     context.author.voice.channel.connect.return_value = async_value(voice_client)
 
     def loop_first(*args, **kwargs):
-        voice_client.play = play
+        voice_client.play.side_effect = play
         play(*args, **kwargs)
 
-    voice_client.play = loop_first
+    voice_client.play.side_effect = loop_first
     clazz = WhoCanItBeNow(bot_spy)
     await clazz.connect_to_voice(context)
     assert clazz.voice_client is not None
-    await clazz._WhoCanItBeNow__start(context)
+    await clazz.start(context)
     assert clazz.audio_task is not None
     assert clazz.streaming is True
     await clazz.stream.wait()
     await asyncio.sleep(0)
     await clazz.stream.wait()
-    await clazz._WhoCanItBeNow__stop(context)
+    await clazz.stop(context)
+    assert clazz.streaming is False
+    assert clazz.audio_task is None
+    assert clazz.voice_client is None
+
+
+@pytest.mark.asyncio
+@mock.patch("duckbot.cogs.audio.who_can_it_be_now.PCMVolumeTransformer", autospec=True)
+@mock.patch("duckbot.cogs.audio.who_can_it_be_now.FFmpegPCMAudio", autospec=True)
+async def test_task_loop_repeats_max_times(ffmpeg, vol, bot_spy, context, voice_client, skip_if_private_channel):
+    context.voice_client = None
+    context.author.voice.channel.connect.return_value = async_value(voice_client)
+    voice_client.play.side_effect = play
+    clazz = WhoCanItBeNow(bot_spy)
+    await clazz.connect_to_voice(context)
+    assert clazz.voice_client is not None
+    await clazz.start(context)
+    assert clazz.audio_task is not None
+    assert clazz.streaming is True
+    for i in range(76):
+        await clazz.stream.wait()
+        await asyncio.sleep(0)
+    # stop() is called after song is played 75 times
     assert clazz.streaming is False
     assert clazz.audio_task is None
     assert clazz.voice_client is None
@@ -99,7 +121,7 @@ async def test_connect_to_voice_already_connected(bot, context, voice_client):
 async def test_start_already_started(bot, context):
     clazz = WhoCanItBeNow(bot)
     clazz.streaming = True
-    await clazz._WhoCanItBeNow__start(context)
+    await clazz.start(context)
     bot.loop.create_task.assert_not_called()
 
 
@@ -111,7 +133,7 @@ async def test_stop_disconnects(ffmpeg, vol, bot, context, voice_client):
     clazz.streaming = True
     clazz.audio_task = asyncio.create_task(clazz.stream_audio())
     clazz.voice_client = voice_client
-    await clazz._WhoCanItBeNow__stop(context)
+    await clazz.stop(context)
     voice_client.disconnect.assert_called()
     assert clazz.voice_client is None
     assert clazz.audio_task is None
@@ -122,7 +144,7 @@ async def test_stop_disconnects(ffmpeg, vol, bot, context, voice_client):
 async def test_stop_not_streaming(bot, context):
     clazz = WhoCanItBeNow(bot)
     clazz.streaming = False
-    await clazz._WhoCanItBeNow__stop(context)
+    await clazz.stop(context)
     context.send.assert_called_once_with("Brother, no :musical_note: :saxophone: is active.", delete_after=30)
 
 
@@ -130,7 +152,7 @@ async def test_stop_not_streaming(bot, context):
 async def test_stop_null_context_not_streaming(bot):
     clazz = WhoCanItBeNow(bot)
     clazz.streaming = False
-    await clazz._WhoCanItBeNow__stop()
+    await clazz.stop()
 
 
 @pytest.mark.asyncio

--- a/wiki/Commands.md
+++ b/wiki/Commands.md
@@ -29,7 +29,7 @@ Do you crave a particular food but want an arbitrary recipe?
 
 Music
 -----
-DuckBot plays everyone's favourite background noise inside whatever voice channel you're in. Use `!start` to summon the bot, and `!stop` to dismiss it.
+DuckBot plays everyone's favourite background noise inside whatever voice channel you're in. Use `!start` to summon the bot, and `!stop` to dismiss it. DuckBot only has so much stamina, and will stop playing music after about four hours.
 
 Weather
 -------


### PR DESCRIPTION
##### Summary 

Title! Causes `!start` to automatically disconnect after playing the song 75 times, which is about 4h20min. This is just to prevent it from running indefinitely when someone forgets to `!stop`.

I also renamed the methods slightly, so `start` -> `start_command` and the private `__start` -> `start`, similar to other cogs.

Tested manually in beta using `bruh.mp3` and reducing the max count to only 3.

##### Checklist

* [x] this is a source code change
  * [x] run `isort . && black .` in the repository root
  * [x] run `pytest` in the repository root
  * [x] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  * [x] update the wiki documentation if necessary
* [ ] or, this is **not** a source code change
