### PR TITLE
change style for mergeability and up to date-ness in `!yolo`

### DIFF
--- a/duckbot/cogs/github/yolo_merge.py
+++ b/duckbot/cogs/github/yolo_merge.py
@@ -6,6 +6,10 @@ import github
 from discord.ext import commands
 from github.PullRequest import PullRequest
 
+CHECK_PASSED = ":white_check_mark:"
+CHECK_FAILED = ":x:"
+CHECK_PENDING = ":coffee:"
+
 
 async def is_repository_admin(context: commands.Context):
     """Disallow !yolo to be used outside of a server, and only allow the bot owner or
@@ -52,16 +56,17 @@ class YoloMerge(commands.Cog):
             lines = [
                 f"[{pr.title}]({pr.html_url})",
                 f"{pr.changed_files} changed file{'s' if pr.changed_files > 1 else ''}; +{pr.additions} -{pr.deletions}",
-                f"Pull is{'' if pr.mergeable else ' NOT'} mergeable. It is currently {pr.mergeable_state}.",
+                f"mergeable {CHECK_PASSED if pr.mergeable else CHECK_FAILED}",
+                f"up to date {CHECK_PASSED if pr.mergeable_state == 'blocked' else CHECK_FAILED}",
             ]
             commit = pr.get_commits().reversed[0]
             for suite in commit.get_check_suites():
                 completed = suite.status == "completed"
                 success = suite.conclusion == "success"
                 if completed:
-                    result = ":white_check_mark:" if success else ":x:"
+                    result = CHECK_PASSED if success else CHECK_FAILED
                 else:
-                    result = ":coffee:"
+                    result = CHECK_PENDING
                 lines.append(f"**{suite.app.name}** {result}")
             embed.add_field(name=f"#{pr.number}", value="\n".join(lines))
         return embed

--- a/tests/cogs/github/yolo_merge_test.py
+++ b/tests/cogs/github/yolo_merge_test.py
@@ -77,6 +77,7 @@ def make_pull_request(number: int, mergeable=True) -> Tuple[github.PullRequest.P
     pull.additions = 50
     pull.deletions = 25
     pull.mergeable = mergeable
+    pull.mergeable_status = "blocked" if mergeable else "behind"
     commits = MockPaginatedList([commit(), commit(), commit()])
     pull.get_commits.return_value = commits
     last_commit = commits[-1]
@@ -94,7 +95,8 @@ def make_pull_request(number: int, mergeable=True) -> Tuple[github.PullRequest.P
     lines = [
         f"[{pull.title}]({pull.html_url})",
         "10 changed files; +50 -25",
-        f"Pull is mergeable. It is currently {pull.mergeable_state}." if mergeable else f"Pull is NOT mergeable. It is currently {pull.mergeable_state}.",
+        "mergeable :white_check_mark:" if pull.mergeable else "mergeable :x:",
+        "up to date :white_check_mark:" if pull.mergeable_state == "blocked" else "up to date :x:",
         f"**{success_check.app.name}** :white_check_mark:",
         f"**{failure_check.app.name}** :x:",
         f"**{incomplete_check.app.name}** :coffee:",


### PR DESCRIPTION
##### Summary 

Changed "Pull is mergeable. It is currently behind." to "mergeable ✅  up to date ❌ " to sorta match the pull request checks results. See `#duckbutt` channel in the beta server for an example.

##### Checklist

* [x] this is a source code change
  * [x] run `isort . && black .` in the repository root
  * [x] run `pytest` in the repository root
  * [x] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  * [x] update the wiki documentation if necessary
* [ ] or, this is **not** a source code change
