### PR TITLE
register slash commands with discord on startup

### DIFF
--- a/duckbot/__main__.py
+++ b/duckbot/__main__.py
@@ -22,6 +22,7 @@ import duckbot.cogs.tito
 import duckbot.cogs.weather
 import duckbot.health
 import duckbot.logs
+import duckbot.slash
 import duckbot.util.connection_test
 from duckbot import DuckBot
 
@@ -33,6 +34,7 @@ def run_duckbot(bot: commands.Bot):
         bot.load_extension(duckbot.util.connection_test.__name__)
 
     bot.load_extension(duckbot.health.__name__)
+    bot.load_extension(duckbot.slash.__name__)
 
     bot.load_extension(duckbot.cogs.duck.__name__)
     bot.load_extension(duckbot.cogs.dogs.__name__)

--- a/duckbot/slash/slash_command_handler.py
+++ b/duckbot/slash/slash_command_handler.py
@@ -32,7 +32,7 @@ class SlashCommandHandler(Cog):
             log.info("registering slash commands in guild=%s", guild.id)
             await self.bot.http.bulk_upsert_guild_commands(self.bot.user.id, guild.id, slash_json)
 
-    def get_commands_registered_to_bot(self):
+    def get_commands_registered_to_bot(self) -> List[SlashCommand]:
         slash_commands: List[SlashCommand] = []
         for command in (c for c in self.bot.walk_commands() if get_slash_command(c)):
             slash = get_slash_command(command)

--- a/duckbot/slash/slash_command_handler.py
+++ b/duckbot/slash/slash_command_handler.py
@@ -1,9 +1,11 @@
 import logging
+from typing import List
 
 from discord import Interaction
 from discord.ext.commands import Bot, Cog
 
 from .context import InteractionContext
+from .slash_command import SlashCommand
 from .slash_command_decorator import get_slash_command
 
 log = logging.getLogger(__name__)
@@ -20,3 +22,26 @@ class SlashCommandHandler(Cog):
             log.info("delegating /%s to command %s%s ; data=%s", command.name, self.bot.command_prefix, command, interaction.data)
             context = InteractionContext(bot=self.bot, interaction=interaction, command=command)
             await command.invoke(context)
+
+    @Cog.listener("on_ready")
+    async def upsert_slash_commands(self):
+        slash_json = [x.to_dict() for x in self.get_commands_registered_to_bot()]
+        log.info("registered slash commands=%s", slash_json)
+        await self.bot.http.bulk_upsert_global_commands(self.bot.user.id, slash_json)
+        for guild in self.bot.guilds:
+            log.info("registering slash commands in guild=%s", guild.id)
+            await self.bot.http.bulk_upsert_guild_commands(self.bot.user.id, guild.id, slash_json)
+
+    def get_commands_registered_to_bot(self):
+        slash_commands: List[SlashCommand] = []
+        for command in (c for c in self.bot.walk_commands() if get_slash_command(c)):
+            slash = get_slash_command(command)
+            # check for a command with the same basename was already registered
+            # if a command group exists, we need to merge options in order to create the top-level
+            # slash command only; each @slash_command is the sub-command in those cases
+            group = [x for x in slash_commands if x.name == slash.name]
+            if group:
+                group[0].append_options(slash.options)  # keep only the existing command to form the top-level one
+            else:
+                slash_commands.append(slash)
+        return slash_commands

