### PR TITLE
add `!yolo` to list open pull requests in duckbot

### DIFF
--- a/.aws/cloudformation.template.yml
+++ b/.aws/cloudformation.template.yml
@@ -32,11 +32,14 @@ Resources:
         Image: !Ref DuckBotImage
         Essential: true
         Links: [postgres]
+        # NOTE secrets are created during the `deploy` github action
         Secrets:
         - Name: DISCORD_TOKEN
           ValueFrom: /duckbot/token/discord
         - Name: OPENWEATHER_TOKEN
           ValueFrom: /duckbot/token/openweather
+        - Name: GITHUB_TOKEN
+          ValueFrom: /duckbot/token/github
         HealthCheck:
           Command: [CMD, python, -m, duckbot.health]
           Interval: 30

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -112,9 +112,11 @@ jobs:
       env:
         DISCORD_TOKEN: ${{ secrets.DISCORD_TOKEN }}
         OPENWEATHER_TOKEN: ${{ secrets.OPENWEATHER_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
       run: |
         aws ssm put-parameter --name /duckbot/token/discord --type String --value "$DISCORD_TOKEN" --overwrite
         aws ssm put-parameter --name /duckbot/token/openweather --type String --value "$OPENWEATHER_TOKEN" --overwrite
+        aws ssm put-parameter --name /duckbot/token/github --type String --value "$GITHUB_TOKEN" --overwrite
 
     - name: Update CloudFormation Stack
       uses: aws-actions/aws-cloudformation-github-deploy@v1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     environment:
       DISCORD_TOKEN: ${DISCORD_TOKEN}
       OPENWEATHER_TOKEN: ${OPENWEATHER_TOKEN}
+      GITHUB_TOKEN: ${GITHUB_TOKEN}
     healthcheck:
       test: [CMD, python, -m, duckbot.health]
       interval: 30s

--- a/duckbot/__main__.py
+++ b/duckbot/__main__.py
@@ -19,6 +19,7 @@ import duckbot.cogs.tito
 import duckbot.cogs.weather
 import duckbot.health
 import duckbot.logs
+import duckbot.cogs.github
 import duckbot.util.connection_test
 from duckbot import DuckBot
 
@@ -35,6 +36,7 @@ def run_duckbot(bot: commands.Bot):
     bot.load_extension(duckbot.cogs.tito.__name__)
     bot.load_extension(duckbot.cogs.text.__name__)
     bot.load_extension(duckbot.cogs.games.__name__)
+    bot.load_extension(duckbot.cogs.github.__name__)
     bot.load_extension(duckbot.cogs.recipe.__name__)
     bot.load_extension(duckbot.cogs.fortune.__name__)
     bot.load_extension(duckbot.cogs.weather.__name__)

--- a/duckbot/__main__.py
+++ b/duckbot/__main__.py
@@ -10,6 +10,7 @@ import duckbot.cogs.duck
 import duckbot.cogs.formula_one
 import duckbot.cogs.fortune
 import duckbot.cogs.games
+import duckbot.cogs.github
 import duckbot.cogs.insights
 import duckbot.cogs.messages
 import duckbot.cogs.recipe
@@ -19,7 +20,6 @@ import duckbot.cogs.tito
 import duckbot.cogs.weather
 import duckbot.health
 import duckbot.logs
-import duckbot.cogs.github
 import duckbot.util.connection_test
 from duckbot import DuckBot
 

--- a/duckbot/cogs/github/__init__.py
+++ b/duckbot/cogs/github/__init__.py
@@ -1,0 +1,5 @@
+from .yolo_merge import YoloMerge
+
+
+def setup(bot):
+    bot.add_cog(YoloMerge(bot))

--- a/duckbot/cogs/github/yolo_merge.py
+++ b/duckbot/cogs/github/yolo_merge.py
@@ -2,8 +2,8 @@ import os
 from typing import List, Optional
 
 import discord
-from discord.ext import commands
 import github
+from discord.ext import commands
 from github.PullRequest import PullRequest
 
 
@@ -57,10 +57,10 @@ class YoloMerge(commands.Cog):
             embed.add_field(
                 name=f"#{pr.number}",
                 value=f"""
-            [{pr.title}]({pr.html_url})
-            {pr.changed_files} changed file{"s" if pr.changed_files > 1 else ""}; +{pr.additions} -{pr.deletions}
-            Pull is {"" if pr.mergeable else "NOT "} mergeable. It is currently {pr.mergeable_state}.
-            {check_results}
-            """,
+                    [{pr.title}]({pr.html_url})
+                    {pr.changed_files} changed file{"s" if pr.changed_files > 1 else ""}; +{pr.additions} -{pr.deletions}
+                    Pull is {"" if pr.mergeable else "NOT "} mergeable. It is currently {pr.mergeable_state}.
+                    {check_results}
+                """,
             )
         return embed

--- a/duckbot/cogs/github/yolo_merge.py
+++ b/duckbot/cogs/github/yolo_merge.py
@@ -39,7 +39,7 @@ class YoloMerge(commands.Cog):
 
     async def list(self, context: commands.Context):
         repo = self.github.get_repo("duck-dynasty/duckbot")
-        pulls = list(repo.get_pulls()[:10])
+        pulls = list(repo.get_pulls()[:6])
         if pulls:
             embed = self.as_embed(pulls)
             await context.send(embed=embed)

--- a/duckbot/cogs/github/yolo_merge.py
+++ b/duckbot/cogs/github/yolo_merge.py
@@ -1,0 +1,60 @@
+import discord
+from discord.ext import commands
+from typing import Optional, List
+import datetime
+import os
+from github import Github
+from github.PullRequest import PullRequest
+
+
+async def is_repository_admin(context: commands.Context):
+    # if context.guild is None:
+    #     raise commands.NoPrivateMessage()
+    if not await context.bot.is_owner(context.author) and context.author.id not in []:
+        raise commands.MissingPermissions(["repository admin"])
+    return True
+
+
+class YoloMerge(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+        self.approvals = {}
+        self._github = None
+
+    def github(self) -> Github:
+        if self._github is None:
+            self._github = Github(os.getenv("GITHUB_TOKEN"))
+        return self._github
+
+    @commands.command(name="yolo")
+    @commands.check(is_repository_admin)
+    async def yolo_command(self, context: commands.Context, pr_id: Optional[int] = None):
+        await self.yolo(context, pr_id)
+
+    async def yolo(self, context: commands.Context, pr_id: Optional[int]):
+        if pr_id is None:
+            await self.list(context)
+        else:
+            await self.merge(context, pr_id)
+
+    async def list(self, context: commands.Context):
+        repo = self.github().get_repo("duck-dynasty/duckbot")
+        embed = self.as_embed(list(repo.get_pulls()[:10]))
+        await context.send(embed=embed)
+
+    def as_embed(self, prs: List[PullRequest]) -> discord.Embed:
+        embed = discord.Embed()
+        # TODO add checks, reviews, etc
+        for pr in prs:
+            embed.add_field(inline=False, name=f"#{pr.number}", value=f"""
+            [{pr.title}]({pr.html_url})
+            {pr.changed_files} changed file{"s" if pr.changed_files > 1 else ""}; +{pr.additions} -{pr.deletions}
+            Pull is {"" if pr.mergeable else "NOT "} mergeable. It is currently {pr.mergeable_state}.
+            """)
+        return embed
+
+    async def merge(self, context: commands.Context, pr_id: int):
+        if pr_id in self.approvals:
+            pass
+        else:
+            self.approvals[pr_id] = datetime.datetime.now()

--- a/duckbot/cogs/github/yolo_merge.py
+++ b/duckbot/cogs/github/yolo_merge.py
@@ -31,7 +31,7 @@ class YoloMerge(commands.Cog):
     @commands.command(name="yolo")
     @commands.check(is_repository_admin)
     async def yolo_command(self, context: commands.Context, pr_id: Optional[int] = None):
-        with context.typing():
+        async with context.typing():
             await self.yolo(context, pr_id)
 
     async def yolo(self, context: commands.Context, pr_id: Optional[int]):

--- a/duckbot/cogs/github/yolo_merge.py
+++ b/duckbot/cogs/github/yolo_merge.py
@@ -1,16 +1,18 @@
+import os
+from typing import List, Optional
+
 import discord
 from discord.ext import commands
-from typing import Optional, List
-import datetime
-import os
-from github import Github
+import github
 from github.PullRequest import PullRequest
 
 
 async def is_repository_admin(context: commands.Context):
-    # if context.guild is None:
-    #     raise commands.NoPrivateMessage()
-    if not await context.bot.is_owner(context.author) and context.author.id not in []:
+    """Disallow !yolo to be used outside of a server, and only allow the bot owner or
+    repository owners to use it."""
+    if context.guild is None:
+        raise commands.NoPrivateMessage()
+    if not await context.bot.is_owner(context.author) and context.author.id not in [368038054558171141, 776607982472921088, 375024417358479380]:
         raise commands.MissingPermissions(["repository admin"])
     return True
 
@@ -18,12 +20,11 @@ async def is_repository_admin(context: commands.Context):
 class YoloMerge(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
-        self.approvals = {}
         self._github = None
 
-    def github(self) -> Github:
+    def github(self) -> github.Github:
         if self._github is None:
-            self._github = Github(os.getenv("GITHUB_TOKEN"))
+            self._github = github.Github(os.getenv("GITHUB_TOKEN"))
         return self._github
 
     @commands.command(name="yolo")
@@ -32,10 +33,7 @@ class YoloMerge(commands.Cog):
         await self.yolo(context, pr_id)
 
     async def yolo(self, context: commands.Context, pr_id: Optional[int]):
-        if pr_id is None:
-            await self.list(context)
-        else:
-            await self.merge(context, pr_id)
+        await self.list(context)
 
     async def list(self, context: commands.Context):
         repo = self.github().get_repo("duck-dynasty/duckbot")
@@ -44,17 +42,25 @@ class YoloMerge(commands.Cog):
 
     def as_embed(self, prs: List[PullRequest]) -> discord.Embed:
         embed = discord.Embed()
-        # TODO add checks, reviews, etc
         for pr in prs:
-            embed.add_field(inline=False, name=f"#{pr.number}", value=f"""
+            commit = [c for c in pr.get_commits()][-1]
+            check_results = []
+            for suite in commit.get_check_suites():
+                completed = suite.status == "completed"
+                success = suite.conclusion == "success"
+                if completed:
+                    result = ":white_check_mark:" if success else ":x:"
+                else:
+                    result = ":coffee:"
+                check_results.append(f"**{suite.app.name}** {result}")
+            check_results = "\n".join(check_results)
+            embed.add_field(
+                name=f"#{pr.number}",
+                value=f"""
             [{pr.title}]({pr.html_url})
             {pr.changed_files} changed file{"s" if pr.changed_files > 1 else ""}; +{pr.additions} -{pr.deletions}
             Pull is {"" if pr.mergeable else "NOT "} mergeable. It is currently {pr.mergeable_state}.
-            """)
+            {check_results}
+            """,
+            )
         return embed
-
-    async def merge(self, context: commands.Context, pr_id: int):
-        if pr_id in self.approvals:
-            pass
-        else:
-            self.approvals[pr_id] = datetime.datetime.now()

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ if __name__ == "__main__":
             "textblob<1",
             "pyfiglet<1",
             "matplotlib>=3.4,<4",
+            "PyGithub>=1.55,<2",
         ],
         extras_require={
             "dev": [

--- a/tests/cogs/github/is_repository_admin_test.py
+++ b/tests/cogs/github/is_repository_admin_test.py
@@ -1,0 +1,52 @@
+from unittest import mock
+
+import pytest
+from discord.ext import commands
+
+from duckbot.cogs.github.yolo_merge import is_repository_admin
+
+
+@pytest.mark.asyncio
+@mock.patch("discord.ext.commands.Context")
+async def test_is_repository_admin_not_in_guild(context):
+    context.guild = None
+    with pytest.raises(commands.NoPrivateMessage):
+        await is_repository_admin(context)
+
+
+@pytest.mark.asyncio
+@mock.patch("discord.ext.commands.Context")
+async def test_is_repository_admin_not_bot_owner_or_repo_admin(context, guild, bot, user):
+    context.guild = guild
+    context.bot = bot
+    context.author = user
+    user.id = 0  # not a repo admin
+    bot.is_owner.return_value = False
+    with pytest.raises(commands.MissingPermissions):
+        await is_repository_admin(context)
+    bot.is_owner.assert_called_once_with(user)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("admin", [368038054558171141, 776607982472921088, 375024417358479380])
+@mock.patch("discord.ext.commands.Context")
+async def test_is_repository_admin_repo_admin(context, guild, bot, user, admin):
+    context.guild = guild
+    context.bot = bot
+    context.author = user
+    user.id = admin
+    bot.is_owner.return_value = False
+    assert await is_repository_admin(context) is True
+    bot.is_owner.assert_called_once_with(user)
+
+
+@pytest.mark.asyncio
+@mock.patch("discord.ext.commands.Context")
+async def test_is_repository_admin_bot_owner(context, guild, bot, user):
+    context.guild = guild
+    context.bot = bot
+    context.author = user
+    user.id = 0
+    bot.is_owner.return_value = True
+    assert await is_repository_admin(context) is True
+    bot.is_owner.assert_called_once_with(user)

--- a/tests/cogs/github/setup_test.py
+++ b/tests/cogs/github/setup_test.py
@@ -1,0 +1,11 @@
+import pytest
+
+from duckbot.cogs.github import YoloMerge
+from duckbot.cogs.github import setup as extension_setup
+from tests.discord_test_ext import assert_cog_added_of_type
+
+
+@pytest.mark.asyncio
+async def test_setup(bot_spy):
+    extension_setup(bot_spy)
+    assert_cog_added_of_type(bot_spy, YoloMerge)

--- a/tests/cogs/github/yolo_merge_test.py
+++ b/tests/cogs/github/yolo_merge_test.py
@@ -1,29 +1,125 @@
+from typing import Tuple
 from unittest import mock
 
+import discord
+import github
+import github.CheckSuite
+import github.Commit
+import github.PullRequest
+import github.Repository
 import pytest
 
 from duckbot.cogs.github import YoloMerge
 
 
 @pytest.fixture
-@mock.patch("github.Github")
-def github(g):
-    return g
+def repo(autospec) -> github.Repository.Repository:
+    return autospec.of("github.Repository.Repository")
 
 
 @pytest.fixture
-def clazz(bot, github):
-    claz = YoloMerge(bot)
-    claz._owm_client = github
-    return claz
+def gh(autospec) -> github.Github:
+    return autospec.of("github.Github")
+
+
+@pytest.fixture
+def yolo(bot, gh) -> YoloMerge:
+    clazz = YoloMerge(bot)
+    clazz._github = gh
+    return clazz
 
 
 def test_github_creates_instance(bot, monkeypatch):
     monkeypatch.setenv("GITHUB_TOKEN", "token")
-    claz = YoloMerge(bot)
-    assert claz.github() == claz._github
+    clazz = YoloMerge(bot)
+    assert clazz.github == clazz._github
 
 
-def test_github_returns_cached_instance(clazz, github):
-    clazz._github = github
-    assert clazz.github() == github
+def test_github_returns_cached_instance(yolo, gh):
+    yolo._github = gh
+    assert yolo.github == gh
+
+
+@pytest.mark.asyncio
+async def test_list_no_pulls(yolo, context, gh, repo, skip_if_private_channel):
+    gh.get_repo.return_value = repo
+    repo.get_pulls.return_value = []
+    await yolo.list(context)
+    context.send.assert_called_once_with("There's no open pull requests, brother. Never forget to wumbo.")
+
+
+@pytest.mark.asyncio
+async def test_list_send_pull_status(yolo, context, gh, repo, skip_if_private_channel):
+    gh.get_repo.return_value = repo
+    pull, embed_value = make_pull_request(1)
+    repo.get_pulls.return_value = [pull]
+    await yolo.list(context)
+    context.send.assert_called_once_with(embed=discord.Embed().add_field(name="#1", value=embed_value))
+
+
+@pytest.mark.asyncio
+async def test_list_max_ten_pulls(yolo, context, gh, repo, skip_if_private_channel):
+    gh.get_repo.return_value = repo
+    all_pulls = [make_pull_request(i, i % 2 == 0) for i in range(15)]
+    kept_pulls = all_pulls[:10]
+    repo.get_pulls.return_value = [p[0] for p in all_pulls]
+    await yolo.list(context)
+    embed = discord.Embed()
+    for pull, embed_value in kept_pulls:
+        embed = embed.add_field(name=f"#{pull.number}", value=embed_value)
+    context.send.assert_called_once_with(embed=embed)
+
+
+def make_pull_request(number: int, mergeable=True) -> Tuple[github.PullRequest.PullRequest, str]:
+    pull = pr()
+    pull.number = number
+    pull.changed_files = 10
+    pull.additions = 50
+    pull.deletions = 25
+    pull.mergeable = mergeable
+    commits = MockPaginatedList([commit(), commit(), commit()])
+    pull.get_commits.return_value = commits
+    last_commit = commits[-1]
+    success_check = check_suite()
+    success_check.status = "completed"
+    success_check.conclusion = "success"
+    failure_check = check_suite()
+    failure_check.status = "completed"
+    failure_check.conclusion = "failed"
+    incomplete_check = check_suite()
+    incomplete_check.status = "queued"
+    incomplete_check.conclusion = "pending"
+    last_commit.get_check_suites.return_value = [success_check, failure_check, incomplete_check]
+
+    lines = [
+        f"[{pull.title}]({pull.html_url})",
+        "10 changed files; +50 -25",
+        f"Pull is mergeable. It is currently {pull.mergeable_state}." if mergeable else f"Pull is NOT mergeable. It is currently {pull.mergeable_state}.",
+        f"**{success_check.app.name}** :white_check_mark:",
+        f"**{failure_check.app.name}** :x:",
+        f"**{incomplete_check.app.name}** :coffee:",
+    ]
+    return pull, "\n".join(lines)
+
+
+@mock.patch("github.PullRequest.PullRequest")
+def pr(p) -> github.PullRequest.PullRequest:
+    return p
+
+
+@mock.patch("github.Commit.Commit")
+def commit(c) -> github.Commit.Commit:
+    return c
+
+
+@mock.patch("github.CheckSuite.CheckSuite")
+def check_suite(c) -> github.CheckSuite.CheckSuite:
+    return c
+
+
+class MockPaginatedList(list):
+    @property
+    def reversed(self):
+        copy = [x for x in self]
+        copy.reverse()
+        return copy

--- a/tests/cogs/github/yolo_merge_test.py
+++ b/tests/cogs/github/yolo_merge_test.py
@@ -1,0 +1,29 @@
+from unittest import mock
+
+import pytest
+
+from duckbot.cogs.github import YoloMerge
+
+
+@pytest.fixture
+@mock.patch("github.Github")
+def github(g):
+    return g
+
+
+@pytest.fixture
+def clazz(bot, github):
+    claz = YoloMerge(bot)
+    claz._owm_client = github
+    return claz
+
+
+def test_github_creates_instance(bot, monkeypatch):
+    monkeypatch.setenv("GITHUB_TOKEN", "token")
+    claz = YoloMerge(bot)
+    assert claz.github() == claz._github
+
+
+def test_github_returns_cached_instance(clazz, github):
+    clazz._github = github
+    assert clazz.github() == github

--- a/tests/cogs/github/yolo_merge_test.py
+++ b/tests/cogs/github/yolo_merge_test.py
@@ -58,10 +58,10 @@ async def test_list_send_pull_status(yolo, context, gh, repo, skip_if_private_ch
 
 
 @pytest.mark.asyncio
-async def test_list_max_ten_pulls(yolo, context, gh, repo, skip_if_private_channel):
+async def test_list_max_six_pulls(yolo, context, gh, repo, skip_if_private_channel):
     gh.get_repo.return_value = repo
     all_pulls = [make_pull_request(i, i % 2 == 0) for i in range(15)]
-    kept_pulls = all_pulls[:10]
+    kept_pulls = all_pulls[:6]
     repo.get_pulls.return_value = [p[0] for p in all_pulls]
     await yolo.list(context)
     embed = discord.Embed()

--- a/tests/cogs/weather/weather_test.py
+++ b/tests/cogs/weather/weather_test.py
@@ -30,10 +30,10 @@ def owm(o, city_id, weather_manager):
 
 
 @pytest.fixture
-def clazz(bot, owm, db):
-    claz = Weather(bot, db)
-    claz.owm_client = owm
-    return claz
+def weather(bot, owm, db):
+    clazz = Weather(bot, db)
+    clazz._owm = owm
+    return clazz
 
 
 def make_city(name):
@@ -42,172 +42,172 @@ def make_city(name):
 
 def test_owm_creates_instance(bot, db, monkeypatch):
     monkeypatch.setenv("OPENWEATHER_TOKEN", "token")
-    claz = Weather(bot, db)
-    assert claz.owm() == claz.owm_client
+    clazz = Weather(bot, db)
+    assert clazz.owm == clazz._owm
 
 
-def test_owm_returns_cached_instance(clazz, owm):
-    clazz.owm_client = owm
-    assert clazz.owm() == owm
+def test_owm_returns_cached_instance(weather, owm):
+    weather._owm = owm
+    assert weather.owm == owm
 
 
 @pytest.mark.asyncio
-async def test_weather_get_failure(clazz, owm, context):
+async def test_weather_get_failure(weather, owm, context):
     owm.weather_manager.side_effect = Exception("ded")
     with pytest.raises(Exception):
-        await clazz.weather(context, "city", None, None)
+        await weather.weather(context, "city", None, None)
     context.send.assert_called_once_with("Iunno. Figure it out.\nded")
 
 
 @pytest.mark.asyncio
-async def test_search_location_no_args(clazz, context):
-    assert await clazz.search_location(context, None, None, None) is None
+async def test_search_location_no_args(weather, context):
+    assert await weather.search_location(context, None, None, None) is None
     context.send.assert_called_once_with("Not enough arguments to determine weather location, see https://github.com/duck-dynasty/duckbot/wiki/Commands#weather")
 
 
 @pytest.mark.asyncio
-async def test_search_location_no_matches(clazz, context, city_id):
+async def test_search_location_no_matches(weather, context, city_id):
     city_id.locations_for.return_value = []
-    assert await clazz.search_location(context, "city", None, None) is None
+    assert await weather.search_location(context, "city", None, None) is None
     context.send.assert_called_once_with("No cities found matching search.")
 
 
 @pytest.mark.asyncio
-async def test_search_location_single_return_city_only(clazz, context, city_id):
+async def test_search_location_single_return_city_only(weather, context, city_id):
     city_id.locations_for.return_value = [make_city("city")]
-    city = await clazz.search_location(context, "city", None, None)
+    city = await weather.search_location(context, "city", None, None)
     city_id.locations_for.assert_called_once_with("city", country=None)
     assert city.to_dict() == make_city("city").to_dict()
 
 
 @pytest.mark.asyncio
-async def test_search_location_city_name_with_comma_removed(clazz, context, city_id):
+async def test_search_location_city_name_with_comma_removed(weather, context, city_id):
     city_id.locations_for.return_value = [make_city("city")]
-    city = await clazz.search_location(context, "city,", None, None)
+    city = await weather.search_location(context, "city,", None, None)
     city_id.locations_for.assert_called_once_with("city", country=None)
     assert city.to_dict() == make_city("city").to_dict()
 
 
 @pytest.mark.asyncio
-async def test_search_location_single_return_country_arg(clazz, context, city_id):
+async def test_search_location_single_return_country_arg(weather, context, city_id):
     city_id.locations_for.return_value = [make_city("city")]
-    city = await clazz.search_location(context, "city", "US", None)
+    city = await weather.search_location(context, "city", "US", None)
     city_id.locations_for.assert_called_once_with("city", country="US")
     assert city.to_dict() == make_city("city").to_dict()
 
 
 @pytest.mark.asyncio
-async def test_search_location_single_return_invalid_country_code(clazz, context, city_id):
+async def test_search_location_single_return_invalid_country_code(weather, context, city_id):
     city_id.locations_for.return_value = [make_city("city")]
-    city = await clazz.search_location(context, "city", "invalid", None)
+    city = await weather.search_location(context, "city", "invalid", None)
     assert city is None
     context.send.assert_called_once_with("Country must be an ISO country code, such as CA for Canada.")
 
 
 @pytest.mark.asyncio
-async def test_search_location_multiple_matches(clazz, context, city_id):
+async def test_search_location_multiple_matches(weather, context, city_id):
     city_id.locations_for.return_value = [make_city("1"), make_city("2")]
-    city = await clazz.search_location(context, "city", None, None)
+    city = await weather.search_location(context, "city", None, None)
     assert city is None
     context.send.assert_called()
 
 
 @pytest.mark.asyncio
-async def test_search_location_multiple_matches_with_index(clazz, context, city_id):
+async def test_search_location_multiple_matches_with_index(weather, context, city_id):
     city_id.locations_for.return_value = [make_city("1"), make_city("2")]
-    city = await clazz.search_location(context, "city", "US", 1)
+    city = await weather.search_location(context, "city", "US", 1)
     assert city.to_dict() == make_city("1").to_dict()
 
 
 @pytest.mark.asyncio
-async def test_set_default_location_location_saved(clazz, session, context):
+async def test_set_default_location_location_saved(weather, session, context):
     async def mock_search_location(context, city, country, index):
         return make_city("city")
 
     city = make_city("city")
-    clazz.search_location = mock_search_location
-    await clazz.set_default_location(context, None, None, None)
+    weather.search_location = mock_search_location
+    await weather.set_default_location(context, None, None, None)
     context.send.assert_called_once_with(f"Location saved! {city.name}, {city.country}, geolocation = ({city.lat}, {city.lon})")
     session.merge.assert_called()
     session.commit.assert_called()
 
 
 @pytest.mark.asyncio
-async def test_set_default_location_location_not_saved(clazz, session, context):
+async def test_set_default_location_location_not_saved(weather, session, context):
     async def mock_search_location(context, city, country, index):
         return None
 
-    clazz.search_location = mock_search_location
-    await clazz.set_default_location(context, None, None, None)
+    weather.search_location = mock_search_location
+    await weather.set_default_location(context, None, None, None)
     session.merge.assert_not_called()
     session.commit.assert_not_called()
 
 
 @pytest.mark.asyncio
-async def test_send_weather_no_default_no_args(clazz, session, context):
+async def test_send_weather_no_default_no_args(weather, session, context):
     session.get.return_value = None
-    await clazz.send_weather(context, None, None, None)
+    await weather.send_weather(context, None, None, None)
     context.send.assert_called_once_with("Set a default location using `!weather set city country-code`")
 
 
 @pytest.mark.asyncio
 @mock.patch("discord.File")
-async def test_send_weather_default_location(file, clazz, session, context):
+async def test_send_weather_default_location(file, weather, session, context):
     session.get.return_value = SavedLocation(id=1, name="city", country="country", city_id=123, latitude=1, longitude=2)
-    clazz.weather_message = stub_weather_msg
-    clazz.weather_graph = stub_weather_gph
-    await clazz.send_weather(context, None, None, None)
+    weather.weather_message = stub_weather_msg
+    weather.weather_graph = stub_weather_gph
+    await weather.send_weather(context, None, None, None)
     context.send.assert_called_once_with("weather", file=file.return_value)
 
 
 @pytest.mark.asyncio
 @mock.patch("discord.File")
-async def test_send_weather_provided_location(file, clazz, context):
+async def test_send_weather_provided_location(file, weather, context):
     async def mock_search_location(context, *args):
         return make_city("city")
 
-    clazz.search_location = mock_search_location
-    clazz.weather_message = stub_weather_msg
-    clazz.weather_graph = stub_weather_gph
-    await clazz.send_weather(context, "city", None, None)
+    weather.search_location = mock_search_location
+    weather.weather_message = stub_weather_msg
+    weather.weather_graph = stub_weather_gph
+    await weather.send_weather(context, "city", None, None)
     context.send.assert_called_once_with("weather", file=file.return_value)
 
 
-def test_weather_message_no_precipitation(clazz):
-    message = clazz.weather_message(make_city("city"), one_call())
+def test_weather_message_no_precipitation(weather):
+    message = weather.weather_message(make_city("city"), one_call())
     assert "In city, it is currently 3°C, but feels like 5°C." in message
     assert "Today, you can expect a high of 10°C (feeling like 15°C) and a low of 0°C (feeling like -10°C)." in message
 
 
-def test_weather_message_rainy(clazz):
-    message = clazz.weather_message(make_city("city"), one_call("rainy"))
+def test_weather_message_rainy(weather):
+    message = weather.weather_message(make_city("city"), one_call("rainy"))
     assert "In city, it is currently 3°C with rainy, but feels like 5°C." in message
     assert "Today, you can expect a high of 10°C (feeling like 15°C) and a low of 0°C (feeling like -10°C), with a 50% chance of 2mm of rain." in message
 
 
-def test_weather_message_snowy(clazz):
-    message = clazz.weather_message(make_city("city"), one_call("snowy"))
+def test_weather_message_snowy(weather):
+    message = weather.weather_message(make_city("city"), one_call("snowy"))
     assert "In city, it is currently 3°C with snowy, but feels like 5°C." in message
     assert "Today, you can expect a high of 10°C (feeling like 15°C) and a low of 0°C (feeling like -10°C), with a 50% chance of 3cm of snow." in message
 
 
-def test_weather_message_umbrella(clazz):
-    message = clazz.weather_message(make_city("city"), one_call("rain", 100))
+def test_weather_message_umbrella(weather):
+    message = weather.weather_message(make_city("city"), one_call("rain", 100))
     assert "Don't forget your umbrella!" in message
 
 
-def test_weather_message_shovel(clazz):
-    message = clazz.weather_message(make_city("city"), one_call("snowy", 100))
+def test_weather_message_shovel(weather):
+    message = weather.weather_message(make_city("city"), one_call("snowy", 100))
     assert "Time to hire the old man down the street to shovel the driveway." in message
 
 
-def test_weather_message_cold(clazz):
-    message = clazz.weather_message(make_city("city"), one_call(max_temp=-11))
+def test_weather_message_cold(weather):
+    message = weather.weather_message(make_city("city"), one_call(max_temp=-11))
     assert "Thankfully, I don't feel the cold." in message
 
 
-def test_weather_message_hot(clazz):
-    message = clazz.weather_message(make_city("city"), one_call(max_temp=40))
+def test_weather_message_hot(weather):
+    message = weather.weather_message(make_city("city"), one_call(max_temp=40))
     assert "I might need to take a break today, it hot." in message
 
 
@@ -223,9 +223,9 @@ def plt(plot):
 
 
 @mock.patch("timezonefinder.TimezoneFinder")
-def test_weather_graph_for_code_coverage(tzfinder, clazz, plt):
+def test_weather_graph_for_code_coverage(tzfinder, weather, plt):
     tzfinder.return_value.timezone_at.return_value = "US/Eastern"
-    img = clazz.weather_graph(make_city("city"), one_call())
+    img = weather.weather_graph(make_city("city"), one_call())
     assert img == "weather.png"
 
 
@@ -238,11 +238,11 @@ def stub_weather_gph(city, weather):
 
 
 def one_call(status=None, prec_chance=49.9, max_temp=10):
-    wea = weather(status, prec_chance, max_temp)
+    wea = make_weather(status, prec_chance, max_temp)
     return OneCall(lat=1, lon=1, timezone="UTC", current=wea, forecast_daily=[wea], forecast_hourly=[wea] * 24)
 
 
-def weather(status, prec_chance, max_temp):
+def make_weather(status, prec_chance, max_temp):
     return pyowmWeather(
         reference_time=0,
         sunset_time=0,

--- a/tests/fixtures/discord/channel.py
+++ b/tests/fixtures/discord/channel.py
@@ -6,7 +6,7 @@ import pytest
 def skip_if_private_channel(channel, dm_channel, group_channel):
     """Skips the test if `channel` is a private channel (a DM or group channel).
     Meant to be used when the `channel` fixture is also used."""
-    if channel is dm_channel or channel is group_channel:
+    if channel.type in [discord.ChannelType.private, discord.ChannelType.group]:
         pytest.skip("test requires a non-private discord channel")
 
 

--- a/wiki/Commands.md
+++ b/wiki/Commands.md
@@ -14,6 +14,7 @@ Command Overview
 | `!mock` | converts text into MoCkInG tExT |
 | [`!roll`](#dice) | rolls Dungeons and Dragons style dice |
 | `!coin` | flips a coin. in real life |
+| [`!yolo`](#yolo-pull-requests) | list open pull requests in this repo |
 | `!help` | gives a link to this wiki |
 | `!duck` | gives a link to this repo |
 
@@ -74,3 +75,7 @@ DuckBot will roll Dungeons and Dragons style dice for you. See [dice syntax](htt
 > Human: !roll 1d20  
 > DuckBot: Rolls: 1d20 (3)  
 > Total: 3
+
+Yolo Pull Requests
+------------------
+DuckBot will list the open pull requests when the bot owner or one of the repository owners uses the `!yolo` command. DuckBot will eventually learn how to merge his own pull requests, or something.


### PR DESCRIPTION
##### Summary 

Related to #39.

This is part 1 of the issue, allowing the bot owner and repo admins to do `!yolo` to get a list of the open pull requests. It includes links to the pull requests as well as checks status. Part 2 will eventually allow people to merge pull requests, but it's not there yet. For results, check the #duckbutt channel in the beta server.

FYI @Chippers255 the token being used in production is your github access token, the same one used to write to the wiki on push.

Part of this change is some minor cleanup in the weather class and tests. I changed the openweather client method to be a `@property`, and changed the name of a local `clazz` fixture to be `weather`. Intellij was confused when I had two `clazz` fixtures (I made one in the tests here at first).  
Also a minor performance improvement to the `skip_if_private_channel` fixture, which now doesn't create other channels and instead uses the `channel.type` property.

##### Checklist

* [x] this is a source code change
  * [x] run `isort . && black .` in the repository root
  * [x] run `pytest` in the repository root
  * [x] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  * [x] update the wiki documentation if necessary
* [ ] or, this is **not** a source code change
