### PR TITLE
publish logs to cloudwatch

### DIFF
--- a/.aws/cloudformation.template.yml
+++ b/.aws/cloudformation.template.yml
@@ -48,6 +48,12 @@ Resources:
           Timeout: 10
           Retries: 3
           StartPeriod: 30
+        LogConfiguration:
+          LogDriver: awslogs
+          Options:
+            "awslogs-region": !Ref AWS::Region
+            "awslogs-group": !Ref LogGroup
+            "awslogs-stream-prefix": ecs
       - Name: postgres
         Image: "postgres:13.2"
         Essential: false
@@ -67,6 +73,12 @@ Resources:
           Interval: 30
           Timeout: 5
           Retries: 3
+        LogConfiguration:
+          LogDriver: awslogs
+          Options:
+            "awslogs-region": !Ref AWS::Region
+            "awslogs-group": !Ref LogGroup
+            "awslogs-stream-prefix": ecs
           StartPeriod: 30
       Volumes:
       - Name: duckbot_dbdata
@@ -112,6 +124,12 @@ Resources:
         Fn::Sub: |
           #!/bin/bash -xe
           echo ECS_CLUSTER=${Cluster} >> /etc/ecs/ecs.config
+
+  LogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: duckbot
+      RetentionInDays: 30
 
   TaskExecutionRole:
     Type: AWS::IAM::Role


### PR DESCRIPTION
##### Summary 

Fixes https://github.com/duck-dynasty/duckbot/issues/227. Sentry is apparently free but requires a lot more setup. Plus this puts all the logs in one place.

The `awslogs` driver captures stdout and stderr, which thankfully all logs already write to (byproduct of changes in https://github.com/duck-dynasty/duckbot/pull/381).

I tested manually by creating a new task definition revision in prod (I know, sue me). Logs successfully published to cloudwatch. So huzzah. I'm not 100% on if the yml is valid, but eh. We'll see.

##### Checklist

* [ ] this is a source code change
  * [ ] run `isort . && black .` in the repository root
  * [ ] run `pytest` in the repository root
  * [ ] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  * [ ] update the wiki documentation if necessary
* [x] or, this is **not** a source code change
