### PR TITLE
fix method call name in recipe

### DIFF
--- a/duckbot/cogs/recipe/recipe.py
+++ b/duckbot/cogs/recipe/recipe.py
@@ -76,4 +76,4 @@ class Recipe(commands.Cog):
     @commands.command(name="recipe")
     async def recipe_command(self, context, *, search_term: str = ""):
         async with context.typing():
-            await self.__recipe(context, search_term)
+            await self.recipe(context, search_term)


### PR DESCRIPTION
##### Summary 

Fix bug introduced in https://github.com/duck-dynasty/duckbot/pull/362 ; logs give:
```
The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/opt/venv/lib/python3.8/site-packages/discord/ext/commands/bot.py", line 994, in invoke
    await ctx.command.invoke(ctx)
  File "/opt/venv/lib/python3.8/site-packages/discord/ext/commands/core.py", line 894, in invoke
    await injected(*ctx.args, **ctx.kwargs)
  File "/opt/venv/lib/python3.8/site-packages/discord/ext/commands/core.py", line 176, in wrapped
    raise CommandInvokeError(exc) from exc
discord.ext.commands.errors.CommandInvokeError: Command raised an exception: AttributeError: 'Recipe' object has no attribute '_Recipe__recipe'
```

I did run the recipe stuff manually while working on that change, but I guess I did it before I renamed the method and never checked again.

##### Checklist

* [x] this is a source code change
  * [x] run `isort . && black .` in the repository root
  * [x] run `pytest` in the repository root
  * [x] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  * [x] update the wiki documentation if necessary
* [ ] or, this is **not** a source code change
