### PR TITLE
correct Delta's birthday

### DIFF
--- a/duckbot/cogs/announce_day/special_days.py
+++ b/duckbot/cogs/announce_day/special_days.py
@@ -38,7 +38,7 @@ class SpecialDays(holidays.Canada):
         self[date(year, 6, 21)] = f"Erin's Birthday. She's {year-1991} years old"
         self[date(year, 9, 8)] = f"Dan's Birthday. He {year-1989} old"
         self[date(year, 9, 26)] = f"Tom's Birthday. He's {year-1990} years old. How he made it this far, we'll never know"
-        self[date(year, 10, 5)] = f"Delta's Birthday. He's {year-2015} years old and is a good boy"
+        self[date(year, 10, 7)] = f"Delta's Birthday. He's {year-2015} years old and is a good boy"
         self[date(year, 10, 31)] = "Halloween"
         self[date(year, 11, 10)] = f"Tom and Kelly's fake wedding anniversary. They've been fake together for {year-2014} years"
         self[date(year, 11, 12)] = f"Sabrina's Birthday. She is {year-1996} years old. Good work on surviving"


### PR DESCRIPTION
##### Summary 

Correcting Delta's birthday in the special days list. For whatever reason, it's listed as the 5th instead of the 7th.

##### Checklist

* [x] this is a source code change
  * [x] run `isort . && black .` in the repository root
  * [x] run `pytest` in the repository root
  * [x] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  * [x] update the wiki documentation if necessary
* [ ] or, this is **not** a source code change
