### PR TITLE
🐛 show skipped checks as successful in `!yolo`

### DIFF
--- a/duckbot/cogs/github/yolo_merge.py
+++ b/duckbot/cogs/github/yolo_merge.py
@@ -77,7 +77,7 @@ class YoloMerge(commands.Cog):
         commit = pr.get_commits().reversed[0]
         for suite in commit.get_check_suites():
             completed = suite.status == "completed"
-            success = suite.conclusion == "success"
+            success = suite.conclusion in ["success", "neutral", "skipped"]
             if completed:
                 result = CHECK_PASSED if success else CHECK_FAILED
             else:

--- a/tests/cogs/github/yolo_merge_test.py
+++ b/tests/cogs/github/yolo_merge_test.py
@@ -1,4 +1,5 @@
 import datetime
+import random
 from typing import Tuple
 from unittest import mock
 
@@ -155,13 +156,13 @@ def make_pull_request(number: int, mergeable=True, checks_passed=False) -> Tuple
     last_commit = commits[-1]
     success_check = check_suite()
     success_check.status = "completed"
-    success_check.conclusion = "success"
+    success_check.conclusion = random.choice(["success", "skipped", "neutral"])
     failure_check = check_suite()
     failure_check.status = "completed"
     failure_check.conclusion = "failed"
     incomplete_check = check_suite()
     incomplete_check.status = "queued"
-    incomplete_check.conclusion = "pending"
+    incomplete_check.conclusion = None
     if checks_passed:
         last_commit.get_check_suites.return_value = [success_check, success_check, success_check]
         lines = [


### PR DESCRIPTION
##### Summary

Fixes https://github.com/duck-dynasty/duckbot/issues/386.


[CheckSuite#conclusion](https://docs.github.com/en/rest/reference/checks#create-a-check-run--parameters) can be a bunch of different values:
> Can be one of action_required, cancelled, failure, neutral, success, skipped, stale, or timed_out.

I picked neutral, success and skipped to be successful checks.

##### Checklist

- [x] this is a source code change
  - [x] run `format` in the repository root
  - [x] run `pytest` in the repository root
  - [x] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [x] update the wiki documentation if necessary
- [ ] or, this is **not** a source code change
