### PR TITLE
change docker image to `duckdynasty/duckbot`

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -75,7 +75,7 @@ jobs:
     - name: Login to Docker
       uses: docker/login-action@v1
       with:
-        username: chippers255
+        username: duckdynasty
         password: ${{ secrets.DOCKER_PASS }}
     - name: Build and Push Docker Image
       run: |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.9"
 services:
     duckbot:
         build: .
-        image: chippers255/duckbot:latest
+        image: duckdynasty/duckbot:latest
         environment:
             DISCORD_TOKEN: ${DISCORD_TOKEN}
             OPENWEATHER_TOKEN: ${OPENWEATHER_TOKEN}


### PR DESCRIPTION
##### Summary 

DuckBot has an org now, I've gone ahead and made an org specific docker account for it. These two instances of `chippers` seem to be the only ones, see [search](https://github.com/duck-dynasty/duckbot/search?q=chippers255).

https://hub.docker.com/repository/docker/duckdynasty/duckbot -- note that docker for some reason doesn't allow dashes in their user names, so I couldn't do `duck-dynasty`.

I'll update the `DOCKER_PASS` secret after approval.

##### Checklist

* [ ] this is a source code change
  * [ ] run `isort . && black .` in the repository root
  * [ ] run `pytest` in the repository root
  * [ ] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  * [ ] update the wiki documentation if necessary
* [x] or, this is **not** a source code change
