### PR TITLE
:bug: :rocket: move duckbot image tag to cdk context variable

### DIFF
--- a/.aws/cdk.json
+++ b/.aws/cdk.json
@@ -1,5 +1,6 @@
 {
   "app": "python app.py",
   "context": {
+    "duckbot_image": "duckdynasty/duckbot:latest"
   }
 }

--- a/.aws/duckdeploy/stack.py
+++ b/.aws/duckdeploy/stack.py
@@ -9,8 +9,6 @@ class DuckBotStack(core.Stack):
     def __init__(self, scope: core.Construct, construct_id: str, *, secrets: List[Secret]):
         super().__init__(scope, construct_id)
 
-        duckbot_image = core.CfnParameter(self, "DuckBotImage", type="String", default="duckdynasty/duckbot:latest", description="The DuckBot image to deploy.")
-
         vpc = aws_ec2.Vpc(
             self,
             "Vpc",
@@ -60,7 +58,7 @@ class DuckBotStack(core.Stack):
             "duckbot",
             container_name="duckbot",
             essential=True,
-            image=aws_ecs.ContainerImage.from_registry(duckbot_image.value_as_string),
+            image=aws_ecs.ContainerImage.from_registry(self.node.try_get_context("duckbot_image")),
             environment={"STAGE": "prod"},
             secrets={k: aws_ecs.Secret.from_ssm_parameter(v) for k, v in secrets_as_parameters.items()},
             health_check=aws_ecs.HealthCheck(

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -198,7 +198,7 @@ jobs:
         echo "::endgroup::"
         echo "::group::cdk deploy"
         cdk deploy \
-          --all \
+          --force --all \
           --context duckbot_image=${{ steps.image.outputs.commit }} \
           --context write_secrets=true \
           --require-approval never \

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -198,7 +198,7 @@ jobs:
         echo "::endgroup::"
         echo "::group::cdk deploy"
         cdk deploy \
-          --all \
+          --all --force \
           --parameter DuckBotImage=${{ steps.image.outputs.commit }} \
           --context write_secrets=true \
           --require-approval never \

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -191,10 +191,10 @@ jobs:
         . ../venv/bin/activate
         export $(jq -r 'to_entries | .[] | "\(.key)=\(.value)"' <<< "$SECRETS" | xargs)
         echo "::group::cdk synth"
-        cdk synth
+        cdk synth --context duckbot_image=${{ steps.image.outputs.commit }}
         echo "::endgroup::"
         echo "::group::cdk diff"
-        cdk diff --parameter DuckBotImage=${{ steps.image.outputs.commit }} || true
+        cdk diff --context duckbot_image=${{ steps.image.outputs.commit }} || true
         echo "::endgroup::"
         echo "::group::cdk deploy"
         cdk deploy \

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -199,7 +199,7 @@ jobs:
         echo "::group::cdk deploy"
         cdk deploy \
           --all \
-          --parameter DuckBotImage=${{ steps.image.outputs.commit }} \
+          --context duckbot_image=${{ steps.image.outputs.commit }} \
           --context write_secrets=true \
           --require-approval never \
           --progress events


### PR DESCRIPTION
##### Summary

CDK seems to have a [bug](https://github.com/aws/aws-cdk/issues/8734) where new parameter values aren't picked up if there's no other stack changes. This means the docker image for duckbot is never actually updated. There's a workaround for now to use `--force`, which I am using. Though, seems the best method is to actually use a context variable instead, so it's available at synthesis time instead of deployment time. I figure let's do both, screw it.

##### Checklist

- [x] this is a source code change
  - [x] run `format` in the repository root
  - [x] run `pytest` in the repository root
  - [x] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [x] update the wiki documentation if necessary
- [ ] or, this is **not** a source code change
