### PR TITLE
notify when office hours goes live

### DIFF
--- a/duckbot/cogs/games/__init__.py
+++ b/duckbot/cogs/games/__init__.py
@@ -2,6 +2,7 @@ from .aoe import AgeOfEmpires
 from .coin_flip import CoinFlip
 from .dice import Dice
 from .discord_activity import DiscordActivity
+from .office_hours import OfficeHours
 
 
 def setup(bot):
@@ -9,3 +10,4 @@ def setup(bot):
     bot.add_cog(AgeOfEmpires(bot))
     bot.add_cog(CoinFlip(bot))
     bot.add_cog(DiscordActivity(bot))
+    bot.add_cog(OfficeHours(bot))

--- a/duckbot/cogs/games/office_hours.py
+++ b/duckbot/cogs/games/office_hours.py
@@ -24,7 +24,7 @@ class OfficeHours(commands.Cog):
             self.streaming = streaming
             if streaming:
                 channel = get(self.bot.get_all_channels(), guild__name="Friends Chat", name="general", type=ChannelType.text)
-                await channel.send("Office Hours have started!\nhttps://www.twitch.tv/conlabx")
+                await channel.send("\"Office Hours\" have started!\nhttps://www.twitch.tv/conlabx")
                 self.check_if_streaming_loop.change_interval(hours=12.0)  # avoid polling for a while
             else:
                 self.check_if_streaming_loop.change_interval(minutes=15.0)  # stream stopped, restart polling

--- a/duckbot/cogs/games/office_hours.py
+++ b/duckbot/cogs/games/office_hours.py
@@ -24,7 +24,7 @@ class OfficeHours(commands.Cog):
             self.streaming = streaming
             if streaming:
                 channel = get(self.bot.get_all_channels(), guild__name="Friends Chat", name="general", type=ChannelType.text)
-                await channel.send("\"Office Hours\" have started!\nhttps://www.twitch.tv/conlabx")
+                await channel.send('"Office Hours" have started!\nhttps://www.twitch.tv/conlabx')
                 self.check_if_streaming_loop.change_interval(hours=12.0)  # avoid polling for a while
             else:
                 self.check_if_streaming_loop.change_interval(minutes=15.0)  # stream stopped, restart polling

