### PR TITLE
move pull request summary logic to a function

### DIFF
--- a/duckbot/cogs/github/yolo_merge.py
+++ b/duckbot/cogs/github/yolo_merge.py
@@ -53,16 +53,20 @@ class YoloMerge(commands.Cog):
     def as_embed(self, prs: List[PullRequest]) -> discord.Embed:
         embed = discord.Embed()
         for pr in prs:
-            embed.add_field(name=f"#{pr.number}", value=self.get_pr_summary(pr))
+            embed.add_field(name=f"#{pr.number}", value="\n".join(self.get_pr_summary_lines(pr)))
         return embed
 
-    def get_pr_summary(self, pr: PullRequest) -> str:
+    def get_pr_summary_lines(self, pr: PullRequest) -> List[str]:
         lines = [
             f"[{pr.title}]({pr.html_url})",
             f"{pr.changed_files} changed file{'s' if pr.changed_files > 1 else ''}; +{pr.additions} -{pr.deletions}",
             f"mergeable {CHECK_PASSED if pr.mergeable else CHECK_FAILED}",
             f"up to date {CHECK_PASSED if pr.mergeable_state == 'blocked' else CHECK_FAILED}",
         ]
+        return lines + self.get_checks_summary_lines(pr)
+
+    def get_checks_summary_lines(self, pr: PullRequest) -> List[str]:
+        lines = []
         commit = pr.get_commits().reversed[0]
         for suite in commit.get_check_suites():
             completed = suite.status == "completed"
@@ -72,4 +76,4 @@ class YoloMerge(commands.Cog):
             else:
                 result = CHECK_PENDING
             lines.append(f"**{suite.app.name}** {result}")
-        return "\n".join(lines)
+        return lines

--- a/duckbot/cogs/github/yolo_merge.py
+++ b/duckbot/cogs/github/yolo_merge.py
@@ -53,20 +53,23 @@ class YoloMerge(commands.Cog):
     def as_embed(self, prs: List[PullRequest]) -> discord.Embed:
         embed = discord.Embed()
         for pr in prs:
-            lines = [
-                f"[{pr.title}]({pr.html_url})",
-                f"{pr.changed_files} changed file{'s' if pr.changed_files > 1 else ''}; +{pr.additions} -{pr.deletions}",
-                f"mergeable {CHECK_PASSED if pr.mergeable else CHECK_FAILED}",
-                f"up to date {CHECK_PASSED if pr.mergeable_state == 'blocked' else CHECK_FAILED}",
-            ]
-            commit = pr.get_commits().reversed[0]
-            for suite in commit.get_check_suites():
-                completed = suite.status == "completed"
-                success = suite.conclusion == "success"
-                if completed:
-                    result = CHECK_PASSED if success else CHECK_FAILED
-                else:
-                    result = CHECK_PENDING
-                lines.append(f"**{suite.app.name}** {result}")
-            embed.add_field(name=f"#{pr.number}", value="\n".join(lines))
+            embed.add_field(name=f"#{pr.number}", value=self.get_pr_summary(pr))
         return embed
+
+    def get_pr_summary(self, pr: PullRequest) -> str:
+        lines = [
+            f"[{pr.title}]({pr.html_url})",
+            f"{pr.changed_files} changed file{'s' if pr.changed_files > 1 else ''}; +{pr.additions} -{pr.deletions}",
+            f"mergeable {CHECK_PASSED if pr.mergeable else CHECK_FAILED}",
+            f"up to date {CHECK_PASSED if pr.mergeable_state == 'blocked' else CHECK_FAILED}",
+        ]
+        commit = pr.get_commits().reversed[0]
+        for suite in commit.get_check_suites():
+            completed = suite.status == "completed"
+            success = suite.conclusion == "success"
+            if completed:
+                result = CHECK_PASSED if success else CHECK_FAILED
+            else:
+                result = CHECK_PENDING
+            lines.append(f"**{suite.app.name}** {result}")
+        return "\n".join(lines)


### PR DESCRIPTION
##### Summary 

Sonarcloud was [complaining](https://sonarcloud.io/project/issues?id=duck-dynasty_duckbot&open=AXx_qj7oEAAxm6J8d524&resolved=false&types=CODE_SMELL) about the complexity of this function, so I decided to just copy/paste the logic to a few new functions. No logic changes.

##### Checklist

* [x] this is a source code change
  * [x] run `isort . && black .` in the repository root
  * [x] run `pytest` in the repository root
  * [x] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  * [x] update the wiki documentation if necessary
* [ ] or, this is **not** a source code change
