### PR TITLE
:bug: :rocket: export environment variables during deployment

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -190,6 +190,7 @@ jobs:
       run: |
         . ../venv/bin/activate
         jq -r 'to_entries | .[] | "\(.key)=\(.value)"' <<< "$SECRETS" >> $GITHUB_ENV
+        export $(cat "$GITHUB_ENV" | xargs)
         echo "::group::cdk synth"
         cdk synth
         echo "::endgroup::"


### PR DESCRIPTION
##### Summary

Seems writing to `$GITHUB_ENV` doesn't actually make envirnment variables show up in the shell, [docs](https://docs.github.com/en/actions/learn-github-actions/workflow-commands-for-github-actions#setting-an-environment-variable). As a workaround, simply re-exporting all the variables so the deployment scripts actually pick them up.

##### Checklist

- [ ] this is a source code change
  - [ ] run `format` in the repository root
  - [ ] run `pytest` in the repository root
  - [ ] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [ ] update the wiki documentation if necessary
- [x] or, this is **not** a source code change