--- a/duckbot/cogs/games/office_hours.py
+++ b/duckbot/cogs/games/office_hours.py
@@ -1,0 +1,31 @@
+from discord.ext import commands, tasks
+import requests
+from discord.utils import get
+from discord import ChannelType
+
+
+class OfficeHours(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+        self.streaming = False
+        self.check_if_streaming_loop.start()
+
+    def cog_unload(self):
+        self.check_if_streaming_loop.cancel()
+
+    @tasks.loop(minutes=5.0)
+    async def check_if_streaming_loop(self):
+        await self.check_if_streaming()
+
+    async def check_if_streaming(self):
+        page = requests.get("https://www.twitch.tv/conlabx").content.decode("utf-8")
+        streaming = "isLiveBroadcast" in page
+        if streaming != self.streaming:
+            self.streaming = streaming
+            if streaming:
+                channel = get(self.bot.get_all_channels(), guild__name="Friends Chat", name="general", type=ChannelType.text)
+                await channel.send("Office Hours have started!\nhttps://www.twitch.tv/conlabx")
+
+    @check_if_streaming_loop.before_loop
+    async def before_loop(self):
+        await self.bot.wait_until_ready()

--- a/duckbot/cogs/games/office_hours.py
+++ b/duckbot/cogs/games/office_hours.py
@@ -1,7 +1,7 @@
-from discord.ext import commands, tasks
 import requests
-from discord.utils import get
 from discord import ChannelType
+from discord.ext import commands, tasks
+from discord.utils import get
 
 
 class OfficeHours(commands.Cog):
@@ -13,7 +13,7 @@ class OfficeHours(commands.Cog):
     def cog_unload(self):
         self.check_if_streaming_loop.cancel()
 
-    @tasks.loop(minutes=5.0)
+    @tasks.loop(minutes=15.0)
     async def check_if_streaming_loop(self):
         await self.check_if_streaming()
 
@@ -25,6 +25,9 @@ class OfficeHours(commands.Cog):
             if streaming:
                 channel = get(self.bot.get_all_channels(), guild__name="Friends Chat", name="general", type=ChannelType.text)
                 await channel.send("Office Hours have started!\nhttps://www.twitch.tv/conlabx")
+                self.check_if_streaming_loop.change_interval(hours=12.0)  # avoid polling for a while
+            else:
+                self.check_if_streaming_loop.change_interval(minutes=15.0)  # stream stopped, restart polling
 
     @check_if_streaming_loop.before_loop
     async def before_loop(self):

--- a/tests/cogs/games/office_hours_test.py
+++ b/tests/cogs/games/office_hours_test.py
@@ -36,7 +36,7 @@ async def test_check_if_streaming_stream_started(get, bot, general_channel):
     clazz = OfficeHours(bot)
     clazz.streaming = False
     await clazz.check_if_streaming()
-    general_channel.send.assert_called_once_with("Office Hours have started!\nhttps://www.twitch.tv/conlabx")
+    general_channel.send.assert_called_once_with("\"Office Hours\" have started!\nhttps://www.twitch.tv/conlabx")
     assert clazz.streaming
     clazz.check_if_streaming_loop.change_interval.assert_called_once_with(hours=12.0)
 

--- a/tests/cogs/games/office_hours_test.py
+++ b/tests/cogs/games/office_hours_test.py
@@ -1,0 +1,45 @@
+from unittest import mock
+
+import pytest
+import requests
+
+from duckbot.cogs.games import OfficeHours
+
+
+@mock.patch("requests.Response")
+def response(r, content: str) -> requests.Response:
+    r.content = content.encode()
+    return r
+
+
+@pytest.mark.asyncio
+async def test_before_loop_waits_for_bot(bot):
+    clazz = OfficeHours(bot)
+    await clazz.before_loop()
+    bot.wait_until_ready.assert_called()
+
+
+def test_cog_unload_cancels_task(bot):
+    clazz = OfficeHours(bot)
+    clazz.cog_unload()
+    clazz.check_if_streaming_loop.cancel.assert_called()
+
+
+@pytest.mark.asyncio
+@mock.patch("requests.get", return_value=response("isLiveBroadcast"))
+async def test_check_if_streaming_stream_started(get, bot, general_channel):
+    clazz = OfficeHours(bot)
+    clazz.streaming = False
+    await clazz.check_if_streaming()
+    general_channel.send.assert_called_once_with("Office Hours have started!\nhttps://www.twitch.tv/conlabx")
+    assert clazz.streaming
+
+
+@pytest.mark.asyncio
+@mock.patch("requests.get", return_value="isLiveBroadcast")
+async def test_check_if_streaming_stream_ongoing(get, bot, general_channel):
+    clazz = OfficeHours(bot)
+    clazz.streaming = True
+    await clazz.check_if_streaming()
+    general_channel.send.assert_not_called()
+    assert clazz.streaming

--- a/tests/cogs/games/office_hours_test.py
+++ b/tests/cogs/games/office_hours_test.py
@@ -36,7 +36,7 @@ async def test_check_if_streaming_stream_started(get, bot, general_channel):
     clazz = OfficeHours(bot)
     clazz.streaming = False
     await clazz.check_if_streaming()
-    general_channel.send.assert_called_once_with("\"Office Hours\" have started!\nhttps://www.twitch.tv/conlabx")
+    general_channel.send.assert_called_once_with('"Office Hours" have started!\nhttps://www.twitch.tv/conlabx')
     assert clazz.streaming
     clazz.check_if_streaming_loop.change_interval.assert_called_once_with(hours=12.0)
 

--- a/tests/cogs/games/office_hours_test.py
+++ b/tests/cogs/games/office_hours_test.py
@@ -7,7 +7,12 @@ from duckbot.cogs.games import OfficeHours
 
 
 @mock.patch("requests.Response")
-def response(r, content: str) -> requests.Response:
+def mock_response(r) -> requests.Response:
+    return r
+
+
+def response(content) -> requests.Response:
+    r = mock_response()
     r.content = content.encode()
     return r
 
@@ -33,13 +38,35 @@ async def test_check_if_streaming_stream_started(get, bot, general_channel):
     await clazz.check_if_streaming()
     general_channel.send.assert_called_once_with("Office Hours have started!\nhttps://www.twitch.tv/conlabx")
     assert clazz.streaming
+    clazz.check_if_streaming_loop.change_interval.assert_called_once_with(hours=12.0)
 
 
 @pytest.mark.asyncio
-@mock.patch("requests.get", return_value="isLiveBroadcast")
+@mock.patch("requests.get", return_value=response("isLiveBroadcast"))
 async def test_check_if_streaming_stream_ongoing(get, bot, general_channel):
     clazz = OfficeHours(bot)
     clazz.streaming = True
     await clazz.check_if_streaming()
     general_channel.send.assert_not_called()
     assert clazz.streaming
+
+
+@pytest.mark.asyncio
+@mock.patch("requests.get", return_value=response("bruh"))
+async def test_check_if_streaming_stream_not_started(get, bot, general_channel):
+    clazz = OfficeHours(bot)
+    clazz.streaming = False
+    await clazz.check_if_streaming()
+    general_channel.send.assert_not_called()
+    assert not clazz.streaming
+
+
+@pytest.mark.asyncio
+@mock.patch("requests.get", return_value=response("bruh"))
+async def test_check_if_streaming_stream_stopped(get, bot, general_channel):
+    clazz = OfficeHours(bot)
+    clazz.streaming = True
+    await clazz.check_if_streaming()
+    general_channel.send.assert_not_called()
+    assert not clazz.streaming
+    clazz.check_if_streaming_loop.change_interval.assert_called_once_with(minutes=15.0)

--- a/tests/cogs/games/setup_test.py
+++ b/tests/cogs/games/setup_test.py
@@ -1,6 +1,6 @@
 import pytest
 
-from duckbot.cogs.games import AgeOfEmpires, CoinFlip, Dice, DiscordActivity
+from duckbot.cogs.games import AgeOfEmpires, CoinFlip, Dice, DiscordActivity, OfficeHours
 from duckbot.cogs.games import setup as extension_setup
 from tests.discord_test_ext import assert_cog_added_of_type
 
@@ -12,3 +12,4 @@ async def test_setup(bot_spy):
     assert_cog_added_of_type(bot_spy, AgeOfEmpires)
     assert_cog_added_of_type(bot_spy, CoinFlip)
     assert_cog_added_of_type(bot_spy, DiscordActivity)
+    assert_cog_added_of_type(bot_spy, OfficeHours)

--- a/tests/cogs/games/setup_test.py
+++ b/tests/cogs/games/setup_test.py
@@ -1,6 +1,12 @@
 import pytest
 
-from duckbot.cogs.games import AgeOfEmpires, CoinFlip, Dice, DiscordActivity, OfficeHours
+from duckbot.cogs.games import (
+    AgeOfEmpires,
+    CoinFlip,
+    Dice,
+    DiscordActivity,
+    OfficeHours,
+)
 from duckbot.cogs.games import setup as extension_setup
 from tests.discord_test_ext import assert_cog_added_of_type
 

--- a/wiki/Events.md
+++ b/wiki/Events.md
@@ -45,6 +45,10 @@ Josip Broz Tito
 ---------------
 Heeeyyyy Mr. Tito! DuckBot will react to messages containing the custom `:tito:` emoji with all the country flags of the formally Yugoslavian countries. DuckBot will do the same when someone reacts with `:tito:`.
 
+Office Hours
+------------
+Don't forget to stop by and ask questions! DuckBot will notify the general channel when office hours start, brother.
+
 Typo Correction
 ---------------
 DuckBot will attempt to correct typos a user's previous message when they send _fuck_. For example,


### PR DESCRIPTION
##### Summary 

Fixes #278

The twitch api is a bit of a pain, so I opted to just poll the stream page. Nice answer on [stackoverflow](https://stackoverflow.com/a/67969583) is the solution I used. For fun (since AWS $$$), I also reduce the polling once we find office hours have started.

##### Checklist

* [x] this is a source code change
  * [x] run `isort . && black .` in the repository root
  * [x] run `pytest` in the repository root
  * [x] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  * [x] update the wiki documentation if necessary
* [ ] or, this is **not** a source code change
