### PR TITLE
add thx as trigger word for thanking duckbot + only respond once

### DIFF
--- a/duckbot/cogs/robot/thanking_robot.py
+++ b/duckbot/cogs/robot/thanking_robot.py
@@ -12,7 +12,7 @@ class ThankingRobot(commands.Cog):
         if message.author == self.bot.user:
             return
 
-        thanks = ["thank you duckbot", "thanks duckbot", "thank you duck bot", "thanks duck bot"]
+        thanks = ["thank you duckbot", "thanks duckbot", "thank you duck bot", "thanks duck bot", "thx duckbot", "thx duck bot"]
         for t in thanks:
             if t in message.content.lower().replace(",", ""):
                 correction = f"I am just a robot.  Do not personify me, {message.author.display_name}"

--- a/duckbot/cogs/robot/thanking_robot.py
+++ b/duckbot/cogs/robot/thanking_robot.py
@@ -13,7 +13,6 @@ class ThankingRobot(commands.Cog):
             return
 
         thanks = ["thank you duckbot", "thanks duckbot", "thank you duck bot", "thanks duck bot", "thx duckbot", "thx duck bot"]
-        for t in thanks:
-            if t in message.content.lower().replace(",", ""):
-                correction = f"I am just a robot.  Do not personify me, {message.author.display_name}"
-                await message.channel.send(correction)
+        if any(t in message.content.lower().replace(",", "") for t in thanks)
+            correction = f"I am just a robot.  Do not personify me, {message.author.display_name}"
+            await message.channel.send(correction)

--- a/duckbot/cogs/robot/thanking_robot.py
+++ b/duckbot/cogs/robot/thanking_robot.py
@@ -13,6 +13,6 @@ class ThankingRobot(commands.Cog):
             return
 
         thanks = ["thank you duckbot", "thanks duckbot", "thank you duck bot", "thanks duck bot", "thx duckbot", "thx duck bot"]
-        if any(t in message.content.lower().replace(",", "") for t in thanks)
+        if any(t in message.content.lower().replace(",", "") for t in thanks):
             correction = f"I am just a robot.  Do not personify me, {message.author.display_name}"
             await message.channel.send(correction)

--- a/tests/cogs/robot/thanking_robot_test.py
+++ b/tests/cogs/robot/thanking_robot_test.py
@@ -20,6 +20,14 @@ async def test_correct_giving_thanks_message_is_thanks(bot, message, text):
     await clazz.correct_giving_thanks(message)
     message.channel.send.assert_called_once_with(f"I am just a robot.  Do not personify me, {message.author.display_name}")
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize("text", ["Thank you DuckBot. thanks duck bot. thx duck bot boy", " tHaNks, DuCK BOt"])
+async def test_correct_number_of_replies_to_very_thankful_messages(bot, message, text):
+    message.content = text
+    clazz = ThankingRobot(bot)
+    await clazz.correct_giving_thanks(message)
+    message.channel.send.assert_called_once_with(f"I am just a robot.  Do not personify me, {message.author.display_name}")
+
 
 @pytest.mark.asyncio
 async def test_correct_giving_thanks_message_has_no_thanks(bot, message):

--- a/tests/cogs/robot/thanking_robot_test.py
+++ b/tests/cogs/robot/thanking_robot_test.py
@@ -13,7 +13,7 @@ async def test_correct_giving_thanks_bot_author(bot, message):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("text", ["Thank you DuckBot. You're becoming so much more polite.", " tHaNks, DuCK BOt"])
+@pytest.mark.parametrize("text", ["Thank you DuckBot. You're becoming so much more polite.", " tHaNks, DuCK BOt", "thx duck bot my man"])
 async def test_correct_giving_thanks_message_is_thanks(bot, message, text):
     message.content = text
     clazz = ThankingRobot(bot)

--- a/tests/cogs/robot/thanking_robot_test.py
+++ b/tests/cogs/robot/thanking_robot_test.py
@@ -20,6 +20,7 @@ async def test_correct_giving_thanks_message_is_thanks(bot, message, text):
     await clazz.correct_giving_thanks(message)
     message.channel.send.assert_called_once_with(f"I am just a robot.  Do not personify me, {message.author.display_name}")
 
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize("text", ["Thank you DuckBot. thanks duck bot. thx duck bot boy", " tHaNks, DuCK BOt"])
 async def test_correct_number_of_replies_to_very_thankful_messages(bot, message, text):


### PR DESCRIPTION
##### Summary 

Closes #321 
Closes #322 

Added "thx" variations on thank you to the `thanks` list of thank yous. This includes "thx duckbot" and "thx duck bot". I considered "thxs" versions too, but I don't think that would be common (but easy to add if we want). 

Also changed the loop checking if a given thank you variation is within the message. Instead of a loop with an if, I use _list comprehension_ (which I typically avoid, but whatever) to make a list of bools and then use `any` to check if any of them are true. I opted for this over a `break` or `return` because I figured there would be a python-ie way to do the check. Also added a test to check that only one reply is sent with a message containing more than one version of thanking.

##### Checklist

* [x] this is a source code change
  * [x] run `isort . && black .` in the repository root
  * [x] run `pytest` in the repository root
  * [x] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  * [ ] update the wiki documentation if necessary
* [ ] or, this is **not** a source code change
