### PR TITLE
:children_crossing: mark `/eightball` as a slash command

### DIFF
--- a/duckbot/cogs/fortune/eightball.py
+++ b/duckbot/cogs/fortune/eightball.py
@@ -4,6 +4,8 @@ import random
 from discord import Colour, Embed
 from discord.ext import commands
 
+from duckbot.slash import Option, slash_command
+
 from .eightball_phrases import joke_phrases, phrases
 
 
@@ -11,7 +13,8 @@ class EightBall(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
 
-    @commands.command(name="eightball", aliases=["8ball"])
+    @slash_command(options=[Option(name="question", description="The question to ask the magic 8 ball.")])
+    @commands.command(name="eightball", aliases=["8ball"], description="Ask the magic 8 ball a question!")
     async def eightball_command(self, context, *, question: str = None):
         await self.eightball(context, question)
 


### PR DESCRIPTION
##### Summary 

Simple example usage for `@slash_command`, marking the `!eightball` command as a slash command as well. The command has a single... optional... option, which you can see in the `@slash_command` line. Options default to optional and string type. I added to the command description, which shows up in the discord client when you hit `/`.

I'm not totally sure what personality the commands description language should have. On one hand, I want it to be funny ('cause why not), on the other, I do want it to be descriptive and clear. Share your thoughts.

Note, this doesn't actually do anything with merging https://github.com/duck-dynasty/duckbot/pull/388

##### Checklist

* [x] this is a source code change
  * [x] run `isort . && black .` in the repository root
  * [x] run `pytest` in the repository root
  * [x] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  * [x] update the wiki documentation if necessary
* [ ] or, this is **not** a source code change
