### PR TITLE
🐛 fix `/eightball` args ending with quotes

### DIFF
--- a/duckbot/cogs/fortune/eightball.py
+++ b/duckbot/cogs/fortune/eightball.py
@@ -15,7 +15,7 @@ class EightBall(commands.Cog):
 
     @slash_command(options=[Option(name="question", description="The question to ask the magic 8 ball.")])
     @commands.command(name="eightball", aliases=["8ball"], description="Ask the magic 8 ball a question!")
-    async def eightball_command(self, context, *, question: str = None):
+    async def eightball_command(self, context, question: str = None):
         await self.eightball(context, question)
 
     async def eightball(self, context: commands.Context, question: str):

--- a/duckbot/cogs/fortune/eightball.py
+++ b/duckbot/cogs/fortune/eightball.py
@@ -15,7 +15,7 @@ class EightBall(commands.Cog):
 
     @slash_command(options=[Option(name="question", description="The question to ask the magic 8 ball.")])
     @commands.command(name="eightball", aliases=["8ball"], description="Ask the magic 8 ball a question!")
-    async def eightball_command(self, context, question: str = None):
+    async def eightball_command(self, context, *, question: str = None):
         await self.eightball(context, question)
 
     async def eightball(self, context: commands.Context, question: str):

--- a/duckbot/logs/logging.py
+++ b/duckbot/logs/logging.py
@@ -26,7 +26,7 @@ class Logging(commands.Cog):
             level=logging.INFO,
             format="%(asctime)s:%(levelname)s:%(name)s: %(message)s",
             handlers=[
-                logging.handlers.RotatingFileHandler(filename=os.path.join(LOGS_DIRECTORY, "duck.log"), mode="a", maxBytes=256000, backupCount=10),
+                logging.handlers.RotatingFileHandler(filename=os.path.join(LOGS_DIRECTORY, "duck.log"), encoding="utf-8", mode="a", maxBytes=256000, backupCount=10),
                 logging.StreamHandler(),  # logs to stderr
             ],
         )

--- a/duckbot/slash/context.py
+++ b/duckbot/slash/context.py
@@ -19,7 +19,9 @@ def _create_arguments_view(interaction: Interaction, command: Command) -> String
         parts = parts + [f'｢{x.get("value", "")}｣' for x in options[0].get("options", [])]
     else:
         parts = parts + [f'｢{x.get("value", "")}｣' for x in options]
-    view = " ".join([x for x in parts])
+
+    # remove wrapping quotes if there's only one arg
+    view = " ".join(parts)[1:-1] if len(parts) == 1 else " ".join(parts)
     log.debug("args string=%s", view)
     return StringView(view)
 

--- a/duckbot/slash/context.py
+++ b/duckbot/slash/context.py
@@ -16,9 +16,9 @@ def _create_arguments_view(interaction: Interaction, command: Command) -> String
     if options and not options[0].get("value", None):  # a command group
         if command._discordpy_include_subcommand_name[options[0]["name"]]:
             parts.append(options[0]["name"])
-        parts = parts + [f'"{x.get("value", "")}"' for x in options[0].get("options", [])]
+        parts = parts + [f'｢{x.get("value", "")}｣' for x in options[0].get("options", [])]
     else:
-        parts = parts + [f'"{x.get("value", "")}"' for x in options]
+        parts = parts + [f'｢{x.get("value", "")}｣' for x in options]
     view = " ".join([x for x in parts])
     log.debug("args string=%s", view)
     return StringView(view)

--- a/tests/slash/context_test.py
+++ b/tests/slash/context_test.py
@@ -41,7 +41,7 @@ def test_ctor_empty_interaction_options(bot, interaction, command):
 def test_ctor_command_options(bot, interaction, command):
     interaction.data = {"options": [{"name": "first", "value": "one"}, {"name": "second", "value": "two"}]}
     clazz = InteractionContext(bot=bot, interaction=interaction, command=command)
-    assert clazz.view.buffer == '"one" "two"'
+    assert clazz.view.buffer == "｢one｣ ｢two｣"
     assert_class_setup(clazz, bot)
 
 
@@ -49,7 +49,7 @@ def test_ctor_subcommand_options(bot, interaction, command):
     command._discordpy_include_subcommand_name = {"sub": True}
     interaction.data = {"options": [{"name": "sub", "options": [{"name": "first", "value": "one"}, {"name": "second", "value": "two"}]}]}
     clazz = InteractionContext(bot=bot, interaction=interaction, command=command)
