### PR TITLE
add slash command context class

### DIFF
--- a/duckbot/slash/__init__.py
+++ b/duckbot/slash/__init__.py
@@ -1,1 +1,2 @@
+from .context import InteractionContext
 from .option import Option, OptionType

--- a/duckbot/slash/context.py
+++ b/duckbot/slash/context.py
@@ -1,0 +1,103 @@
+import logging
+from typing import Optional
+
+from discord import Client, Embed, File, Guild, Interaction
+from discord.ext.commands import Command
+from discord.ext.commands.view import StringView
+
+log = logging.getLogger(__name__)
+
+
+def _create_arguments_view(interaction: Interaction, command: Command) -> StringView:
+    # create option string by joining all of the arguments together, so we can delegate to discord.py
+    # note that slash commands can accept spaces in their args, whereas discord.py required "bash style quotes"
+    options = interaction.data.get("options", [])
+    parts = []
+    if options and not options[0].get("value", None):  # a command group
+        if command._discordpy_include_subcommand_name[options[0]["name"]]:
+            parts.append(options[0]["name"])
+        parts = parts + [f'"{x.get("value", "")}"' for x in options[0].get("options", [])]
+    else:
+        parts = parts + [f'"{x.get("value", "")}"' for x in options]
+    view = " ".join([x for x in parts])
+    log.debug("args string=%s", view)
+    return StringView(view)
+
+
+class InteractionContext:
+    """A slash duplication of `discord.ext.commands.Context`, meant to bridge between
+    discord.py commands and discord slash commands.
+
+    This class will have mostly the same interface as `Context`, but will call interaction
+    based discord APIs instead of traditional message based ones.
+    Fair word of warning, it is substantially trimmed down. Missing features from `Context`
+    will be added on an as-needed basis."""
+
+    def __init__(self, *, bot: Client, interaction: Interaction, command: Command):
+        self.bot = bot
+        self._interaction = interaction
+        self._command = command
+        self.invoked_with = None
+        self.invoked_parents = []
+        self.invoked_subcommand = None
+        self.subcommand_passed = None
+        self.command_failed = False
+        self.view = _create_arguments_view(interaction, command)
+        self.follow_up = False
+
+    @property
+    def interaction(self) -> Interaction:
+        return self._interaction
+
+    @property
+    def channel(self):
+        return self.interaction.channel
+
+    @property
+    def guild(self) -> Optional[Guild]:
+        return self.interaction.guild
+
+    @property
+    def author(self):
+        return self.interaction.user
+
+    @property
+    def command(self):
+        return self._command
+
+    @command.setter
+    def command(self, value):
+        self._command = value
+
+    async def send(self, content="", *, embed: Optional[Embed] = None, file: Optional[File] = None, delete_after: Optional[float] = None) -> None:
+        """Send a message as a response to an interaction. There are some restrictions to this, see `typing()`.
+
+        :param content: the message content to send
+        :param embed: embed message content to send
+        :param file: a file to upload and sent; requires `typing()` first
+        :param delete_after: does nothing, exists for interface parity with discord.py
+        :return: None
+        """
+        if self.follow_up:
+            kwargs = {"embed": embed, "file": file}
+            await self.interaction.followup.send(content, **{k: v for k, v in kwargs.items() if v})
+        else:
+            kwargs = {"embed": embed}
+            await self.interaction.response.send_message(content, **{k: v for k, v in kwargs.items() if v})
+
+    def typing(self):
+        """Triggers a "Bot is thinking..." response to the interaction. Should be used in any of the following conditions:
+        1. The command is unable to response within three seconds. The interaction token lifespan is increased to 15 minutes
+        after calling `typing()`.
+        2. The response will contain a file. Discord.py for whatever reason only allows files to be sent via webhooks, which
+        is what messages turn into after `typing()` is called.
+        3. Multiple responses will be sent. All of the `send()` calls should be wrapped in `typing()`."""
+        return self
+
+    async def __aenter__(self):
+        await self.interaction.response.defer()
+        self.follow_up = True
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return None

