### PR TITLE
🎨 load all available extensions in `duckbot.cogs` automatically

### DIFF
--- a/duckbot/__main__.py
+++ b/duckbot/__main__.py
@@ -1,25 +1,9 @@
 import os
+import pkgutil
 
 from discord.ext import commands
 
-import duckbot.cogs.announce_day
-import duckbot.cogs.audio
-import duckbot.cogs.corrections
-import duckbot.cogs.dogs
-import duckbot.cogs.duck
-import duckbot.cogs.formula_one
-import duckbot.cogs.fortune
-import duckbot.cogs.games
-import duckbot.cogs.github
-import duckbot.cogs.google
-import duckbot.cogs.insights
-import duckbot.cogs.math
-import duckbot.cogs.messages
-import duckbot.cogs.recipe
-import duckbot.cogs.robot
-import duckbot.cogs.text
-import duckbot.cogs.tito
-import duckbot.cogs.weather
+import duckbot.cogs
 import duckbot.health
 import duckbot.logs
 import duckbot.slash
@@ -36,28 +20,11 @@ def run_duckbot(bot: commands.Bot):
     bot.load_extension(duckbot.health.__name__)
     bot.load_extension(duckbot.slash.__name__)
 
-    bot.load_extension(duckbot.cogs.duck.__name__)
-    bot.load_extension(duckbot.cogs.dogs.__name__)
-    bot.load_extension(duckbot.cogs.tito.__name__)
-    bot.load_extension(duckbot.cogs.text.__name__)
-    bot.load_extension(duckbot.cogs.math.__name__)
-    bot.load_extension(duckbot.cogs.games.__name__)
-    bot.load_extension(duckbot.cogs.github.__name__)
-    bot.load_extension(duckbot.cogs.google.__name__)
-    bot.load_extension(duckbot.cogs.recipe.__name__)
-    bot.load_extension(duckbot.cogs.fortune.__name__)
-    bot.load_extension(duckbot.cogs.weather.__name__)
-    bot.load_extension(duckbot.cogs.insights.__name__)
-    bot.load_extension(duckbot.cogs.corrections.__name__)
-    bot.load_extension(duckbot.cogs.formula_one.__name__)
-    bot.load_extension(duckbot.cogs.announce_day.__name__)
-    bot.load_extension(duckbot.cogs.robot.__name__)
-    bot.load_extension(duckbot.cogs.audio.__name__)
-    bot.load_extension(duckbot.cogs.messages.__name__)
+    for extension in pkgutil.iter_modules(duckbot.cogs.__path__):
+        bot.load_extension(f"{duckbot.cogs.__name__}.{extension.name}")
 
     bot.run(os.getenv("DISCORD_TOKEN"))
 
 
 if __name__ == "__main__":
-    bot = DuckBot()
-    run_duckbot(bot)
+    run_duckbot(DuckBot())

--- a/duckbot/__main__.py
+++ b/duckbot/__main__.py
@@ -20,7 +20,7 @@ def run_duckbot(bot: commands.Bot):
     bot.load_extension(duckbot.health.__name__)
     bot.load_extension(duckbot.slash.__name__)
 
-    for extension in pkgutil.iter_modules(duckbot.cogs.__path__):
+    for extension in (x for x in pkgutil.iter_modules(duckbot.cogs.__path__) if x.ispkg):
         bot.load_extension(f"{duckbot.cogs.__name__}.{extension.name}")
 
     bot.run(os.getenv("DISCORD_TOKEN"))

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -1,6 +1,8 @@
+from unittest.mock import call
+
 import pytest
 
-import duckbot
+import duckbot.util.connection_test
 from duckbot.__main__ import run_duckbot
 
 DISCORD_TOKEN = "discord-token"
@@ -14,10 +16,38 @@ def set_discord_token_env(monkeypatch):
 def test_run_duckbot_connection_test(bot_spy, monkeypatch):
     monkeypatch.setenv("DUCKBOT_ARGS", "connection-test")
     run_duckbot(bot_spy)
-    bot_spy.load_extension.assert_any_call(duckbot.util.connection_test.__name__)
+    assert_extensions_loaded(bot_spy, [duckbot.util.connection_test.__name__])
     bot_spy.run.assert_called_once_with(DISCORD_TOKEN)
 
 
 def test_run_duckbot_normal_run(bot_spy):
     run_duckbot(bot_spy)
+    assert_extensions_loaded(bot_spy)
     bot_spy.run.assert_called_once_with(DISCORD_TOKEN)
+
+
+def assert_extensions_loaded(bot_spy, additional_extensions=[]):
+    extensions = [
+        "duckbot.logs",
+        "duckbot.health",
+        "duckbot.slash",
+        "duckbot.cogs.announce_day",
+        "duckbot.cogs.audio",
+        "duckbot.cogs.corrections",
+        "duckbot.cogs.dogs",
+        "duckbot.cogs.duck",
+        "duckbot.cogs.formula_one",
+        "duckbot.cogs.fortune",
+        "duckbot.cogs.games",
+        "duckbot.cogs.github",
+        "duckbot.cogs.google",
+        "duckbot.cogs.insights",
+        "duckbot.cogs.math",
+        "duckbot.cogs.messages",
+        "duckbot.cogs.recipe",
+        "duckbot.cogs.robot",
+        "duckbot.cogs.text",
+        "duckbot.cogs.tito",
+        "duckbot.cogs.weather",
+    ]
+    bot_spy.load_extension.assert_has_calls([call(x) for x in extensions + additional_extensions], any_order=True)


### PR DESCRIPTION
##### Summary 

Title. Instead of calling `load_extension` manually a bunch of times, this will loop over the module contents and load each of them. Updated the tests to ensure the behaviour was the same before and after.

##### Checklist

* [x] this is a source code change
  * [x] run `format` in the repository root
  * [x] run `pytest` in the repository root
  * [x] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  * [x] update the wiki documentation if necessary
* [ ] or, this is **not** a source code change