--- a/tests/slash/slash_command_handler_test.py
+++ b/tests/slash/slash_command_handler_test.py
@@ -39,7 +39,7 @@ async def test_handle_slash_interaction_only_invokes_slashes(bot, interaction, c
 async def test_upsert_slash_commands_no_commands(bot, http, guild):
     bot.walk_commands.return_value = []
     bot.guilds = [guild]
-    clazz = SlashCommandPatch(bot)
+    clazz = SlashCommandHandler(bot)
     await clazz.upsert_slash_commands()
     bot.http.bulk_upsert_global_commands.assert_called_once_with(bot.user.id, [])
     bot.http.bulk_upsert_guild_commands.assert_called_once_with(bot.user.id, guild.id, [])
@@ -50,7 +50,7 @@ async def test_upsert_slash_commands_create_commands(bot, http, guild, command):
     create_slash_command(command, "command_name")
     bot.walk_commands.return_value = [command]
     bot.guilds = [guild]
-    clazz = SlashCommandPatch(bot)
+    clazz = SlashCommandHandler(bot)
     await clazz.upsert_slash_commands()
     bot.http.bulk_upsert_global_commands.assert_called_once_with(bot.user.id, [command.slash_ext.to_dict()])
     bot.http.bulk_upsert_guild_commands.assert_called_once_with(bot.user.id, guild.id, [command.slash_ext.to_dict()])
@@ -61,7 +61,7 @@ async def test_upsert_slash_commands_create_subcommand(bot, http, guild, command
     create_slash_command(command, "command_name", name="name", root="root", options=[Option(name="opt")])
     bot.walk_commands.return_value = [command]
     bot.guilds = [guild]
-    clazz = SlashCommandPatch(bot)
+    clazz = SlashCommandHandler(bot)
     await clazz.upsert_slash_commands()
     bot.http.bulk_upsert_global_commands.assert_called_once_with(bot.user.id, [command.slash_ext.to_dict()])
     bot.http.bulk_upsert_guild_commands.assert_called_once_with(bot.user.id, guild.id, [command.slash_ext.to_dict()])
@@ -76,7 +76,7 @@ async def test_upsert_slash_commands_create_subcommand_group(bot, http, guild, c
     expected.append_options(command2.slash_ext.options)
     bot.walk_commands.return_value = [command, command2]
     bot.guilds = [guild]
-    clazz = SlashCommandPatch(bot)
+    clazz = SlashCommandHandler(bot)
     await clazz.upsert_slash_commands()
     bot.http.bulk_upsert_global_commands.assert_called_once_with(bot.user.id, [expected.to_dict()])
     bot.http.bulk_upsert_guild_commands.assert_called_once_with(bot.user.id, guild.id, [expected.to_dict()])

--- a/tests/slash/slash_command_handler_test.py
+++ b/tests/slash/slash_command_handler_test.py
@@ -1,6 +1,6 @@
 import pytest
 
-from duckbot.slash import SlashCommandHandler, slash_command
+from duckbot.slash import Option, SlashCommandHandler, slash_command
 
 
 @pytest.mark.asyncio
@@ -33,3 +33,56 @@ async def test_handle_slash_interaction_only_invokes_slashes(bot, interaction, c
     clazz = SlashCommandHandler(bot)
     await clazz.handle_slash_interaction(interaction)
     command.invoke.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_upsert_slash_commands_no_commands(bot, http, guild):
+    bot.walk_commands.return_value = []
+    bot.guilds = [guild]
+    clazz = SlashCommandPatch(bot)
+    await clazz.upsert_slash_commands()
+    bot.http.bulk_upsert_global_commands.assert_called_once_with(bot.user.id, [])
+    bot.http.bulk_upsert_guild_commands.assert_called_once_with(bot.user.id, guild.id, [])
+
+
+@pytest.mark.asyncio
+async def test_upsert_slash_commands_create_commands(bot, http, guild, command):
+    create_slash_command(command, "command_name")
+    bot.walk_commands.return_value = [command]
+    bot.guilds = [guild]
+    clazz = SlashCommandPatch(bot)
+    await clazz.upsert_slash_commands()
+    bot.http.bulk_upsert_global_commands.assert_called_once_with(bot.user.id, [command.slash_ext.to_dict()])
+    bot.http.bulk_upsert_guild_commands.assert_called_once_with(bot.user.id, guild.id, [command.slash_ext.to_dict()])
+
+
+@pytest.mark.asyncio
+async def test_upsert_slash_commands_create_subcommand(bot, http, guild, command):
+    create_slash_command(command, "command_name", name="name", root="root", options=[Option(name="opt")])
+    bot.walk_commands.return_value = [command]
+    bot.guilds = [guild]
+    clazz = SlashCommandPatch(bot)
+    await clazz.upsert_slash_commands()
+    bot.http.bulk_upsert_global_commands.assert_called_once_with(bot.user.id, [command.slash_ext.to_dict()])
+    bot.http.bulk_upsert_guild_commands.assert_called_once_with(bot.user.id, guild.id, [command.slash_ext.to_dict()])
+
+
+@pytest.mark.asyncio
+async def test_upsert_slash_commands_create_subcommand_group(bot, http, guild, command, autospec):
+    command2 = autospec.of("discord.ext.commands.Command")
+    create_slash_command(command, "first", name="1", root="root", options=[Option(name="1")])
+    create_slash_command(command2, "second", name="2", root="root", options=[Option(name="2")])
+    expected = command.slash_ext
+    expected.append_options(command2.slash_ext.options)
+    bot.walk_commands.return_value = [command, command2]
+    bot.guilds = [guild]
+    clazz = SlashCommandPatch(bot)
+    await clazz.upsert_slash_commands()
+    bot.http.bulk_upsert_global_commands.assert_called_once_with(bot.user.id, [expected.to_dict()])
+    bot.http.bulk_upsert_guild_commands.assert_called_once_with(bot.user.id, guild.id, [expected.to_dict()])
+
+
+def create_slash_command(command, command_name, **kwargs):
+    command.name = command_name
+    command.description = f"description for {command_name}"
+    slash_command(**kwargs)(command)


### PR DESCRIPTION
##### Summary 

Yo. Basically the last bit of #200. The only thing left after this is to mark existing commands as `@slash_command`s. And also #369 so duckbot can actually use slash commands.

The bulk upsert method is basically a force put, it creates, updates and deletes slash commands.

##### Checklist

* [x] this is a source code change
  * [x] run `isort . && black .` in the repository root
  * [x] run `pytest` in the repository root
  * [x] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  * [x] update the wiki documentation if necessary
* [ ] or, this is **not** a source code change
