### PR TITLE
👷 increase dependabot open pull request limit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,9 @@ updates:
   directory: /
   schedule:
     interval: monthly
+  open-pull-requests-limit: 100
 - package-ecosystem: github-actions
   directory: /
   schedule:
     interval: monthly
+  open-pull-requests-limit: 100


### PR DESCRIPTION
##### Summary

Title. Default is only 5, which is a little annoying when all the CDK packages fail to update nicely.

##### Checklist

- [ ] this is a source code change
  - [ ] run `format` in the repository root
  - [ ] run `pytest` in the repository root
  - [ ] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [ ] update the wiki documentation if necessary
- [x] or, this is **not** a source code change
