### PR TITLE
add tests for calculated date special days

### DIFF
--- a/tests/cogs/announce_day/special_days_test.py
+++ b/tests/cogs/announce_day/special_days_test.py
@@ -1,4 +1,6 @@
-import datetime
+from datetime import datetime
+
+import pytest
 
 from duckbot.cogs.announce_day.special_days import SpecialDays
 
@@ -9,4 +11,16 @@ def test_populate_bro_tito_day(bot, guild, emoji):
     emoji.name = "tito"
     guild.name = "Friends Chat"
     clazz = SpecialDays(bot)
-    assert clazz.get_list(datetime.datetime(2020, 5, 7)) == [f"Bro Tito Day {emoji}"]
+    assert clazz.get_list(datetime(2020, 5, 7)) == [f"Bro Tito Day {emoji}"]
+
+
+@pytest.mark.parametrize("date", [datetime(2021, 5, 9), datetime(2022, 5, 8), datetime(2023, 5, 14)])
+def test_populate_mothers_day(bot, date):
+    clazz = SpecialDays(bot)
+    assert clazz.get_list(date) == ["Mother's Day"]
+
+
+@pytest.mark.parametrize("date", [datetime(2021, 6, 20), datetime(2022, 6, 19), datetime(2023, 6, 18)])
+def test_populate_fathers_day(bot, date):
+    clazz = SpecialDays(bot)
+    assert clazz.get_list(date) == ["Father's Day"]


### PR DESCRIPTION
##### Summary 

Adds tests for the special days that are calculated dates. Mother's day for example is the 2nd Sunday of May, or whatever.

Test cases, I pulled from https://www.timeanddate.com/holidays/canada/mother-day

I could also add tests for the rest of them. Stuff like birthdays includes age as a calculation, but I think they're just not required. I don't think the test would catch any logic errors there.

##### Checklist

* [x] this is a source code change
  * [x] run `isort . && black .` in the repository root
  * [x] run `pytest` in the repository root
  * [x] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  * [x] update the wiki documentation if necessary
* [ ] or, this is **not** a source code change
