### PR TITLE
✨ add black friday special day

### DIFF
--- a/duckbot/cogs/announce_day/special_days.py
+++ b/duckbot/cogs/announce_day/special_days.py
@@ -3,7 +3,7 @@ from datetime import date
 
 import discord
 import holidays
-from dateutil.relativedelta import SU
+from dateutil.relativedelta import SU, FR
 from dateutil.relativedelta import relativedelta as rd
 
 
@@ -44,6 +44,7 @@ class SpecialDays(holidays.Canada):
         self[date(year, 10, 31)] = "Halloween"
         self[date(year, 11, 10)] = f"Tom and Kelly's fake wedding anniversary. They've been fake together for {year-2014} years"
         self[date(year, 11, 12)] = f"Sabrina's Birthday. She is {year-1996} years old. Good work on surviving"
+        self[date(year, 11, 1) + rd(weekday=FR(+4))] = "Black Friday. I hope I can get some new socks"
         self[date(year, 12, 2)] = f"Female Kelly's Birthday. She's {year-1989} years old"
         self[date(year, 12, 3)] = "DuckBot's Inception Day"
         self[date(year, 12, 5)] = f"Taras' Birthday. He's {year-1989} years old"

--- a/duckbot/cogs/announce_day/special_days.py
+++ b/duckbot/cogs/announce_day/special_days.py
@@ -3,7 +3,7 @@ from datetime import date
 
 import discord
 import holidays
-from dateutil.relativedelta import SU, FR
+from dateutil.relativedelta import FR, SU
 from dateutil.relativedelta import relativedelta as rd
 
 

--- a/tests/cogs/announce_day/special_days_test.py
+++ b/tests/cogs/announce_day/special_days_test.py
@@ -24,3 +24,9 @@ def test_populate_mothers_day(bot, date):
 def test_populate_fathers_day(bot, date):
     clazz = SpecialDays(bot)
     assert clazz.get_list(date) == ["Father's Day"]
+
+
+@pytest.mark.parametrize("date", [datetime(2020, 11, 27), datetime(2021, 11, 26), datetime(2022, 11, 25)])
+def test_populate_black_friday(bot, date):
+    clazz = SpecialDays(bot)
+    assert clazz.get_list(date) == ["Black Friday. I hope I can get some new socks"]


### PR DESCRIPTION
##### Summary

Adding black friday as a special day. American thanksgiving is the 4th thursday, and black friday is the day after. So... should be the fourth friday.

##### Checklist

- [x] this is a source code change
  - [x] run `format` in the repository root
  - [x] run `pytest` in the repository root
  - [x] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [x] update the wiki documentation if necessary
- [ ] or, this is **not** a source code change