--- a/duckbot/slash/context.py
+++ b/duckbot/slash/context.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Optional
+from typing import List, Optional
 
 from discord import Client, Embed, File, Guild, Interaction, Message, VoiceProtocol
 from discord.ext.commands import Command
@@ -77,20 +77,21 @@ class InteractionContext:
     def command(self, value):
         self._command = value
 
-    async def send(self, content="", *, embed: Optional[Embed] = None, file: Optional[File] = None, delete_after: Optional[float] = None) -> None:
+    async def send(self, content="", *, embed: Optional[Embed] = None, embeds: Optional[List[Embed]] = None, file: Optional[File] = None, delete_after: Optional[float] = None) -> None:
         """Send a message as a response to an interaction. There are some restrictions to this, see `typing()`.
 
         :param content: the message content to send
-        :param embed: embed message content to send
+        :param embed: embed message content to send, mutually exclusive with embeds
+        :param embeds: multiple embed message contents to send, mutually exclusive with embed
         :param file: a file to upload and sent; requires `typing()` first
         :param delete_after: does nothing, exists for interface parity with discord.py
         :return: None
         """
         if self.follow_up:
-            kwargs = {"embed": embed, "file": file}
+            kwargs = {"embed": embed, "embeds": embeds, "file": file}
             await self.interaction.followup.send(content, **{k: v for k, v in kwargs.items() if v})
         else:
-            kwargs = {"embed": embed}
+            kwargs = {"embed": embed, "embeds": embeds}
             await self.interaction.response.send_message(content, **{k: v for k, v in kwargs.items() if v})
 
     def typing(self):

--- a/duckbot/slash/context.py
+++ b/duckbot/slash/context.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Optional
 
-from discord import Client, Embed, File, Guild, Interaction
+from discord import Client, Embed, File, Guild, Interaction, VoiceProtocol
 from discord.ext.commands import Command
 from discord.ext.commands.view import StringView
 
@@ -56,6 +56,10 @@ class InteractionContext:
     @property
     def guild(self) -> Optional[Guild]:
         return self.interaction.guild
+
+    @property
+    def voice_client(self) -> Optional[VoiceProtocol]:
+        return self.guild.voice_client if self.guild else None
 
     @property
     def author(self):

--- a/duckbot/slash/context.py
+++ b/duckbot/slash/context.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Optional
 
-from discord import Client, Embed, File, Guild, Interaction, VoiceProtocol
+from discord import Client, Embed, File, Guild, Interaction, Message, VoiceProtocol
 from discord.ext.commands import Command
 from discord.ext.commands.view import StringView
 
@@ -60,6 +60,10 @@ class InteractionContext:
     @property
     def voice_client(self) -> Optional[VoiceProtocol]:
         return self.guild.voice_client if self.guild else None
+
+    @property
+    def message(self) -> Optional[Message]:
+        return self.interaction.message  # discord.py context ALWAYS has a message, this is an interface mismatch
 
     @property
     def author(self):

--- a/setup.py
+++ b/setup.py
@@ -73,6 +73,7 @@ if __name__ == "__main__":
                 "pytest-sugar",
                 "pytest-icdiff",
                 "pytest-cov",
+                "pytest-lazy-fixture",
             ]
         },
     )

--- a/tests/fixtures/discord/__init__.py
+++ b/tests/fixtures/discord/__init__.py
@@ -9,7 +9,7 @@ from .channel import (
     thread,
 )
 from .command import command
-from .context import context
+from .context import command_context, context, interaction_context
 from .embed import patch_embed_equals
 from .emoji import emoji
 from .general_channel import general_channel

