### PR TITLE
remove restart_policy conditions in docker compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,6 @@ services:
       mode: replicated
       replicas: 1
       restart_policy:
-        condition: any
         window: 10s
       update_config:
         failure_action: rollback
@@ -48,7 +47,6 @@ services:
       mode: replicated
       replicas: 1
       restart_policy:
-        condition: any
         window: 10s
       update_config:
         failure_action: rollback


### PR DESCRIPTION
##### Summary 

Not sure why, but docker started to complain about the `any` for these, even though it's a [valid value](https://docs.docker.com/compose/compose-file/compose-file-v3/#restart_policy). Docs also say `any` is the default, so just removing it fixes.

Error I was getting:
```
Error response from daemon: invalid restart policy 'any'
```
After removing, the stack starts up.

##### Checklist

* [ ] this is a source code change
  * [ ] run `isort . && black .` in the repository root
  * [ ] run `pytest` in the repository root
  * [ ] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  * [ ] update the wiki documentation if necessary
* [x] or, this is **not** a source code change
