### PR TITLE
restore --editable because pip is confusing

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -23,7 +23,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: venv
-        key: ${{ env.pythonLocation }}-venv-${{ hashFiles('setup.py') }}
+        key: ${{ env.pythonLocation }}-env-${{ hashFiles('setup.py') }}
 
     - name: Install Packages
       if: steps.venv.outputs.cache-hit != 'true'

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -11,12 +11,15 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.8.10', '3.8.11', '3.8.12']
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python 3.8
       uses: actions/setup-python@v2
       with:
-        python-version: '3.8'
+        python-version: ${{ matrix.python-version }}
 
     - name: Setup Virtual Environment Cache
       id: venv

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -31,7 +31,7 @@ jobs:
         python -m venv --clear venv
         . ./venv/bin/activate
         pip install --upgrade pip setuptools wheel
-        pip install .[dev]
+        pip install --editable .[dev]
     - name: Run Tests
       run: |
         . venv/bin/activate

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Before running DuckBot, you want to create a virtualenv to develop in. DuckBot r
 python3.8 -m venv --clear --prompt duckbot venv
 . venv/bin/activate
 pip install --upgrade pip setuptools wheel
-pip install .[dev]
+pip install --editable .[dev]
 ```
 
 The `dev` extras will also install development dependencies, like `pytest`. The installation commands should be run whenever you merge from upstream.


### PR DESCRIPTION
##### Summary 

Recently removed `--editable` (https://github.com/duck-dynasty/duckbot/pull/347) because docs made it sound like it was the default. Apparently that's not the case, we still need it to avoid installing our package into our own `venv`.

I also changed the github actions cache key for our virtual env used by the tests. The new key will make whatever is currently cached never be accessed, so we'll recreate it. Whatever is there now may conflict with code changes we add, so it could lead to more confusing errors.

James called it out. I DIDN'T LISTEN.

##### Checklist

* [ ] this is a source code change
  * [ ] run `isort . && black .` in the repository root
  * [ ] run `pytest` in the repository root
  * [ ] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  * [ ] update the wiki documentation if necessary
* [x] or, this is **not** a source code change
