### PR TITLE
🚸 mark `/recipe` as a slash command

### DIFF
--- a/duckbot/cogs/recipe/recipe.py
+++ b/duckbot/cogs/recipe/recipe.py
@@ -5,6 +5,8 @@ import requests
 from bs4 import BeautifulSoup
 from discord.ext import commands
 
+from duckbot.slash import Option, slash_command
+
 
 class Recipe(commands.Cog):
     def __init__(self, bot):
@@ -73,7 +75,8 @@ class Recipe(commands.Cog):
 
         await context.send(response)
 
-    @commands.command(name="recipe")
+    @slash_command(options=[Option(name="search", description="Search terms for the recipe")])
+    @commands.command(name="recipe", description="Get a random recipe for something.")
     async def recipe_command(self, context, *, search_term: str = ""):
         async with context.typing():
             await self.recipe(context, search_term)


### PR DESCRIPTION
##### Summary 

Marking `/recipe` as a slash command. Tested in the beta `#gluten` channel.

##### Checklist

* [x] this is a source code change
  * [x] run `isort . && black .` in the repository root
  * [x] run `pytest` in the repository root
  * [x] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  * [x] update the wiki documentation if necessary
* [ ] or, this is **not** a source code change
