### PR TITLE
correct @mock.patch argument order

### DIFF
--- a/tests/cogs/announce_day/announce_day_test.py
+++ b/tests/cogs/announce_day/announce_day_test.py
@@ -28,8 +28,8 @@ async def test_cog_unload_cancels_task(bot, dog_photos):
 
 
 @pytest.mark.asyncio
-@mock.patch("random.random", return_value=0.5)
 @mock.patch("random.choice", side_effect=["today", "tomorrow", "yesterday", "{today} {tomorrow} {yesterday}"])
+@mock.patch("random.random", return_value=0.5)
 async def test_on_hour_7am_eastern_special_day(random, choice, bot, dog_photos, general_channel):
     with patch_now(datetime.datetime(2002, 1, 1, hour=7)):
         clazz = AnnounceDay(bot, dog_photos)
@@ -38,8 +38,8 @@ async def test_on_hour_7am_eastern_special_day(random, choice, bot, dog_photos, 
 
 
 @pytest.mark.asyncio
-@mock.patch("random.random", return_value=0.5)
 @mock.patch("random.choice", side_effect=["today", "tomorrow", "yesterday", "{today} {tomorrow} {yesterday}"])
+@mock.patch("random.random", return_value=0.5)
 async def test_on_hour_7am_eastern_not_special_day(random, choice, bot, dog_photos, general_channel):
     with patch_now(datetime.datetime(2002, 1, 21, hour=7)):
         clazz = AnnounceDay(bot, dog_photos)


### PR DESCRIPTION
##### Summary 

Title. While working on slash commands stuff, I noticed this. Bottom first for @mock.patch! ([scroll down a bit here](https://docs.python.org/3/library/unittest.mock.html#quick-guide)) Tiny PR to fix it.

##### Checklist

* [x] this is a source code change
  * [x] run `isort . && black .` in the repository root
  * [x] run `pytest` in the repository root
  * [x] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  * [x] update the wiki documentation if necessary
* [ ] or, this is **not** a source code change
