### PR TITLE
:construction_worker: change github token for autoupdate pull requests

### DIFF
--- a/.github/workflows/update-pull-requests.yml
+++ b/.github/workflows/update-pull-requests.yml
@@ -11,5 +11,5 @@ jobs:
     steps:
     - uses: chinthakagodawita/autoupdate@v1.5.0
       env:
-        GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         MERGE_CONFLICT_ACTION: ignore


### PR DESCRIPTION
##### Summary

Not really sure why the actions failed, the error says it needs "admin rights" to the repo, but it's acting as @Chippers255 with the token it's currently using. The action's readme says:

> GITHUB_TOKEN: autoupdate uses this token to perform its operations on your repository. This should generally be set to "${{ secrets.GITHUB_TOKEN }}".
> 
> You may want to override this if you want the action to run as a different user than the default actions bot.

So I'm trying that.

##### Checklist

- [ ] this is a source code change
  - [ ] run `format` in the repository root
  - [ ] run `pytest` in the repository root
  - [ ] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [ ] update the wiki documentation if necessary
- [x] or, this is **not** a source code change
