### PR TITLE
📌 pin setuptools and wheel to current versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,15 @@
 [build-system]
-requires = ["setuptools", "wheel", "nltk==3.6.5", "textblob==0.17.1"]
+requires = [
+    "setuptools==58.5.3",
+    "wheel==0.37.0",
+    "nltk==3.6.5",
+    "textblob==0.17.1"
+]
 build-backend = "setuptools.build_meta"
 
 [tool.black]
 line-length = 200
-target-version = ['py38']
+target-version = ["py38"]
 
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
##### Summary

These were missed in a [recent commit](https://github.com/duck-dynasty/duckbot/commit/09b39414beac809562eb56e4989aaee4bbddbc80#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7) which pinned all our dependencies.

##### Checklist

- [ ] this is a source code change
  - [ ] run `format` in the repository root
  - [ ] run `pytest` in the repository root
  - [ ] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [ ] update the wiki documentation if necessary
- [x] or, this is **not** a source code change
