### PR TITLE
add Duckbot advertisement video to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ A Discord bot for personal friend group. If you don't know me personally, consid
 
 View the [wiki](https://github.com/duck-dynasty/duckbot/wiki) for a short description on what the Duck does.
 
-https://user-images.githubusercontent.com/3149083/135647011-c5869f04-abef-41a9-9550-99292dc4e792.mp4
+
+https://user-images.githubusercontent.com/3149083/135654217-244d7457-9db9-4c30-a98a-785b25453fd8.mp4
 
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ A Discord bot for personal friend group. If you don't know me personally, consid
 
 View the [wiki](https://github.com/duck-dynasty/duckbot/wiki) for a short description on what the Duck does.
 
+https://user-images.githubusercontent.com/3149083/135647011-c5869f04-abef-41a9-9550-99292dc4e792.mp4
+
+
 ## Development
 Before running DuckBot, you want to create a virtualenv to develop in. DuckBot runs on `python3.8`, so prefer to use that.
 


### PR DESCRIPTION
##### Summary 

This one is pretty simple, I uploaded the advert for Duckbot to the readme. Turns out you can just drag and drop a video file into the markdown editor on github. We can't hide the file name so let me know if we should change it. This will close out issue #324.

##### Checklist

* [ ] this is a source code change
  * [ ] run `isort . && black .` in the repository root
  * [ ] run `pytest` in the repository root
  * [ ] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  * [ ] update the wiki documentation if necessary
* [x] or, this is **not** a source code change
