### PR TITLE
Revert "move dnd day to wednesday (#296)"

### DIFF
--- a/duckbot/cogs/announce_day/phrases.py
+++ b/duckbot/cogs/announce_day/phrases.py
@@ -17,6 +17,7 @@ days = {
         "names": [
             "Tyr's day",
             "Tuesday",
+            "Dndndndndndndnd",
             "Taco Tuesday",
         ],
         "templates": [
@@ -31,7 +32,6 @@ days = {
             "Wednesday, my dudes",
             "hump day",
             "Ness' wedding day",
-            "Dndndndndndndnd",
             "https://www.youtube.com/watch?v=du-TY1GUFGk",
         ],
         "templates": [


### PR DESCRIPTION
##### Summary 

This reverts commit 48e89d9d1a4ec4788c78bbd4fc649a89160c4193.

Old PR #296  -- dnd  is back on tuesdays.

##### Checklist

* [x] this is a source code change
  * [x] run `isort . && black .` in the repository root
  * [x] run `pytest` in the repository root
  * [x] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  * [x] update the wiki documentation if necessary
* [ ] or, this is **not** a source code change
