### PR TITLE
add type hints to patched discord.py equals/tostring

### DIFF
--- a/tests/fixtures/discord/embed.py
+++ b/tests/fixtures/discord/embed.py
@@ -9,10 +9,10 @@ def patch_embed_equals():
     as discord.Embed doesn't implement equals itself.
     See also: https://github.com/Rapptz/discord.py/issues/5962"""
 
-    def embed_equals(self, other):
+    def embed_equals(self: discord.Embed, other: discord.Embed):
         return self.to_dict() == other.to_dict()
 
-    def embed_str(self):
+    def embed_str(self: discord.Embed):
         return str(self.to_dict())
 
     discord.Embed.__eq__ = embed_equals


### PR DESCRIPTION
##### Summary 

Apparently I did this at some point while working on slash commands stuff. So here's a pull request.

##### Checklist

* [x] this is a source code change
  * [x] run `isort . && black .` in the repository root
  * [x] run `pytest` in the repository root
  * [x] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  * [x] update the wiki documentation if necessary
* [ ] or, this is **not** a source code change