-    assert clazz.view.buffer == 'sub "one" "two"'
+    assert clazz.view.buffer == "sub ｢one｣ ｢two｣"
     assert_class_setup(clazz, bot)
 
 
@@ -57,7 +57,7 @@ def test_ctor_subcommand_options_no_subcommand_name(bot, interaction, command):
     command._discordpy_include_subcommand_name = {"sub": False}
     interaction.data = {"options": [{"name": "sub", "options": [{"name": "first", "value": "one"}, {"name": "second", "value": "two"}]}]}
     clazz = InteractionContext(bot=bot, interaction=interaction, command=command)
-    assert clazz.view.buffer == '"one" "two"'
+    assert clazz.view.buffer == "｢one｣ ｢two｣"
     assert_class_setup(clazz, bot)
 
 

--- a/tests/slash/context_test.py
+++ b/tests/slash/context_test.py
@@ -38,10 +38,25 @@ def test_ctor_empty_interaction_options(bot, interaction, command):
     assert_class_setup(clazz, bot)
 
 
+def test_ctor_command_single_option(bot, interaction, command):
+    interaction.data = {"options": [{"name": "first", "value": "one"}]}
+    clazz = InteractionContext(bot=bot, interaction=interaction, command=command)
+    assert clazz.view.buffer == "one"
+    assert_class_setup(clazz, bot)
+
+
 def test_ctor_command_options(bot, interaction, command):
     interaction.data = {"options": [{"name": "first", "value": "one"}, {"name": "second", "value": "two"}]}
     clazz = InteractionContext(bot=bot, interaction=interaction, command=command)
     assert clazz.view.buffer == "｢one｣ ｢two｣"
+    assert_class_setup(clazz, bot)
+
+
+def test_ctor_subcommand_single_option(bot, interaction, command):
+    command._discordpy_include_subcommand_name = {"sub": True}
+    interaction.data = {"options": [{"name": "sub", "options": [{"name": "first", "value": "one"}]}]}
+    clazz = InteractionContext(bot=bot, interaction=interaction, command=command)
+    assert clazz.view.buffer == "sub ｢one｣"
     assert_class_setup(clazz, bot)
 
 
@@ -50,6 +65,22 @@ def test_ctor_subcommand_options(bot, interaction, command):
     interaction.data = {"options": [{"name": "sub", "options": [{"name": "first", "value": "one"}, {"name": "second", "value": "two"}]}]}
     clazz = InteractionContext(bot=bot, interaction=interaction, command=command)
     assert clazz.view.buffer == "sub ｢one｣ ｢two｣"
+    assert_class_setup(clazz, bot)
+
+
+def test_ctor_subcommand_empty_options_no_subcommand_name(bot, interaction, command):
+    command._discordpy_include_subcommand_name = {"sub": False}
+    interaction.data = {"options": [{"name": "sub"}]}
+    clazz = InteractionContext(bot=bot, interaction=interaction, command=command)
+    assert clazz.view.buffer == ""
+    assert_class_setup(clazz, bot)
+
+
+def test_ctor_subcommand_single_option_no_subcommand_name(bot, interaction, command):
+    command._discordpy_include_subcommand_name = {"sub": False}
+    interaction.data = {"options": [{"name": "sub", "options": [{"name": "first", "value": "one"}]}]}
+    clazz = InteractionContext(bot=bot, interaction=interaction, command=command)
+    assert clazz.view.buffer == "one"
     assert_class_setup(clazz, bot)
 
 


### PR DESCRIPTION
##### Summary 

Seems https://github.com/duck-dynasty/duckbot/pull/389 doesn't work perfectly. After some investigation, it seems it's erroneously receiving `"question?"` instead of `question?` as the input string. I construct the args string manually using the options passed into the slash command, but it turns out some internal stuff collided with the command signature just perfectly so to keep unwanted quotes around. Essentially, using a kwarg-only arg told discord.py to consume the rest of the args and jam it into that kwarg -- and for some reason, that's _as is_, even though everything else removes quotes.

Fix is basic enough for now, I just check if there's only one argument to the command, and if so, remove the quotes. I also changed the quotes to be less likely to clash with quotes that people might actually type themselves.  
I fully expect to revisit this as we register more slash commands, but keeping this change focused on fixing `/eightball` for now.

Did some manually testing in the beta `#stonks` channel.

(To face my own face, let it be known that quoting stuff was a last minute addition that I didn't really test.)

##### Checklist

* [x] this is a source code change
  * [x] run `isort . && black .` in the repository root
  * [x] run `pytest` in the repository root
  * [x] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  * [x] update the wiki documentation if necessary
* [ ] or, this is **not** a source code change
