### PR TITLE
🥚 use main branch for rick roll action

### DIFF
--- a/.github/workflows/memes.yml
+++ b/.github/workflows/memes.yml
@@ -12,6 +12,6 @@ jobs:
   roll:
     runs-on: ubuntu-latest
     steps:
-    - uses: duck-dynasty/rick-roll-action@latest
+    - uses: duck-dynasty/rick-roll-action@main
       with:
         chance: 2


### PR DESCRIPTION
##### Summary

Using the head of the main branch instead of a tag for the rick roll action. Just less effort to maintain.

##### Checklist

- [ ] this is a source code change
  - [ ] run `format` in the repository root
  - [ ] run `pytest` in the repository root
  - [ ] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [ ] update the wiki documentation if necessary
- [x] or, this is **not** a source code change
