### PR TITLE
periodically change the discord activity duckbot is doing

### DIFF
--- a/duckbot/bot.py
+++ b/duckbot/bot.py
@@ -1,6 +1,4 @@
-import random
-
-from discord import Game, Intents
+from discord import Intents
 from discord.ext import commands
 
 
@@ -10,7 +8,6 @@ def intents() -> Intents:
     intent.presences = False
     intent.bans = False
     intent.integrations = False
-    intent.webhooks = False
     intent.invites = False
     intent.webhooks = False
     intent.typing = False
@@ -19,8 +16,7 @@ def intents() -> Intents:
 
 class DuckBot(commands.Bot):
     def __init__(self):
-        game = ["Duck Game", "the Banjo", "Gloomhaven", "with Fire", "with the Boys"]
-        super().__init__(command_prefix="!", help_command=None, intents=intents(), activity=Game(name=random.choice(game)))
+        super().__init__(command_prefix="!", help_command=None, intents=intents())
         self.add_listener(self.ready, name="on_ready")
 
     async def ready(self):

--- a/duckbot/cogs/games/__init__.py
+++ b/duckbot/cogs/games/__init__.py
@@ -1,9 +1,11 @@
 from .aoe import AgeOfEmpires
 from .coin_flip import CoinFlip
 from .dice import Dice
+from .discord_activity import DiscordActivity
 
 
 def setup(bot):
     bot.add_cog(Dice(bot))
     bot.add_cog(AgeOfEmpires(bot))
     bot.add_cog(CoinFlip(bot))
+    bot.add_cog(DiscordActivity(bot))

--- a/duckbot/cogs/games/discord_activity.py
+++ b/duckbot/cogs/games/discord_activity.py
@@ -12,7 +12,7 @@ class DiscordActivity(commands.Cog):
     def cog_unload(self):
         self.change_activity_loop.cancel()
 
-    @tasks.loop(minutes=769)
+    @tasks.loop(minutes=281)
     async def change_activity_loop(self):
         # docs mention there's a "high chance" of disconnecting when changing the presence shortly after connecting
         # however, the issue was never replicated in testing with @loop, the docs specifically mention on_ready event

--- a/duckbot/cogs/games/discord_activity.py
+++ b/duckbot/cogs/games/discord_activity.py
@@ -1,0 +1,39 @@
+import random
+
+import discord
+from discord.ext import commands, tasks
+
+
+class DiscordActivity(commands.Cog):
+    def __init__(self, bot: commands.Bot):
+        self.bot = bot
+        self.change_activity_loop.start()
+
+    def cog_unload(self):
+        self.change_activity_loop.cancel()
+
+    @tasks.loop(minutes=769)
+    async def change_activity_loop(self):
+        # docs mention there's a "high chance" of disconnecting when changing the presence shortly after connecting
+        # however, the issue was never replicated in testing with @loop, the docs specifically mention on_ready event
+        # at any rate, if this fails a bunch, we can consider doing something as simple as sleeping a bit here maybe
+        # https://discordpy.readthedocs.io/en/latest/faq.html#how-do-i-set-the-playing-status
+        await self.change_activity()
+
+    async def change_activity(self):
+        await self.bot.change_presence(activity=self.random_activity())
+
+    def random_activity(self):
+        return random.choice(
+            [
+                discord.Game("Duck Game"),
+                discord.Game("the Banjo"),
+                discord.Game("Gloomhaven"),
+                discord.Game("with Fire"),
+                discord.Game("with the Boys"),
+            ]
+        )
+
+    @change_activity_loop.before_loop
+    async def before_loop(self):
+        await self.bot.wait_until_ready()

--- a/tests/bot_test.py
+++ b/tests/bot_test.py
@@ -1,5 +1,5 @@
 import pytest
-from discord import Game, Intents
+from discord import Intents
 
 from duckbot import DuckBot
 from duckbot.bot import intents
@@ -21,7 +21,6 @@ async def test_duckbot_constructor():
     assert bot.command_prefix == "!"
     assert bot.help_command is None
     assert bot.intents == intents()
-    assert bot.activity in [Game("Duck Game"), Game("the Banjo"), Game("Gloomhaven"), Game("with Fire"), Game("with the Boys")]
     await bot.close()
 
 

--- a/tests/cogs/games/discord_activity_test.py
+++ b/tests/cogs/games/discord_activity_test.py
@@ -1,0 +1,28 @@
+from unittest import mock
+
+import discord
+import pytest
+
+from duckbot.cogs.games import DiscordActivity
+
+
+@pytest.mark.asyncio
+async def test_before_loop_waits_for_bot(bot):
+    clazz = DiscordActivity(bot)
+    await clazz.before_loop()
+    bot.wait_until_ready.assert_called()
+
+
+@pytest.mark.asyncio
+async def test_cog_unload_cancels_task(bot):
+    clazz = DiscordActivity(bot)
+    clazz.cog_unload()
+    clazz.change_activity_loop.cancel.assert_called()
+
+
+@pytest.mark.asyncio
+@mock.patch("random.choice", return_value=discord.Game("game"))
+async def test_change_activity_changes_activity(bot):
+    clazz = DiscordActivity(bot)
+    await clazz.change_activity()
+    bot.change_presence.assert_called_once_with(activity=discord.Game("game"))

--- a/tests/cogs/games/discord_activity_test.py
+++ b/tests/cogs/games/discord_activity_test.py
@@ -22,7 +22,7 @@ async def test_cog_unload_cancels_task(bot):
 
 @pytest.mark.asyncio
 @mock.patch("random.choice", return_value=discord.Game("game"))
-async def test_change_activity_changes_activity(bot):
+async def test_change_activity_changes_activity(choice, bot):
     clazz = DiscordActivity(bot)
     await clazz.change_activity()
     bot.change_presence.assert_called_once_with(activity=discord.Game("game"))

--- a/tests/cogs/games/setup_test.py
+++ b/tests/cogs/games/setup_test.py
@@ -1,6 +1,6 @@
 import pytest
 
-from duckbot.cogs.games import AgeOfEmpires, CoinFlip, Dice
+from duckbot.cogs.games import AgeOfEmpires, CoinFlip, Dice, DiscordActivity
 from duckbot.cogs.games import setup as extension_setup
 from tests.discord_test_ext import assert_cog_added_of_type
 
@@ -11,3 +11,4 @@ async def test_setup(bot_spy):
     assert_cog_added_of_type(bot_spy, Dice)
     assert_cog_added_of_type(bot_spy, AgeOfEmpires)
     assert_cog_added_of_type(bot_spy, CoinFlip)
+    assert_cog_added_of_type(bot_spy, DiscordActivity)


### PR DESCRIPTION
##### Summary 

Fixes #329 

I also put this in a comment, but the docs mention to avoid do many API calls shortly after connecting to discord, [link](https://discordpy.readthedocs.io/en/latest/faq.html#how-do-i-set-the-playing-status). It specifically mentions `on_ready`, whereas I am using a `@loop`, but both still make an API call shortly after connecting. The ran the bot a bunch of times and never experienced an issue. If we see it as an issue in the future, we can do something hacky like adding `sleep` to the loop, or provide the `acitivity` in the bot constructor (like before this PR) and skip the first time the loop runs.

With this, the discord activity will change every ~5h.

##### Checklist

* [x] this is a source code change
  * [x] run `isort . && black .` in the repository root
  * [x] run `pytest` in the repository root
  * [x] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  * [x] update the wiki documentation if necessary
* [ ] or, this is **not** a source code change
