### PR TITLE
restore `--editable` because pip is confusing

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -23,7 +23,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: venv
-        key: ${{ env.pythonLocation }}-venv-${{ hashFiles('setup.py') }}
+        key: ${{ env.pythonLocation }}-env-${{ hashFiles('setup.py') }}
 
     - name: Install Packages
       if: steps.venv.outputs.cache-hit != 'true'

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -11,12 +11,15 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.8.10', '3.8.11', '3.8.12']
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python 3.8
       uses: actions/setup-python@v2
       with:
-        python-version: '3.8'
+        python-version: ${{ matrix.python-version }}
 
     - name: Setup Virtual Environment Cache
       id: venv

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -11,15 +11,12 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ['3.8.10', '3.8.11', '3.8.12']
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python 3.8
       uses: actions/setup-python@v2
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: '3.8'
 
     - name: Setup Virtual Environment Cache
       id: venv

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -23,7 +23,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: venv
-        key: ${{ env.pythonLocation }}-env-${{ hashFiles('setup.py') }}
+        key: ${{ env.pythonLocation }}-venv-${{ hashFiles('setup.py', 'pyproject.toml') }}
 
     - name: Install Packages
       if: steps.venv.outputs.cache-hit != 'true'

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -31,7 +31,7 @@ jobs:
         python -m venv --clear venv
         . ./venv/bin/activate
         pip install --upgrade pip setuptools wheel
-        pip install .[dev]
+        pip install --editable .[dev]
     - name: Run Tests
       run: |
         . venv/bin/activate

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Before running DuckBot, you want to create a virtualenv to develop in. DuckBot r
 python3.8 -m venv --clear --prompt duckbot venv
 . venv/bin/activate
 pip install --upgrade pip setuptools wheel
-pip install .[dev]
+pip install --editable .[dev]
 ```
 
 The `dev` extras will also install development dependencies, like `pytest`. The installation commands should be run whenever you merge from upstream.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "wheel"]
+requires = ["setuptools", "wheel", "nltk>=3.6,<4", "textblob<1"]
 build-backend = "setuptools.build_meta"
 
 [tool.black]

--- a/setup.py
+++ b/setup.py
@@ -38,10 +38,6 @@ if __name__ == "__main__":
         python_requires=">=3.8",
         packages=find_packages(),
         cmdclass={"develop": PostDevelop, "install": PostInstall},
-        setup_requires=[
-            "nltk>=3.6,<4",
-            "textblob<1",
-        ],
         install_requires=[
             "discord.py[voice] @ git+https://github.com/Rapptz/discord.py",
             "beautifulsoup4",
@@ -52,8 +48,8 @@ if __name__ == "__main__":
             "psycopg2",
             "sqlalchemy>=1.4,<2",
             "d20>=1.1.0,<2",
-            "nltk>=3.6,<4",
-            "textblob<1",
+            "nltk>=3.6,<4",  # also in pyproject.toml, required for setup script above
+            "textblob<1",  # also in pyproject.toml, required for setup script above
             "pyfiglet<1",
             "matplotlib>=3.4,<4",
             "PyGithub>=1.55,<2",


### PR DESCRIPTION
##### Summary 

Re-open of https://github.com/duck-dynasty/duckbot/pull/354

Found some context in https://github.com/pypa/pip/issues/7778 -- seems `setup_requires` is deprecated, I guess behaviour for it changed in recent updates. We use it to install nltk corpora during the `pip install`, which means nltk has to be available during the build (ie, the setup). The way to do that now is via `build-system.requires` in `pyproject.toml`. A little annoying, dependencies are split across files, but not sure what else I can do.

##### Checklist

* [ ] this is a source code change
  * [ ] run `isort . && black .` in the repository root
  * [ ] run `pytest` in the repository root
  * [ ] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  * [ ] update the wiki documentation if necessary
* [x] or, this is **not** a source code change
