### PR TITLE
:construction_worker: update codecov action to v2

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -38,7 +38,7 @@ jobs:
         pytest
     - name: Report Code Coverage
       if: ${{ always() }}
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v2
 
   sanity:
     runs-on: ubuntu-latest


### PR DESCRIPTION
##### Summary

`v1` is deprecated and slated for full removal in Feb, see their [readme](https://github.com/codecov/codecov-action). Thankfully, upgrading for us seems to be a no-brainer since we only use the defaults.

##### Checklist

- [ ] this is a source code change
  - [ ] run `format` in the repository root
  - [ ] run `pytest` in the repository root
  - [ ] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [ ] update the wiki documentation if necessary
- [x] or, this is **not** a source code change
