### PR TITLE
use SecureString for tokens

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -114,9 +114,9 @@ jobs:
         OPENWEATHER_TOKEN: ${{ secrets.OPENWEATHER_TOKEN }}
         GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
       run: |
-        aws ssm put-parameter --name /duckbot/token/discord --type String --value "$DISCORD_TOKEN" --overwrite
-        aws ssm put-parameter --name /duckbot/token/openweather --type String --value "$OPENWEATHER_TOKEN" --overwrite
-        aws ssm put-parameter --name /duckbot/token/github --type String --value "$GITHUB_TOKEN" --overwrite
+        aws ssm put-parameter --name /duckbot/token/discord --type SecureString --value "$DISCORD_TOKEN" --overwrite
+        aws ssm put-parameter --name /duckbot/token/openweather --type SecureString --value "$OPENWEATHER_TOKEN" --overwrite
+        aws ssm put-parameter --name /duckbot/token/github --type SecureString --value "$GITHUB_TOKEN" --overwrite
 
     - name: Update CloudFormation Stack
       uses: aws-actions/aws-cloudformation-github-deploy@v1


### PR DESCRIPTION
##### Summary 

Update the parameter store secrets to use `SecureString` instead of just `String`. This keeps the secrets encrypted using an aws provided key.

Tested by running the command locally, then I knocked over the ECS task to force a new one to start up. I ran `!weather` (the parameter I modified) and the bot responded successfully.

##### Checklist

* [ ] this is a source code change
  * [ ] run `isort . && black .` in the repository root
  * [ ] run `pytest` in the repository root
  * [ ] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  * [ ] update the wiki documentation if necessary
* [x] or, this is **not** a source code change
