### PR TITLE
respond to slash command events

### DIFF
--- a/duckbot/slash/__init__.py
+++ b/duckbot/slash/__init__.py
@@ -1,3 +1,8 @@
 from .context import InteractionContext
 from .option import Option, OptionType
 from .slash_command_decorator import slash_command
+from .slash_command_handler import SlashCommandHandler
+
+
+def setup(bot):
+    bot.add_cog(SlashCommandHandler(bot))

--- a/duckbot/slash/slash_command_handler.py
+++ b/duckbot/slash/slash_command_handler.py
@@ -1,0 +1,22 @@
+import logging
+
+from discord import Interaction
+from discord.ext.commands import Bot, Cog
+
+from .context import InteractionContext
+from .slash_command_decorator import get_slash_command
+
+log = logging.getLogger(__name__)
+
+
+class SlashCommandHandler(Cog):
+    def __init__(self, bot: Bot):
+        self.bot = bot
+
+    @Cog.listener("on_interaction")
+    async def handle_slash_interaction(self, interaction: Interaction):
+        command = next((c for c in self.bot.commands if get_slash_command(c) and c.name == interaction.data["name"]), None)
+        if command:
+            log.info("delegating /%s to command %s%s ; data=%s", command.name, self.bot.command_prefix, command, interaction.data)
+            context = InteractionContext(bot=self.bot, interaction=interaction, command=command)
+            await command.invoke(context)

--- a/tests/slash/setup_test.py
+++ b/tests/slash/setup_test.py
@@ -1,0 +1,8 @@
+from duckbot.slash import SlashCommandHandler
+from duckbot.slash import setup as extension_setup
+from tests.discord_test_ext import assert_cog_added_of_type
+
+
+def test_setup(bot_spy):
+    extension_setup(bot_spy)
+    assert_cog_added_of_type(bot_spy, SlashCommandHandler)

--- a/tests/slash/slash_command_handler_test.py
+++ b/tests/slash/slash_command_handler_test.py
@@ -1,0 +1,35 @@
+import pytest
+
+from duckbot.slash import SlashCommandHandler, slash_command
+
+
+@pytest.mark.asyncio
+async def test_handle_slash_interaction_calls_command_invoke(bot, interaction, command):
+    bot.commands = [command]
+    slash_command()(command)
+    command.name = "command_name"
+    interaction.data = {"name": "command_name"}
+    clazz = SlashCommandHandler(bot)
+    await clazz.handle_slash_interaction(interaction)
+    command.invoke.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_handle_slash_interaction_no_matching_command(bot, interaction, command):
+    bot.commands = [command]
+    slash_command()(command)
+    command.name = "some_other_command"
+    interaction.data = {"name": "command_name"}
+    clazz = SlashCommandHandler(bot)
+    await clazz.handle_slash_interaction(interaction)
+    command.invoke.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_handle_slash_interaction_only_invokes_slashes(bot, interaction, command):
+    bot.commands = [command]
+    command.name = "command_name"
+    interaction.data = {"name": "command_name"}
+    clazz = SlashCommandHandler(bot)
+    await clazz.handle_slash_interaction(interaction)
+    command.invoke.assert_not_called()


### PR DESCRIPTION
##### Summary 

I'm currently working on slash commands (#200) and have working code, but the diff is pretty large. I'm splitting it up into several smaller changes so it'll be easier to review, and it'll hopefully allow for a better overall understanding on how I've chosen to integrate slash commands into discord.py, which doesn't really support it out of the box.

Everything starting to come together now! This change will actually listen for slash command events, ie a discord _interaction_. Thankfully, discord.py actually implemented the event for it already, so it's as simple as `@listener("on_interaction")`. In the listener, we search through all the discord.py `@command`s in the bot which are also `@slash_command`s (https://github.com/duck-dynasty/duckbot/pull/379) to find the command that has the same name as the slash command interaction that was sent in. If we find one, we create a slash commands context class (https://github.com/duck-dynasty/duckbot/pull/368) and delegate to the discord.py command we found, but passing in the slash context. The slash context is _mostly_ the same interface as the discord.py context, but interacts with the slash command discord APIs instead. It's not total feature parity, but it covers everything we currently do.

After this, we still need to actually register our slash commands with discord, so one more PR to get the logic fully working. Then it's small PRs to add the `@slash_command` decorators to our existing commands.

##### Checklist

* [x] this is a source code change
  * [x] run `isort . && black .` in the repository root
  * [x] run `pytest` in the repository root
  * [x] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  * [x] update the wiki documentation if necessary
* [ ] or, this is **not** a source code change
