### PR TITLE
remove `pip --editable` since it is now the default; pin flake8 to <4

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -31,7 +31,7 @@ jobs:
         python -m venv --clear venv
         . ./venv/bin/activate
         pip install --upgrade pip setuptools wheel
-        pip install --editable .[dev]
+        pip install .[dev]
     - name: Run Tests
       run: |
         . venv/bin/activate

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Before running DuckBot, you want to create a virtualenv to develop in. DuckBot r
 python3.8 -m venv --clear --prompt duckbot venv
 . venv/bin/activate
 pip install --upgrade pip setuptools wheel
-pip install --editable .[dev]
+pip install .[dev]
 ```
 
 The `dev` extras will also install development dependencies, like `pytest`. The installation commands should be run whenever you merge from upstream.

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ if __name__ == "__main__":
                 "pytest",
                 "pytest-asyncio",
                 "pytest-xdist[psutil]",
-                "flake8",
+                "flake8<4",
                 "black",
                 "flake8-black",
                 "isort",


### PR DESCRIPTION
##### Summary 

Had some weird build errors recently, turns out [pip updated recently](https://pip.pypa.io/en/stable/news/#v21-3) to 21.3, which semi-broke our `--editable` build. Not sure what else happened, but it also upgraded our flake8 to 4.0, which breaks `flake8-isort`, so I opted to pin the version to <4.

For testing, I ran all the commands in the readme, as well as running stuff like `python -m duckbot`. The docker image isn't affected as it never used `--editable` anyways.

##### Checklist

* [ ] this is a source code change
  * [ ] run `isort . && black .` in the repository root
  * [ ] run `pytest` in the repository root
  * [ ] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  * [ ] update the wiki documentation if necessary
* [x] or, this is **not** a source code change
