### PR TITLE
add discord.py http test fixture

### DIFF
--- a/tests/fixtures/discord/__init__.py
+++ b/tests/fixtures/discord/__init__.py
@@ -1,5 +1,5 @@
 from .author import member, user
-from .bot import bot, bot_spy
+from .bot import bot, bot_spy, http
 from .channel import (
     channel,
     dm_channel,

--- a/tests/fixtures/discord/bot.py
+++ b/tests/fixtures/discord/bot.py
@@ -21,7 +21,16 @@ async def bot_spy() -> DuckBot:
 def bot(autospec, monkeypatch) -> DuckBot:
     """Returns a mock DuckBot instance. The default event loops are replaced by mocks."""
     b = autospec.of("duckbot.DuckBot")
+    b.command_prefix = "!"
     b.loop = mock.Mock()
     # mock out loop, it uses `asyncio.get_event_loop()` by default
     monkeypatch.setattr(discord.ext.tasks, "Loop", mock.Mock())
     return b
+
+
+@pytest.fixture
+def http(autospec, bot):
+    """Returns a mock discord.py http client. The client is also attached to `bot.http`."""
+    h = autospec.of("discord.http.HTTPClient")
+    bot.http = h
+    return h


### PR DESCRIPTION
##### Summary 

I'm currently working on slash commands (#200) and have working code, but the diff is pretty large. I'm splitting it up into several smaller changes so it'll be easier to review, and it'll hopefully allow for a better overall understanding on how I've chosen to integrate slash commands into discord.py, which doesn't really support it out of the box.

This change simply adds a new, unused, test fixture: discord.py's `HTTPClient` class. The class is a wrapper for all of the discord APIs and it's what is used when creating/updating slash commands.

This also adds `bot.command_prefix` to the `bot` fixture. It's a dynamic property that python's autospec'd mocks don't find, and I end up logging it, which would break in the test (autospec throws if you access a property that doesn't staticly exist -- dynamic properties don't staticly exist).

##### Checklist

* [x] this is a source code change
  * [x] run `isort . && black .` in the repository root
  * [x] run `pytest` in the repository root
  * [x] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  * [x] update the wiki documentation if necessary
* [ ] or, this is **not** a source code change