--- a/tests/fixtures/discord/__init__.py
+++ b/tests/fixtures/discord/__init__.py
@@ -4,6 +4,7 @@ from .channel import (
     channel,
     dm_channel,
     group_channel,
+    is_private_channel,
     skip_if_private_channel,
     text_channel,
     thread,

--- a/tests/fixtures/discord/channel.py
+++ b/tests/fixtures/discord/channel.py
@@ -3,10 +3,16 @@ import pytest
 
 
 @pytest.fixture
-def skip_if_private_channel(channel, dm_channel, group_channel):
+def is_private_channel(channel):
+    """Returns True if `channel` is a private channel (a DM or group channel), False otherwise."""
+    return channel.type in [discord.ChannelType.private, discord.ChannelType.group]
+
+
+@pytest.fixture
+def skip_if_private_channel(channel, is_private_channel):
     """Skips the test if `channel` is a private channel (a DM or group channel).
     Meant to be used when the `channel` fixture is also used."""
-    if channel.type in [discord.ChannelType.private, discord.ChannelType.group]:
+    if is_private_channel:
         pytest.skip("test requires a non-private discord channel")
 
 

--- a/tests/fixtures/discord/context.py
+++ b/tests/fixtures/discord/context.py
@@ -23,6 +23,7 @@ def interaction_context(autospec, interaction, command) -> duckbot.slash.Interac
     c = autospec.of("duckbot.slash.InteractionContext")
     c.interaction = interaction
     c.command = command
+    c.message = interaction.message
     c.channel = interaction.channel
     c.author = interaction.user
     return c

--- a/tests/fixtures/discord/context.py
+++ b/tests/fixtures/discord/context.py
@@ -1,12 +1,39 @@
+from typing import Union
+
 import discord.ext.commands
 import pytest
+from pytest_lazyfixture import lazy_fixture
+
+import duckbot.slash
 
 
 @pytest.fixture
-def context(autospec, message) -> discord.ext.commands.Context:
+def command_context(autospec, message) -> discord.ext.commands.Context:
     """Returns a context with nested properties set, for each channel type a command can be sent to."""
     c = autospec.of("discord.ext.commands.Context")
     c.message = message
     c.channel = message.channel
     c.author = message.author
     return c
+
+
+@pytest.fixture
+def interaction_context(autospec, interaction, command) -> duckbot.slash.InteractionContext:
+    """Returns an interaction context with nested properties set, for each channel type a slash command can be sent to."""
+    c = autospec.of("duckbot.slash.InteractionContext")
+    c.interaction = interaction
+    c.command = command
+    c.channel = interaction.channel
+    c.author = interaction.user
+    return c
+
+
+@pytest.fixture(
+    params=[
+        lazy_fixture(command_context.__name__),
+        lazy_fixture(interaction_context.__name__),
+    ]
+)
+def context(request) -> Union[discord.ext.commands.Context, duckbot.slash.InteractionContext]:
+    """Returns a set of discord.py command contexts and slash command contexts."""
+    return request.param

--- a/tests/fixtures/discord/context.py
+++ b/tests/fixtures/discord/context.py
@@ -20,7 +20,7 @@ def command_context(autospec, message) -> discord.ext.commands.Context:
 @pytest.fixture
 def interaction_context(autospec, interaction, command) -> duckbot.slash.InteractionContext:
     """Returns an interaction context with nested properties set, for each channel type a slash command can be sent to."""
-    c = autospec.of("duckbot.slash.InteractionContext")
+    c = autospec.of(duckbot.slash.InteractionContext)
     c.interaction = interaction
     c.command = command
     c.message = interaction.message

--- a/tests/fixtures/discord/interaction.py
+++ b/tests/fixtures/discord/interaction.py
@@ -3,15 +3,10 @@ import pytest
 
 
 @pytest.fixture
-def interaction(request, autospec, channel) -> discord.Interaction:
+def interaction(request, autospec, message) -> discord.Interaction:
     """Returns an interaction with nested properties set, for each channel type a command can be sent to."""
     i = autospec.of("discord.Interaction")
-    """Returns a message with nested properties set, for each channel type a message can be sent to."""
-    i.channel = channel
-    if channel.type in [discord.ChannelType.private, discord.ChannelType.group]:
-        i.guild = None
-    else:
-        i.guild = request.getfixturevalue("guild")
-    author = "user" if channel.type in [discord.ChannelType.private, discord.ChannelType.group] else "member"
-    i.user = request.getfixturevalue(author)
+    i.channel = message.channel
+    i.guild = message.guild
+    i.user = message.author
     return i

--- a/tests/fixtures/discord/interaction.py
+++ b/tests/fixtures/discord/interaction.py
@@ -3,7 +3,7 @@ import pytest
 
 
 @pytest.fixture
-def interaction(request, autospec, message) -> discord.Interaction:
+def interaction(autospec, message) -> discord.Interaction:
     """Returns an interaction with nested properties set, for each channel type a command can be sent to."""
     i = autospec.of("discord.Interaction")
     i.message = message

--- a/tests/fixtures/discord/interaction.py
+++ b/tests/fixtures/discord/interaction.py
@@ -8,6 +8,10 @@ def interaction(request, autospec, channel) -> discord.Interaction:
     i = autospec.of("discord.Interaction")
     """Returns a message with nested properties set, for each channel type a message can be sent to."""
     i.channel = channel
+    if channel.type in [discord.ChannelType.private, discord.ChannelType.group]:
+        i.guild = None
+    else:
+        i.guild = request.getfixturevalue("guild")
     author = "user" if channel.type in [discord.ChannelType.private, discord.ChannelType.group] else "member"
     i.user = request.getfixturevalue(author)
     return i

--- a/tests/fixtures/discord/interaction.py
+++ b/tests/fixtures/discord/interaction.py
@@ -6,6 +6,7 @@ import pytest
 def interaction(request, autospec, message) -> discord.Interaction:
     """Returns an interaction with nested properties set, for each channel type a command can be sent to."""
     i = autospec.of("discord.Interaction")
+    i.message = message
     i.channel = message.channel
     i.guild = message.guild
     i.user = message.author

--- a/tests/fixtures/discord/message.py
+++ b/tests/fixtures/discord/message.py
@@ -3,10 +3,9 @@ import pytest
 
 
 @pytest.fixture
-def message(request, raw_message, channel) -> discord.Message:
+def message(request, raw_message, channel, is_private_channel) -> discord.Message:
     """Returns a message with nested properties set, for each channel type a message can be sent to."""
     raw_message.channel = channel
-    is_private_channel = channel.type in [discord.ChannelType.private, discord.ChannelType.group]
     raw_message.guild = None if is_private_channel else request.getfixturevalue("guild")
     raw_message.author = request.getfixturevalue("user" if is_private_channel else "member")
     return raw_message

--- a/tests/fixtures/discord/message.py
+++ b/tests/fixtures/discord/message.py
@@ -6,8 +6,9 @@ import pytest
 def message(request, raw_message, channel) -> discord.Message:
     """Returns a message with nested properties set, for each channel type a message can be sent to."""
     raw_message.channel = channel
-    author = "user" if channel.type in [discord.ChannelType.private, discord.ChannelType.group] else "member"
-    raw_message.author = request.getfixturevalue(author)
+    is_private_channel = channel.type in [discord.ChannelType.private, discord.ChannelType.group]
+    raw_message.guild = None if is_private_channel else request.getfixturevalue("guild")
+    raw_message.author = request.getfixturevalue("user" if is_private_channel else "member")
     return raw_message
 
 

--- a/tests/slash/context_test.py
+++ b/tests/slash/context_test.py
@@ -9,13 +9,13 @@ from duckbot.slash import InteractionContext
 @pytest.fixture
 def interaction_response(autospec) -> discord.InteractionResponse:
     """Returns a mock interaction response."""
-    return autospec.of("discord.InteractionResponse")
+    return autospec.of(discord.InteractionResponse)
 
 
 @pytest.fixture
 def interaction_followup(autospec) -> discord.Webhook:
     """Returns a mock interaction followup webhook."""
-    return autospec.of("discord.Webhook")
+    return autospec.of(discord.Webhook)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/slash/context_test.py
+++ b/tests/slash/context_test.py
@@ -81,6 +81,10 @@ def test_voice_client_getter(bot, interaction, command):
         assert voice is None
 
 
+def test_message_getter(bot, interaction, command):
+    assert InteractionContext(bot=bot, interaction=interaction, command=command).message == interaction.message
+
+
 def test_author_getter(bot, interaction, command):
     assert InteractionContext(bot=bot, interaction=interaction, command=command).author == interaction.user
 

--- a/tests/slash/context_test.py
+++ b/tests/slash/context_test.py
@@ -73,6 +73,14 @@ def test_guild_getter(bot, interaction, command):
     assert InteractionContext(bot=bot, interaction=interaction, command=command).guild == interaction.guild
 
 
+def test_voice_client_getter(bot, interaction, command):
+    voice = InteractionContext(bot=bot, interaction=interaction, command=command).voice_client
+    if interaction.guild:
+        assert voice is interaction.guild.voice_client
+    else:
+        assert voice is None
+
+
 def test_author_getter(bot, interaction, command):
     assert InteractionContext(bot=bot, interaction=interaction, command=command).author == interaction.user
 

--- a/tests/slash/context_test.py
+++ b/tests/slash/context_test.py
@@ -117,10 +117,26 @@ async def test_send_response_embed_only(embed, bot, interaction, command):
 
 @pytest.mark.asyncio
 @mock.patch("discord.Embed")
+async def test_send_response_embeds_only(embed, bot, interaction, command):
+    clazz = InteractionContext(bot=bot, interaction=interaction, command=command)
+    await clazz.send(embeds=[embed])
+    interaction.response.send_message.assert_called_once_with("", embeds=[embed])
+
+
+@pytest.mark.asyncio
+@mock.patch("discord.Embed")
 async def test_send_response_message_and_embed(embed, bot, interaction, command):
     clazz = InteractionContext(bot=bot, interaction=interaction, command=command)
     await clazz.send("hi", embed=embed)
     interaction.response.send_message.assert_called_once_with("hi", embed=embed)
+
+
+@pytest.mark.asyncio
+@mock.patch("discord.Embed")
+async def test_send_response_message_and_embeds(embed, bot, interaction, command):
+    clazz = InteractionContext(bot=bot, interaction=interaction, command=command)
+    await clazz.send("hi", embeds=[embed])
+    interaction.response.send_message.assert_called_once_with("hi", embeds=[embed])
 
 
 @pytest.mark.asyncio
@@ -153,12 +169,23 @@ async def test_send_follow_up_file_only(file, bot, interaction, command):
 @pytest.mark.asyncio
 @mock.patch("discord.Embed")
 @mock.patch("discord.File")
-async def test_send_follow_up_all_args(file, embed, bot, interaction, command):
+async def test_send_follow_up_all_args_embed(file, embed, bot, interaction, command):
     clazz = InteractionContext(bot=bot, interaction=interaction, command=command)
     async with clazz.typing():
         await clazz.send("hi", embed=embed, file=file)
     interaction.response.defer.assert_called_once()
     interaction.followup.send.assert_called_once_with("hi", embed=embed, file=file)
+
+
+@pytest.mark.asyncio
+@mock.patch("discord.Embed")
+@mock.patch("discord.File")
+async def test_send_follow_up_all_args_embeds(file, embed, bot, interaction, command):
+    clazz = InteractionContext(bot=bot, interaction=interaction, command=command)
+    async with clazz.typing():
+        await clazz.send("hi", embeds=[embed], file=file)
+    interaction.response.defer.assert_called_once()
+    interaction.followup.send.assert_called_once_with("hi", embeds=[embed], file=file)
 
 
 @pytest.mark.asyncio

--- a/tests/slash/context_test.py
+++ b/tests/slash/context_test.py
@@ -1,0 +1,167 @@
+from unittest import mock
+
+import discord
+import pytest
+
+from duckbot.slash import InteractionContext
+
+
+@pytest.fixture
+def interaction_response(autospec) -> discord.InteractionResponse:
+    """Returns a mock interaction response."""
+    return autospec.of("discord.InteractionResponse")
+
+
+@pytest.fixture
+def interaction_followup(autospec) -> discord.Webhook:
+    """Returns a mock interaction followup webhook."""
+    return autospec.of("discord.Webhook")
+
+
+@pytest.fixture(autouse=True)
+def attach_interaction_responses(interaction, interaction_response, interaction_followup):
+    interaction.response = interaction_response
+    interaction.followup = interaction_followup
+
+
+def test_ctor_no_interaction_options(bot, interaction, command):
+    interaction.data = {}
+    clazz = InteractionContext(bot=bot, interaction=interaction, command=command)
+    assert clazz.view.buffer == ""
+    assert_class_setup(clazz, bot)
+
+
+def test_ctor_empty_interaction_options(bot, interaction, command):
+    interaction.data = {"options": []}
+    clazz = InteractionContext(bot=bot, interaction=interaction, command=command)
+    assert clazz.view.buffer == ""
+    assert_class_setup(clazz, bot)
+
+
+def test_ctor_command_options(bot, interaction, command):
+    interaction.data = {"options": [{"name": "first", "value": "one"}, {"name": "second", "value": "two"}]}
+    clazz = InteractionContext(bot=bot, interaction=interaction, command=command)
+    assert clazz.view.buffer == '"one" "two"'
+    assert_class_setup(clazz, bot)
+
+
+def test_ctor_subcommand_options(bot, interaction, command):
+    command._discordpy_include_subcommand_name = {"sub": True}
+    interaction.data = {"options": [{"name": "sub", "options": [{"name": "first", "value": "one"}, {"name": "second", "value": "two"}]}]}
+    clazz = InteractionContext(bot=bot, interaction=interaction, command=command)
+    assert clazz.view.buffer == 'sub "one" "two"'
+    assert_class_setup(clazz, bot)
+
+
+def test_ctor_subcommand_options_no_subcommand_name(bot, interaction, command):
+    command._discordpy_include_subcommand_name = {"sub": False}
+    interaction.data = {"options": [{"name": "sub", "options": [{"name": "first", "value": "one"}, {"name": "second", "value": "two"}]}]}
+    clazz = InteractionContext(bot=bot, interaction=interaction, command=command)
+    assert clazz.view.buffer == '"one" "two"'
+    assert_class_setup(clazz, bot)
+
+
+def test_interaction_getter(bot, interaction, command):
+    assert InteractionContext(bot=bot, interaction=interaction, command=command).interaction == interaction
+
+
+def test_channel_getter(bot, interaction, command):
+    assert InteractionContext(bot=bot, interaction=interaction, command=command).channel == interaction.channel
+
+
+def test_guild_getter(bot, interaction, command):
+    assert InteractionContext(bot=bot, interaction=interaction, command=command).guild == interaction.guild
+
+
+def test_author_getter(bot, interaction, command):
+    assert InteractionContext(bot=bot, interaction=interaction, command=command).author == interaction.user
+
+
+def test_command_getter(bot, interaction, command):
+    assert InteractionContext(bot=bot, interaction=interaction, command=command).command == command
+
+
+def test_command_setter(bot, interaction, command):
+    clazz = InteractionContext(bot=bot, interaction=interaction, command=command)
+    new_command = mock.Mock()
+    clazz.command = new_command
+    assert clazz.command == new_command
+
+
+@pytest.mark.asyncio
+async def test_send_response_message_only(bot, interaction, command):
+    clazz = InteractionContext(bot=bot, interaction=interaction, command=command)
+    await clazz.send("hi")
+    interaction.response.send_message.assert_called_once_with("hi")
+
+
+@pytest.mark.asyncio
+@mock.patch("discord.Embed")
+async def test_send_response_embed_only(embed, bot, interaction, command):
+    clazz = InteractionContext(bot=bot, interaction=interaction, command=command)
+    await clazz.send(embed=embed)
+    interaction.response.send_message.assert_called_once_with("", embed=embed)
+
+
+@pytest.mark.asyncio
+@mock.patch("discord.Embed")
+async def test_send_response_message_and_embed(embed, bot, interaction, command):
+    clazz = InteractionContext(bot=bot, interaction=interaction, command=command)
+    await clazz.send("hi", embed=embed)
+    interaction.response.send_message.assert_called_once_with("hi", embed=embed)
+
+
+@pytest.mark.asyncio
+@mock.patch("discord.File")
+async def test_send_response_file_ignored(file, bot, interaction, command):
+    clazz = InteractionContext(bot=bot, interaction=interaction, command=command)
+    await clazz.send(file=file)
+    interaction.response.send_message.assert_called_once_with("")
+
+
+@pytest.mark.asyncio
+async def test_send_follow_up_message_only(bot, interaction, command):
+    clazz = InteractionContext(bot=bot, interaction=interaction, command=command)
+    async with clazz.typing():
+        await clazz.send("hi")
+    interaction.response.defer.assert_called_once()
+    interaction.followup.send.assert_called_once_with("hi")
+
+
+@pytest.mark.asyncio
+@mock.patch("discord.File")
+async def test_send_follow_up_file_only(file, bot, interaction, command):
+    clazz = InteractionContext(bot=bot, interaction=interaction, command=command)
+    async with clazz.typing():
+        await clazz.send(file=file)
+    interaction.response.defer.assert_called_once()
+    interaction.followup.send.assert_called_once_with("", file=file)
+
+
+@pytest.mark.asyncio
+@mock.patch("discord.Embed")
+@mock.patch("discord.File")
+async def test_send_follow_up_all_args(file, embed, bot, interaction, command):
+    clazz = InteractionContext(bot=bot, interaction=interaction, command=command)
+    async with clazz.typing():
+        await clazz.send("hi", embed=embed, file=file)
+    interaction.response.defer.assert_called_once()
+    interaction.followup.send.assert_called_once_with("hi", embed=embed, file=file)
+
+
+@pytest.mark.asyncio
+async def test_typing_starts_follow_up(bot, interaction, command):
+    clazz = InteractionContext(bot=bot, interaction=interaction, command=command)
+    async with clazz.typing():
+        pass
+    assert clazz.follow_up
+    interaction.response.defer.assert_called_once()
+
+
+def assert_class_setup(clazz, bot):
+    assert clazz.bot == bot
+    assert clazz.invoked_with is None
+    assert clazz.invoked_parents == []
+    assert clazz.invoked_subcommand is None
+    assert clazz.command_failed is False
+    assert clazz.follow_up is False


### PR DESCRIPTION
##### Summary 

I'm currently working on slash commands (#200) and have working code, but the diff is pretty large. I'm splitting it up into several smaller changes so it'll be easier to review, and it'll hopefully allow for a better overall understanding on how I've chosen to integrate slash commands into discord.py, which doesn't really support it out of the box.

This change adds a slash command _context_ class, which is meant to mimic the discord.py [context](https://discordpy.readthedocs.io/en/stable/ext/commands/api.html#context) class, but change some methods (like `send`, etc) to interact with the slash commands APIs instead of message ones.

For tests, I changed the existing `context` fixture to now provide instances of the discord.py context and the new slash context introduced here. Autospec'd mocks allow us to hopefully capture the interface differences between the two contexts before we actually run any real code, since they'll throw when you access non-existent properties. As of this change, every command we have is also being tested as if it is a slash command, we just don't have any slash commands registered yet.

##### Checklist

* [x] this is a source code change
  * [x] run `isort . && black .` in the repository root
  * [x] run `pytest` in the repository root
  * [x] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  * [x] update the wiki documentation if necessary
* [ ] or, this is **not** a source code change
