### PR TITLE
:children_crossing: mark `/define` as a slash command

### DIFF
--- a/duckbot/cogs/text/dictionary.py
+++ b/duckbot/cogs/text/dictionary.py
@@ -5,6 +5,8 @@ import discord
 import requests
 from discord.ext import commands
 
+from duckbot.slash import Option, slash_command
+
 
 class Dictionary(commands.Cog):
     def __init__(self, bot):
@@ -12,7 +14,8 @@ class Dictionary(commands.Cog):
         self.headers = {"app_id": os.getenv("OXFORD_DICTIONARY_ID"), "app_key": os.getenv("OXFORD_DICTIONARY_KEY")}
         self.url = "https://od-api.oxforddictionaries.com/api/v2"
 
-    @commands.command(name="define")
+    @slash_command(options=[Option(name="word", description="The word to define.", required=True)])
+    @commands.command(name="define", description="Define a brother, word.")
     async def define_command(self, context, *, word: str = "taco"):
         await self.define(context, word)
 


### PR DESCRIPTION
##### Summary

Title!

##### Checklist

- [x] this is a source code change
  - [x] run `format` in the repository root
  - [x] run `pytest` in the repository root
  - [x] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [x] update the wiki documentation if necessary
- [ ] or, this is **not** a source code change
