### PR TITLE
👷 automatically update open pull requests on merge

### DIFF
--- a/.github/workflows/update-pull-requests.yml
+++ b/.github/workflows/update-pull-requests.yml
@@ -8,7 +8,7 @@ jobs:
   update:
     runs-on: ubuntu-latest
     steps:
-    - uses: chinthakagodawita/autoupdate@v1
+    - uses: chinthakagodawita/autoupdate@v1.5.0
       env:
         GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
         MERGE_CONFLICT_ACTION: ignore

--- a/.github/workflows/update-pull-requests.yml
+++ b/.github/workflows/update-pull-requests.yml
@@ -2,6 +2,7 @@ name: Update Open Pull Requests
 
 on:
   push:
+  pull_request:
 
 jobs:
   update:

--- a/.github/workflows/update-pull-requests.yml
+++ b/.github/workflows/update-pull-requests.yml
@@ -2,7 +2,8 @@ name: Update Open Pull Requests
 
 on:
   push:
-  pull_request:
+    branches:
+    - main
 
 jobs:
   update:

--- a/.github/workflows/update-pull-requests.yml
+++ b/.github/workflows/update-pull-requests.yml
@@ -1,0 +1,13 @@
+name: Update Open Pull Requests
+
+on:
+  push:
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: chinthakagodawita/autoupdate@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+        MERGE_CONFLICT_ACTION: ignore


### PR DESCRIPTION
##### Summary

Runs [autoupdate](https://github.com/chinthakagodawita/autoupdate) action on pushes to the main branch, which merges the new changes into open pull requests. This saves us from having to click UPDATE all the time, hopefully.

Haven't really tested it.

##### Checklist

- [ ] this is a source code change
  - [ ] run `format` in the repository root
  - [ ] run `pytest` in the repository root
  - [ ] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [ ] update the wiki documentation if necessary
- [x] or, this is **not** a source code change
