### PR TITLE
:see_no_evil: correctly ignore logs directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # log files
-./logs
+logs/
 logs.tar.gz
 
 # matplotlib artifacts


### PR DESCRIPTION
##### Summary 

Just something I noticed, apparently my local logs got big enough to rotate, and `git add` actually added them.

##### Checklist

* [ ] this is a source code change
  * [ ] run `format` in the repository root
  * [ ] run `pytest` in the repository root
  * [ ] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  * [ ] update the wiki documentation if necessary
* [x] or, this is **not** a source code change
