### PR TITLE
add discord.py command test fixture

### DIFF
--- a/tests/fixtures/discord/__init__.py
+++ b/tests/fixtures/discord/__init__.py
@@ -8,6 +8,7 @@ from .channel import (
     text_channel,
     thread,
 )
+from .command import command
 from .context import context
 from .embed import patch_embed_equals
 from .emoji import emoji

--- a/tests/fixtures/discord/command.py
+++ b/tests/fixtures/discord/command.py
@@ -1,0 +1,8 @@
+import discord.ext.commands
+import pytest
+
+
+@pytest.fixture
+def command(autospec) -> discord.ext.commands.Command:
+    """Returns a mock discord.py command."""
+    return autospec.of("discord.ext.commands.Command")


### PR DESCRIPTION
##### Summary 

I'm currently working on slash commands (#200) and have working code, but the diff is pretty large. I'm splitting it up into several smaller changes so it'll be easier to review, and it'll hopefully allow for a better overall understanding on how I've chosen to integrate slash commands into discord.py, which doesn't really support it out of the box.

This change simply adds a new, unused, test fixture: discord.py's `Command` class. The way I wrote slash commands, they'll actually end up delegating to the existing commands we have. We never access the class directly for another other reason, so I had to add it for slash specific stuff.

##### Checklist

* [x] this is a source code change
  * [x] run `isort . && black .` in the repository root
  * [x] run `pytest` in the repository root
  * [x] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  * [x] update the wiki documentation if necessary
* [ ] or, this is **not** a source code change
