### PR TITLE
add discord.py interaction test fixture

### DIFF
--- a/tests/fixtures/discord/__init__.py
+++ b/tests/fixtures/discord/__init__.py
@@ -13,5 +13,6 @@ from .embed import patch_embed_equals
 from .emoji import emoji
 from .general_channel import general_channel
 from .guild import guild
+from .interaction import interaction
 from .message import message, raw_message
 from .voice import voice_channel, voice_client

--- a/tests/fixtures/discord/interaction.py
+++ b/tests/fixtures/discord/interaction.py
@@ -9,5 +9,5 @@ def interaction(request, autospec, channel) -> discord.Interaction:
     """Returns a message with nested properties set, for each channel type a message can be sent to."""
     i.channel = channel
     author = "user" if channel.type in [discord.ChannelType.private, discord.ChannelType.group] else "member"
-    i.author = request.getfixturevalue(author)
+    i.user = request.getfixturevalue(author)
     return i

--- a/tests/fixtures/discord/interaction.py
+++ b/tests/fixtures/discord/interaction.py
@@ -1,0 +1,13 @@
+import discord
+import pytest
+
+
+@pytest.fixture
+def interaction(request, autospec, channel) -> discord.Interaction:
+    """Returns an interaction with nested properties set, for each channel type a command can be sent to."""
+    i = autospec.of("discord.Interaction")
+    """Returns a message with nested properties set, for each channel type a message can be sent to."""
+    i.channel = channel
+    author = "user" if channel.type in [discord.ChannelType.private, discord.ChannelType.group] else "member"
+    i.author = request.getfixturevalue(author)
+    return i


### PR DESCRIPTION
##### Summary 

I'm currently working on slash commands (#200) and have working code, but the diff is pretty large. I'm splitting it up into several smaller changes so it'll be easier to review, and it'll hopefully allow for a better overall understanding on how I've chosen to integrate slash commands into discord.py, which doesn't really support it out of the box.

This change simply adds a new, unused, test fixture: discord.py's `Interaction` class. The original PR #246 implemented this manually, but discord.py 2.0 included the model. It's also substantially more complete, allowed for responding and stuff like that (similar to their `Message` model). See the [interaction](https://github.com/Rapptz/discord.py/blob/master/discord/interactions.py#L71) class in discord.py.

##### Checklist

* [x] this is a source code change
  * [x] run `isort . && black .` in the repository root
  * [x] run `pytest` in the repository root
  * [x] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  * [x] update the wiki documentation if necessary
* [ ] or, this is **not** a source code change
