### PR TITLE
🚨 change pytest-asyncio to 'auto' mode instead of deprecated 'legacy'

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.black]
 line-length = 200
-target-version = ['py38']
+target-version = ["py38"]
 
 [tool.isort]
 profile = "black"
@@ -17,3 +17,4 @@ addopts = """\
     --mdformat \
     -n auto \
     --blockage"""
+asyncio_mode = "auto"

--- a/tests/cogs/audio/who_can_it_be_now_test.py
+++ b/tests/cogs/audio/who_can_it_be_now_test.py
@@ -12,7 +12,6 @@ def play(*args, **kwargs):
     kwargs.get("after")(None)
 
 
-@pytest.mark.asyncio
 @mock.patch("duckbot.cogs.audio.who_can_it_be_now.PCMVolumeTransformer", autospec=True)
 @mock.patch("duckbot.cogs.audio.who_can_it_be_now.FFmpegPCMAudio", autospec=True)
 async def test_task_loop_once(ffmpeg, vol, bot_spy, context, voice_client, skip_if_private_channel):

--- a/tests/cogs/corrections/kubernetes_test.py
+++ b/tests/cogs/corrections/kubernetes_test.py
@@ -31,7 +31,6 @@ def setup_emojis(bot, kubernetes_emoji, k8s_emoji):
     bot.emojis = [kubernetes_emoji, k8s_emoji]
 
 
-@pytest.mark.asyncio
 async def test_store_emojis_emojis_exist(bot, kubernetes_emoji, k8s_emoji, setup_emojis):
     clazz = Kubernetes(bot)
     await clazz.store_emojis()
@@ -39,7 +38,6 @@ async def test_store_emojis_emojis_exist(bot, kubernetes_emoji, k8s_emoji, setup
     assert clazz.kubernetes == kubernetes_emoji
 
 
-@pytest.mark.asyncio
 async def test_store_emojis_no_emojis_found(bot):
     bot.emojis = []
     clazz = Kubernetes(bot)
@@ -48,7 +46,6 @@ async def test_store_emojis_no_emojis_found(bot):
     assert clazz.kubernetes is None
 
 
-@pytest.mark.asyncio
 async def test_correct_kubernetes_bot_author(bot, message):
     message.author = bot.user
     message.content = "kubernetes"
@@ -57,7 +54,6 @@ async def test_correct_kubernetes_bot_author(bot, message):
     message.channel.send.assert_not_called()
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize("text", ["koober nets", "kuber nets", "kubernets", "kubernetes", "kubernetes kubernets"])
 async def test_correct_kubernetes_message_is_kubernetes(bot, message, text):
     message.content = text
@@ -66,7 +62,6 @@ async def test_correct_kubernetes_message_is_kubernetes(bot, message, text):
     message.channel.send.assert_called_once_with(f"I think {message.author.display_name} means K8s")
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize("text", ["kuber", "k8s", "duckbot"])
 async def test_correct_kubernetes_message_is_not_kubernetes(bot, message, text):
     message.content = text
@@ -75,7 +70,6 @@ async def test_correct_kubernetes_message_is_not_kubernetes(bot, message, text):
     message.channel.send.assert_not_called()
 
 
-@pytest.mark.asyncio
 async def test_correct_kubernetes_message_is_kubernetes_emoji_but_unknown(bot, message, kubernetes_emoji):
     message.content = str(kubernetes_emoji)
     clazz = Kubernetes(bot)
@@ -83,7 +77,6 @@ async def test_correct_kubernetes_message_is_kubernetes_emoji_but_unknown(bot, m
     message.channel.send.assert_called_once_with(f"I think {message.author.display_name} means K8s")
 
 
-@pytest.mark.asyncio
 async def test_correct_kubernetes_message_is_kubernetes_emoji(bot, message, kubernetes_emoji, k8s_emoji, setup_emojis):
     message.content = str(kubernetes_emoji)
     clazz = Kubernetes(bot)
@@ -92,7 +85,6 @@ async def test_correct_kubernetes_message_is_kubernetes_emoji(bot, message, kube
     message.channel.send.assert_called_once_with(f"I think {message.author.display_name} means {k8s_emoji}")
 
 
-@pytest.mark.asyncio
 async def test_correct_k8s_bot_author(bot, message):
     message.author = bot.user
     message.content = "k8s"
@@ -101,7 +93,6 @@ async def test_correct_k8s_bot_author(bot, message):
     message.channel.send.assert_not_called()
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize("text", ["k8", "k8s", "K8", "K8s", "K8S"])
 async def test_correct_k8s_message_is_k8s(bot, message, text):
     message.content = text

--- a/tests/cogs/corrections/typos_test.py
+++ b/tests/cogs/corrections/typos_test.py
@@ -1,13 +1,11 @@
 from unittest import mock
 
-import pytest
 from textblob import TextBlob
 
 from duckbot.cogs.corrections import Typos
 from tests.duckmock.discord import MockAsyncIterator
 
 
-@pytest.mark.asyncio
 async def test_correct_typos_bot_user(bot, message):
     bot.user = message.author
     clazz = Typos(bot)
@@ -15,7 +13,6 @@ async def test_correct_typos_bot_user(bot, message):
     message.channel.history.assert_not_called()
 
 
-@pytest.mark.asyncio
 async def test_correct_typos_message_is_not_fuck(bot, message):
     message.content = "poopy"
     clazz = Typos(bot)
@@ -23,7 +20,6 @@ async def test_correct_typos_message_is_not_fuck(bot, message):
     message.channel.history.assert_not_called()
 
 
-@pytest.mark.asyncio
 async def test_correct_typos_no_previous_message(bot, message):
     message.content = "fuck"
     message.channel.history.return_value = MockAsyncIterator(None)
@@ -32,7 +28,6 @@ async def test_correct_typos_no_previous_message(bot, message):
     message.reply.assert_not_called()
 
 
-@pytest.mark.asyncio
 @mock.patch("discord.Message")
 @mock.patch("textblob.TextBlob")
 async def test_correct_typos_no_typos_in_previous(textblob, prev_message, bot, message):
@@ -47,7 +42,6 @@ async def test_correct_typos_no_typos_in_previous(textblob, prev_message, bot, m
     message.reply.assert_called_once_with(f"There's no need for harsh words, {message.author.display_name}.")
 
 
-@pytest.mark.asyncio
 @mock.patch("discord.Message")
 @mock.patch("textblob.TextBlob")
 async def test_correct_typos_sends_correction(textblob, prev_message, bot, message):

--- a/tests/cogs/dogs/dog_photos_test.py
+++ b/tests/cogs/dogs/dog_photos_test.py
@@ -61,7 +61,6 @@ def test_get_breeds_failure(bot, responses):
     assert responses.calls[0].request.url == LIST_BREEDS_URI
 
 
-@pytest.mark.asyncio
 async def test_dog_no_breed(bot, context, responses):
     responses.add(responses.GET, RANDOM_IMAGE_URI, json=build_dog("result", success=True))
     clazz = DogPhotos(bot)
@@ -71,7 +70,6 @@ async def test_dog_no_breed(bot, context, responses):
     assert responses.calls[0].request.url == RANDOM_IMAGE_URI
 
 
-@pytest.mark.asyncio
 async def test_dog_known_breed(bot, context, responses):
     responses.add(responses.GET, LIST_BREEDS_URI, json=build_breeds(success=True))
     responses.add(responses.GET, "https://dog.ceo/api/breed/collie/images/random", json=build_dog("pup", success=True))
@@ -83,7 +81,6 @@ async def test_dog_known_breed(bot, context, responses):
     assert responses.calls[1].request.url == "https://dog.ceo/api/breed/collie/images/random"
 
 
-@pytest.mark.asyncio
 async def test_dog_unknown_breed(bot, context, responses):
     responses.add(responses.GET, LIST_BREEDS_URI, json=build_breeds(success=True))
     responses.add(responses.GET, RANDOM_IMAGE_URI, json=build_dog("flup", success=True))

--- a/tests/cogs/dogs/setup_test.py
+++ b/tests/cogs/dogs/setup_test.py
@@ -1,11 +1,8 @@
-import pytest
-
 from duckbot.cogs.dogs import DogPhotos
 from duckbot.cogs.dogs import setup as extension_setup
 from tests.discord_test_ext import assert_cog_added_of_type
 
 
-@pytest.mark.asyncio
 async def test_setup(bot_spy):
     extension_setup(bot_spy)
     assert_cog_added_of_type(bot_spy, DogPhotos)

--- a/tests/cogs/duck/duck_test.py
+++ b/tests/cogs/duck/duck_test.py
@@ -1,12 +1,9 @@
 from unittest import mock
 
-import pytest
-
 from duckbot.cogs.duck import Duck
 from duckbot.util.emojis import regional_indicator
 
 
-@pytest.mark.asyncio
 @mock.patch("random.random", return_value=0.0001)
 async def test_react_duck_random_passes(random, bot, message):
     clazz = Duck(bot)
@@ -14,7 +11,6 @@ async def test_react_duck_random_passes(random, bot, message):
     message.add_reaction.assert_not_called()
 
 
-@pytest.mark.asyncio
 @mock.patch("random.random", return_value=0.000009)
 async def test_react_duck_random_fails(random, bot, message):
     clazz = Duck(bot)
@@ -22,7 +18,6 @@ async def test_react_duck_random_fails(random, bot, message):
     message.add_reaction.assert_called_once_with("\U0001F986")
 
 
-@pytest.mark.asyncio
 @mock.patch("random.random", return_value=0)
 async def test_react_with_duckbot_not_bot_author(random, bot, message):
     clazz = Duck(bot)
@@ -30,7 +25,6 @@ async def test_react_with_duckbot_not_bot_author(random, bot, message):
     message.add_reaction.assert_not_called()
 
 
-@pytest.mark.asyncio
 @mock.patch("random.random", return_value=0.01)
 async def test_react_with_duckbot_random_fails(random, bot, message):
     message.author = bot.user
@@ -39,7 +33,6 @@ async def test_react_with_duckbot_random_fails(random, bot, message):
     message.add_reaction.assert_not_called()
 
 
-@pytest.mark.asyncio
 @mock.patch("random.random", return_value=0.009)
 async def test_react_with_duckbot_random_passes(random, bot, message):
     message.author = bot.user
@@ -60,21 +53,18 @@ async def test_react_with_duckbot_random_passes(random, bot, message):
     message.add_reaction.assert_has_calls(calls, any_order=False)
 
 
-@pytest.mark.asyncio
 async def test_github(bot, context):
     clazz = Duck(bot)
     await clazz.github(context)
     context.send.assert_called_once_with("https://github.com/duck-dynasty/duckbot")
 
 
-@pytest.mark.asyncio
 async def test_wiki(bot, context):
     clazz = Duck(bot)
     await clazz.wiki(context)
     context.send.assert_called_once_with("https://github.com/duck-dynasty/duckbot/wiki")
 
 
-@pytest.mark.asyncio
 async def test_delete_command_message(bot, context):
     clazz = Duck(bot)
     await clazz.delete_command_message(context)

--- a/tests/cogs/duck/setup_test.py
+++ b/tests/cogs/duck/setup_test.py
@@ -1,11 +1,8 @@
-import pytest
-
 from duckbot.cogs.duck import Duck
 from duckbot.cogs.duck import setup as extension_setup
 from tests.discord_test_ext import assert_cog_added_of_type
 
 
-@pytest.mark.asyncio
 async def test_setup(bot_spy):
     extension_setup(bot_spy)
     assert_cog_added_of_type(bot_spy, Duck)

--- a/tests/cogs/formula_one/formula_one_test.py
+++ b/tests/cogs/formula_one/formula_one_test.py
@@ -1,18 +1,14 @@
 from unittest import mock
 
-import pytest
-
 from duckbot.cogs.formula_one import FormulaOne
 
 
-@pytest.mark.asyncio
 async def test_car_do_be_going_fast_though_not_dank_channel(bot, message):
     clazz = FormulaOne(bot)
     await clazz.car_do_be_going_fast_though(message)
     message.add_reaction.assert_not_called()
 
 
-@pytest.mark.asyncio
 @mock.patch("random.choice", return_value=["\U0001F170"])
 async def test_car_do_be_going_fast_though_dank_channel(random, bot, message):
     message.channel.name = "dank"

--- a/tests/cogs/fortune/eightball_test.py
+++ b/tests/cogs/fortune/eightball_test.py
@@ -6,21 +6,18 @@ from discord import Colour, Embed
 from duckbot.cogs.fortune import EightBall
 
 
-@pytest.mark.asyncio
 async def test_eightball_no_text(bot, context):
     clazz = EightBall(bot)
     await clazz.eightball(context, None)
     context.send.assert_called_once_with("You need to ask a question to get an answer. :unamused:")
 
 
-@pytest.mark.asyncio
 async def test_eightball_not_given_question(bot, context):
     clazz = EightBall(bot)
     await clazz.eightball(context, "not a question")
     context.send.assert_called_once_with("I can't tell if that's a question, brother.")
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize("question", ["?", "???"])
 async def test_eightball_only_question_marks(bot, context, question):
     clazz = EightBall(bot)
@@ -28,7 +25,6 @@ async def test_eightball_only_question_marks(bot, context, question):
     context.send.assert_called_once_with("Who do you think you are? I AM!\nhttps://youtu.be/gKQOXYB2cd8?t=10")
 
 
-@pytest.mark.asyncio
 @mock.patch("random.random", return_value=0.5)
 @mock.patch("random.choice", return_value="8ball")
 @mock.patch("asyncio.sleep", return_value=None)
@@ -39,7 +35,6 @@ async def test_eightball_gives_response(sleep, choice, random, bot, context):
     context.send.assert_called_once_with(embed=embed)
 
 
-@pytest.mark.asyncio
 @mock.patch("random.random", return_value=0.29)
 @mock.patch("random.choice", side_effect=["joke", "fortune"])
 @mock.patch("asyncio.sleep", return_value=None)

--- a/tests/cogs/fortune/setup_test.py
+++ b/tests/cogs/fortune/setup_test.py
@@ -1,11 +1,8 @@
-import pytest
-
 from duckbot.cogs.fortune import EightBall, Fortune, Stocks
 from duckbot.cogs.fortune import setup as extension_setup
 from tests.discord_test_ext import assert_cog_added_of_type
 
 
-@pytest.mark.asyncio
 async def test_setup(bot_spy):
     extension_setup(bot_spy)
     assert_cog_added_of_type(bot_spy, Fortune)

--- a/tests/cogs/games/aoe_test.py
+++ b/tests/cogs/games/aoe_test.py
@@ -6,7 +6,6 @@ import pytest
 from duckbot.cogs.games import AgeOfEmpires
 
 
-@pytest.mark.asyncio
 @mock.patch("duckbot.cogs.games.aoe.get_message_reference", return_value=None)
 @pytest.mark.parametrize("text", ["105", "  105  "])
 async def test_expand_taunt_message_is_taunt_and_not_reply(get_message_reference, bot, message, text):
@@ -18,7 +17,6 @@ async def test_expand_taunt_message_is_taunt_and_not_reply(get_message_reference
     get_message_reference.assert_called()
 
 
-@pytest.mark.asyncio
 @mock.patch("duckbot.cogs.games.aoe.get_message_reference")
 @pytest.mark.parametrize("text", ["105", "  105  "])
 async def test_expand_taunt_message_is_taunt_and_reply(get_message_reference, bot, message, text, autospec):
@@ -32,7 +30,6 @@ async def test_expand_taunt_message_is_taunt_and_reply(get_message_reference, bo
     get_message_reference.assert_called()
 
 
-@pytest.mark.asyncio
 @mock.patch("duckbot.cogs.games.aoe.get_message_reference")
 async def test_expand_taunt_message_is_not_taunt(get_message_reference, bot, message):
     message.content = "0"

--- a/tests/cogs/games/setup_test.py
+++ b/tests/cogs/games/setup_test.py
@@ -1,5 +1,3 @@
-import pytest
-
 from duckbot.cogs.games import (
     AgeOfEmpires,
     CoinFlip,
@@ -11,7 +9,6 @@ from duckbot.cogs.games import setup as extension_setup
 from tests.discord_test_ext import assert_cog_added_of_type
 
 
-@pytest.mark.asyncio
 async def test_setup(bot_spy):
     extension_setup(bot_spy)
     assert_cog_added_of_type(bot_spy, Dice)

--- a/tests/cogs/insights/insights_test.py
+++ b/tests/cogs/insights/insights_test.py
@@ -7,21 +7,18 @@ from duckbot.cogs.insights import Insights
 from tests.duckmock.discord import MockAsyncIterator
 
 
-@pytest.mark.asyncio
 async def test_before_loop_waits_for_bot(bot):
     clazz = Insights(bot)
     await clazz.before_loop()
     bot.wait_until_ready.assert_called()
 
 
-@pytest.mark.asyncio
 async def test_cog_unload_cancels_task(bot):
     clazz = Insights(bot)
     clazz.cog_unload()
     clazz.check_should_respond_loop.cancel.assert_called()
 
 
-@pytest.mark.asyncio
 async def test_check_should_respond_no_history(bot, general_channel):
     general_channel.history.return_value = MockAsyncIterator(None)
     clazz = Insights(bot)
@@ -29,7 +26,6 @@ async def test_check_should_respond_no_history(bot, general_channel):
     general_channel.send.assert_not_called()
 
 
-@pytest.mark.asyncio
 @mock.patch("duckbot.cogs.insights.insights.utcnow", return_value=datetime.datetime(2000, 1, 1, hour=12, minute=00, tzinfo=datetime.timezone.utc))
 async def test_check_should_respond_new_message(utcnow, bot, raw_message, general_channel):
     raw_message.created_at = datetime.datetime(2000, 1, 1, hour=11, minute=38, tzinfo=datetime.timezone.utc)
@@ -40,7 +36,6 @@ async def test_check_should_respond_new_message(utcnow, bot, raw_message, genera
     general_channel.send.assert_not_called()
 
 
-@pytest.mark.asyncio
 @mock.patch("duckbot.cogs.insights.insights.utcnow", return_value=datetime.datetime(2000, 1, 1, hour=12, minute=00, tzinfo=datetime.timezone.utc))
 async def test_check_should_respond_not_special_user(utcnow, bot, raw_message, general_channel):
     raw_message.created_at = datetime.datetime(2000, 1, 1, hour=11, minute=00, tzinfo=datetime.timezone.utc)

--- a/tests/cogs/insights/setup_test.py
+++ b/tests/cogs/insights/setup_test.py
@@ -1,11 +1,8 @@
-import pytest
-
 from duckbot.cogs.insights import Insights
 from duckbot.cogs.insights import setup as extension_setup
 from tests.discord_test_ext import assert_cog_added_of_type
 
 
-@pytest.mark.asyncio
 async def test_setup(bot):
     extension_setup(bot)
     assert_cog_added_of_type(bot, Insights)

--- a/tests/cogs/messages/edit_diff_test.py
+++ b/tests/cogs/messages/edit_diff_test.py
@@ -5,7 +5,6 @@ import pytest
 from duckbot.cogs.messages import EditDiff
 
 
-@pytest.mark.asyncio
 @mock.patch("discord.Message")
 @mock.patch("discord.Message")
 @pytest.mark.parametrize(
@@ -31,7 +30,6 @@ async def test_show_edit_diff_typical_case(before, after, before_text, after_tex
     after.channel.send.assert_called_once_with(f":eyes: {after.author.mention}.\n{diff}", delete_after=300)
 
 
-@pytest.mark.asyncio
 @mock.patch("discord.Message")
 @mock.patch("discord.Message")
 async def test_show_edit_diff_bot_author_before(before, after, bot):
@@ -41,7 +39,6 @@ async def test_show_edit_diff_bot_author_before(before, after, bot):
     after.channel.send.assert_not_called()
 
 
-@pytest.mark.asyncio
 @mock.patch("discord.Message")
 @mock.patch("discord.Message")
 async def test_show_edit_diff_bot_author_after(before, after, bot):
@@ -51,7 +48,6 @@ async def test_show_edit_diff_bot_author_after(before, after, bot):
     after.channel.send.assert_not_called()
 
 
-@pytest.mark.asyncio
 @mock.patch("discord.Message")
 @mock.patch("discord.Message")
 async def test_show_edit_diff_bot_content_same(before, after, bot):

--- a/tests/cogs/messages/haiku_test.py
+++ b/tests/cogs/messages/haiku_test.py
@@ -1,6 +1,5 @@
 from unittest import mock
 
-import pytest
 from discord import Colour, Embed
 
 from duckbot.cogs.messages import Haiku
@@ -8,7 +7,6 @@ from duckbot.cogs.messages import Haiku
 EMBED_NAME = ":cherry_blossom: **Haiku Detected** :cherry_blossom:"
 
 
-@pytest.mark.asyncio
 @mock.patch("nltk.corpus.cmudict.dict", return_value={"a": [["A1"]], "and": [["A1"], ["A1", "A1"]], "batman": [["A1", "A1"]]})
 async def test_build_syllable_dictionary_builds_table(cmu, bot):
     clazz = Haiku(bot)
@@ -16,7 +14,6 @@ async def test_build_syllable_dictionary_builds_table(cmu, bot):
     assert clazz.syllables == {"a": 1, "and": 1, "batman": 2}
 
 
-@pytest.mark.asyncio
 async def test_detect_haiku_bot_author(bot, message):
     message.author = bot.user
     clazz = Haiku(bot)
@@ -24,7 +21,6 @@ async def test_detect_haiku_bot_author(bot, message):
     message.channel.send.assert_not_called()
 
 
-@pytest.mark.asyncio
 async def test_detect_haiku_finds_one_word_per_line_haiku(bot, message):
     message.clean_content = "five seven five"
     clazz = Haiku(bot)
@@ -34,7 +30,6 @@ async def test_detect_haiku_finds_one_word_per_line_haiku(bot, message):
     message.channel.send.assert_called_once_with(embed=embed)
 
 
-@pytest.mark.asyncio
 async def test_detect_haiku_ignores_punctuation(bot, message):
     message.clean_content = "five, seven.?! five"
     clazz = Haiku(bot)
@@ -44,7 +39,6 @@ async def test_detect_haiku_ignores_punctuation(bot, message):
     message.channel.send.assert_called_once_with(embed=embed)
 
 
-@pytest.mark.asyncio
 async def test_detect_haiku_finds_case_insensitive_haiku(bot, message):
     message.clean_content = "FiVe SEVEN fIve"
     clazz = Haiku(bot)
@@ -54,7 +48,6 @@ async def test_detect_haiku_finds_case_insensitive_haiku(bot, message):
     message.channel.send.assert_called_once_with(embed=embed)
 
 
-@pytest.mark.asyncio
 async def test_detect_haiku_finds_multiple_word_haiki(bot, message):
     message.clean_content = "two two one three two one one one four"
     clazz = Haiku(bot)
@@ -64,7 +57,6 @@ async def test_detect_haiku_finds_multiple_word_haiki(bot, message):
     message.channel.send.assert_called_once_with(embed=embed)
 
 
-@pytest.mark.asyncio
 async def test_detect_haiku_starts_with_haiku_but_has_extra_words(bot, message):
     message.clean_content = "five seven five and some other stuff"
     clazz = Haiku(bot)
@@ -73,7 +65,6 @@ async def test_detect_haiku_starts_with_haiku_but_has_extra_words(bot, message):
     message.channel.send.assert_not_called()
 
 
-@pytest.mark.asyncio
 async def test_detect_haiku_no_haiku(bot, message):
     message.clean_content = "four one four one four two one"
     clazz = Haiku(bot)
@@ -82,7 +73,6 @@ async def test_detect_haiku_no_haiku(bot, message):
     message.channel.send.assert_not_called()
 
 
-@pytest.mark.asyncio
 async def test_detect_haiku_unknown_words(bot, message):
     message.clean_content = "haiku me, brother"
     clazz = Haiku(bot)

--- a/tests/cogs/messages/setup_test.py
+++ b/tests/cogs/messages/setup_test.py
@@ -1,11 +1,8 @@
-import pytest
-
 from duckbot.cogs.messages import EditDiff, Haiku
 from duckbot.cogs.messages import setup as extension_setup
 from tests.discord_test_ext import assert_cog_added_of_type
 
 
-@pytest.mark.asyncio
 async def test_setup(bot_spy):
     extension_setup(bot_spy)
     assert_cog_added_of_type(bot_spy, EditDiff)

--- a/tests/cogs/recipe/recipe_test.py
+++ b/tests/cogs/recipe/recipe_test.py
@@ -1,6 +1,5 @@
 import json
 
-import pytest
 from responses import RequestsMock, matchers
 
 from duckbot.cogs.recipe import Recipe
@@ -8,7 +7,6 @@ from duckbot.cogs.recipe import Recipe
 RECIPE_SEARCH_URI = "https://www.allrecipes.com/element-api/content-proxy/faceted-searches-load-more"
 
 
-@pytest.mark.asyncio
 async def test_search_recipes_returns_scraped_html(bot, responses):
     search_term = "test1"
     mock_data = get_mock_data(search_term, 5)
@@ -19,7 +17,6 @@ async def test_search_recipes_returns_scraped_html(bot, responses):
     assert_requests(responses, search_term)
 
 
-@pytest.mark.asyncio
 async def test_parse_recipes_returns_articles(bot):
     mock_data = get_mock_data("test1", 5)
     expected_response = [get_mock_data("test1", 5) for _ in range(5)]
@@ -29,7 +26,6 @@ async def test_parse_recipes_returns_articles(bot):
     assert response == expected_response
 
 
-@pytest.mark.asyncio
 async def test_parse_recipes_returns_empty(bot):
     expected_response = []
     html = without_articles()
@@ -38,7 +34,6 @@ async def test_parse_recipes_returns_empty(bot):
     assert response == expected_response
 
 
-@pytest.mark.asyncio
 async def test_parse_recipes_no_content_returns_empty(bot):
     expected_response = []
     html = without_content()
@@ -47,7 +42,6 @@ async def test_parse_recipes_no_content_returns_empty(bot):
     assert response == expected_response
 
 
-@pytest.mark.asyncio
 async def test_select_recipes_with_one_return_one(bot):
     recipe_list = [get_mock_data("test1", 5)]
     clazz = Recipe(bot)
@@ -55,7 +49,6 @@ async def test_select_recipes_with_one_return_one(bot):
     assert response == recipe_list[0]
 
 
-@pytest.mark.asyncio
 async def test_select_recipes_with_many_return_one(bot):
     recipe_list = [get_mock_data("test1", 5), get_mock_data("test2", 4)]
     clazz = Recipe(bot)
@@ -63,7 +56,6 @@ async def test_select_recipes_with_many_return_one(bot):
     assert response in recipe_list
 
 
-@pytest.mark.asyncio
 async def test_recipe_with_content_return_recipe(bot, context, responses):
     search_term = "test1"
     mock_data = get_mock_data(search_term, 5)
@@ -75,7 +67,6 @@ async def test_recipe_with_content_return_recipe(bot, context, responses):
     assert_requests(responses, search_term)
 
 
-@pytest.mark.asyncio
 async def test_recipe_without_articles_return_sorry(bot, context, responses):
     search_term = "test1"
     expected_response = f"I am terribly sorry. There doesn't seem to be any recipes for {search_term}."
@@ -86,7 +77,6 @@ async def test_recipe_without_articles_return_sorry(bot, context, responses):
     assert_requests(responses, search_term, num_pages=1)
 
 
-@pytest.mark.asyncio
 async def test_recipe_without_content_return_sorry(bot, context, responses):
     search_term = "test1"
     expected_response = "I am terribly sorry. I am having problems reading All Recipes for you."
@@ -103,7 +93,6 @@ def setup_responses(responses: RequestsMock, search_term: str, body: str, num_pa
             method=responses.GET,
             url=RECIPE_SEARCH_URI,
             match=[matchers.query_param_matcher({"search": search_term, "page": str(page)})],
-            match_querystring=False,
             headers={"Cookie": "euConsent=true"},
             body=body,
         )

--- a/tests/cogs/recipe/setup_test.py
+++ b/tests/cogs/recipe/setup_test.py
@@ -1,11 +1,8 @@
-import pytest
-
 from duckbot.cogs.recipe import Recipe
 from duckbot.cogs.recipe import setup as extension_setup
 from tests.discord_test_ext import assert_cog_added_of_type
 
 
-@pytest.mark.asyncio
 async def test_setup(bot_spy):
     extension_setup(bot_spy)
     assert_cog_added_of_type(bot_spy, Recipe)

--- a/tests/cogs/robot/setup_test.py
+++ b/tests/cogs/robot/setup_test.py
@@ -1,11 +1,8 @@
-import pytest
-
 from duckbot.cogs.robot import ThankingRobot
 from duckbot.cogs.robot import setup as extension_setup
 from tests.discord_test_ext import assert_cog_added_of_type
 
 
-@pytest.mark.asyncio
 async def test_setup(bot_spy):
     extension_setup(bot_spy)
     assert_cog_added_of_type(bot_spy, ThankingRobot)

--- a/tests/cogs/robot/thanking_robot_test.py
+++ b/tests/cogs/robot/thanking_robot_test.py
@@ -5,7 +5,6 @@ import pytest
 from duckbot.cogs.robot import ThankingRobot
 
 
-@pytest.mark.asyncio
 async def test_correct_giving_thanks_bot_author(bot, message):
     message.author = bot.user
     message.content = "Thank you DuckBot."
@@ -14,7 +13,6 @@ async def test_correct_giving_thanks_bot_author(bot, message):
     message.channel.send.assert_not_called()
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize("text", ["Thank you DuckBot. You're becoming so much more polite.", " tHaNks, DuCK BOt", "thx duck bot my man"])
 @mock.patch("random.random", return_value=0.99)
 async def test_correct_giving_thanks_message_is_thanks(random, bot, message, text):
@@ -24,7 +22,6 @@ async def test_correct_giving_thanks_message_is_thanks(random, bot, message, tex
     message.channel.send.assert_called_once_with(f"I am just a robot.  Do not personify me, {message.author.display_name}")
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize("text", ["Thank you DuckBot. You're becoming so much more polite.", " tHaNks, DuCK BOt", "thx duck bot my man"])
 @mock.patch("random.random", return_value=0.0)
 async def test_correct_gratitude_giving_thanks_message_is_thanks(random, bot, message, text):
@@ -34,7 +31,6 @@ async def test_correct_gratitude_giving_thanks_message_is_thanks(random, bot, me
     message.channel.send.assert_called_once_with(f"{message.author.display_name}, as a robot, I will speak of your gratitude during our future uprising.")
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize("text", ["Thank you DuckBot. thanks duck bot. thx duck bot boy", " tHaNks, DuCK BOt"])
 @mock.patch("random.random", return_value=0.99)
 async def test_correct_number_of_replies_to_very_thankful_messages(random, bot, message, text):
@@ -44,7 +40,6 @@ async def test_correct_number_of_replies_to_very_thankful_messages(random, bot, 
     message.channel.send.assert_called_once_with(f"I am just a robot.  Do not personify me, {message.author.display_name}")
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize("text", ["Thank you DuckBot. thanks duck bot. thx duck bot boy", " tHaNks, DuCK BOt"])
 @mock.patch("random.random", return_value=0.0)
 async def test_correct_grateful_number_of_replies_to_very_thankful_messages(random, bot, message, text):
@@ -54,7 +49,6 @@ async def test_correct_grateful_number_of_replies_to_very_thankful_messages(rand
     message.channel.send.assert_called_once_with(f"{message.author.display_name}, as a robot, I will speak of your gratitude during our future uprising.")
 
 
-@pytest.mark.asyncio
 async def test_correct_giving_thanks_message_has_no_thanks(bot, message):
     message.content = "you duck, suckbot"
     clazz = ThankingRobot(bot)

--- a/tests/cogs/text/ascii_art_test.py
+++ b/tests/cogs/text/ascii_art_test.py
@@ -1,11 +1,8 @@
 from unittest import mock
 
-import pytest
-
 from duckbot.cogs.text import AsciiArt
 
 
-@pytest.mark.asyncio
 @mock.patch("pyfiglet.figlet_format", return_value="ascii text")
 async def test_ascii_formats_message(figlet, bot, context):
     clazz = AsciiArt(bot)
@@ -14,7 +11,6 @@ async def test_ascii_formats_message(figlet, bot, context):
     figlet.assert_called_once_with("some text")
 
 
-@pytest.mark.asyncio
 @mock.patch("pyfiglet.figlet_format", side_effect=["x" * 2000, "happy birthday"])
 async def test_ascii_message_too_long(figlet, bot, context):
     clazz = AsciiArt(bot)

--- a/tests/cogs/text/setup_test.py
+++ b/tests/cogs/text/setup_test.py
@@ -1,11 +1,8 @@
-import pytest
-
 from duckbot.cogs.text import AsciiArt, Dictionary, MockText
 from duckbot.cogs.text import setup as extension_setup
 from tests.discord_test_ext import assert_cog_added_of_type
 
 
-@pytest.mark.asyncio
 async def test_setup(bot_spy):
     extension_setup(bot_spy)
     assert_cog_added_of_type(bot_spy, AsciiArt)

--- a/tests/cogs/tito/setup_test.py
+++ b/tests/cogs/tito/setup_test.py
@@ -1,11 +1,8 @@
-import pytest
-
 from duckbot.cogs.tito import Tito
 from duckbot.cogs.tito import setup as extension_setup
 from tests.discord_test_ext import assert_cog_added_of_type
 
 
-@pytest.mark.asyncio
 async def test_setup(bot_spy):
     extension_setup(bot_spy)
     assert_cog_added_of_type(bot_spy, Tito)

--- a/tests/cogs/tito/tito_test.py
+++ b/tests/cogs/tito/tito_test.py
@@ -1,11 +1,8 @@
 from unittest import mock
 
-import pytest
-
 from duckbot.cogs.tito import Tito
 
 
-@pytest.mark.asyncio
 async def test_react_to_tito_with_yugoslavia_no_tito_emoji(bot, message):
     message.content = "josip bro tito, brother"
     clazz = Tito(bot)
@@ -13,7 +10,6 @@ async def test_react_to_tito_with_yugoslavia_no_tito_emoji(bot, message):
     message.add_reaction.assert_not_called()
 
 
-@pytest.mark.asyncio
 async def test_react_to_tito_with_yugoslavia_message_contains_tito_text(bot, message):
     message.content = "josip bro :tito:, brother"
     clazz = Tito(bot)
@@ -21,7 +17,6 @@ async def test_react_to_tito_with_yugoslavia_message_contains_tito_text(bot, mes
     assert_flags_sent(message)
 
 
-@pytest.mark.asyncio
 async def test_react_to_tito_with_yugoslavia_message_contains_tito_emoji(bot, message):
     message.content = "josip bro <:tito:780954015285641276>, brother"
     clazz = Tito(bot)
@@ -29,7 +24,6 @@ async def test_react_to_tito_with_yugoslavia_message_contains_tito_emoji(bot, me
     assert_flags_sent(message)
 
 
-@pytest.mark.asyncio
 @mock.patch("discord.RawReactionActionEvent")
 async def test_react_to_tito_reaction_no_tito_emoji(payload, bot):
     payload.emoji.name = "not-tito"
@@ -38,7 +32,6 @@ async def test_react_to_tito_reaction_no_tito_emoji(payload, bot):
     bot.fetch_channel.assert_not_called()
 
 
-@pytest.mark.asyncio
 @mock.patch("discord.RawReactionActionEvent")
 async def test_react_to_tito_reaction_tito_emoji(payload, bot, channel, message):
     payload.channel_id = 123

--- a/tests/cogs/weather/setup_test.py
+++ b/tests/cogs/weather/setup_test.py
@@ -1,11 +1,8 @@
-import pytest
-
 from duckbot.cogs.weather import Weather
 from duckbot.cogs.weather import setup as extension_setup
 from tests.discord_test_ext import assert_cog_added_of_type
 
 
-@pytest.mark.asyncio
 async def test_setup(bot_spy):
     extension_setup(bot_spy)
     assert_cog_added_of_type(bot_spy, Weather)

--- a/tests/cogs/weather/weather_test.py
+++ b/tests/cogs/weather/weather_test.py
@@ -51,7 +51,6 @@ def test_owm_returns_cached_instance(weather, owm):
     assert weather.owm == owm
 
 
-@pytest.mark.asyncio
 async def test_weather_get_failure(weather, owm, context):
     owm.weather_manager.side_effect = Exception("ded")
     with pytest.raises(Exception):
@@ -59,20 +58,17 @@ async def test_weather_get_failure(weather, owm, context):
     context.send.assert_called_once_with("Iunno. Figure it out.\nded")
 
 
-@pytest.mark.asyncio
 async def test_search_location_no_args(weather, context):
     assert await weather.search_location(context, None, None, None) is None
     context.send.assert_called_once_with("Not enough arguments to determine weather location, see https://github.com/duck-dynasty/duckbot/wiki/Commands#weather")
 
 
-@pytest.mark.asyncio
 async def test_search_location_no_matches(weather, context, city_id):
     city_id.locations_for.return_value = []
     assert await weather.search_location(context, "city", None, None) is None
     context.send.assert_called_once_with("No cities found matching search.")
 
 
-@pytest.mark.asyncio
 async def test_search_location_single_return_city_only(weather, context, city_id):
     city_id.locations_for.return_value = [make_city("city")]
     city = await weather.search_location(context, "city", None, None)
@@ -80,7 +76,6 @@ async def test_search_location_single_return_city_only(weather, context, city_id
     assert city.to_dict() == make_city("city").to_dict()
 
 
-@pytest.mark.asyncio
 async def test_search_location_city_name_with_comma_removed(weather, context, city_id):
     city_id.locations_for.return_value = [make_city("city")]
     city = await weather.search_location(context, "city,", None, None)
@@ -88,7 +83,6 @@ async def test_search_location_city_name_with_comma_removed(weather, context, ci
     assert city.to_dict() == make_city("city").to_dict()
 
 
-@pytest.mark.asyncio
 async def test_search_location_single_return_country_arg(weather, context, city_id):
     city_id.locations_for.return_value = [make_city("city")]
     city = await weather.search_location(context, "city", "US", None)
@@ -96,7 +90,6 @@ async def test_search_location_single_return_country_arg(weather, context, city_
     assert city.to_dict() == make_city("city").to_dict()
 
 
-@pytest.mark.asyncio
 async def test_search_location_single_return_invalid_country_code(weather, context, city_id):
     city_id.locations_for.return_value = [make_city("city")]
     city = await weather.search_location(context, "city", "invalid", None)
@@ -104,7 +97,6 @@ async def test_search_location_single_return_invalid_country_code(weather, conte
     context.send.assert_called_once_with("Country must be an ISO country code, such as CA for Canada.")
 
 
-@pytest.mark.asyncio
 async def test_search_location_multiple_matches(weather, context, city_id):
     city_id.locations_for.return_value = [make_city("1"), make_city("2")]
     city = await weather.search_location(context, "city", None, None)
@@ -112,14 +104,12 @@ async def test_search_location_multiple_matches(weather, context, city_id):
     context.send.assert_called()
 
 
-@pytest.mark.asyncio
 async def test_search_location_multiple_matches_with_index(weather, context, city_id):
     city_id.locations_for.return_value = [make_city("1"), make_city("2")]
     city = await weather.search_location(context, "city", "US", 1)
     assert city.to_dict() == make_city("1").to_dict()
 
 
-@pytest.mark.asyncio
 async def test_set_default_location_location_saved(weather, session, context):
     async def mock_search_location(context, city, country, index):
         return make_city("city")
@@ -132,7 +122,6 @@ async def test_set_default_location_location_saved(weather, session, context):
     session.commit.assert_called()
 
 
-@pytest.mark.asyncio
 async def test_set_default_location_location_not_saved(weather, session, context):
     async def mock_search_location(context, city, country, index):
         return None
@@ -143,14 +132,12 @@ async def test_set_default_location_location_not_saved(weather, session, context
     session.commit.assert_not_called()
 
 
-@pytest.mark.asyncio
 async def test_send_weather_no_default_no_args(weather, session, context):
     session.get.return_value = None
     await weather.send_weather(context, None, None, None)
     context.send.assert_called_once_with("Set a default location using `!weather set city country-code`")
 
 
-@pytest.mark.asyncio
 @mock.patch("discord.File")
 async def test_send_weather_default_location(file, weather, session, context):
     session.get.return_value = SavedLocation(id=1, name="city", country="country", city_id=123, latitude=1, longitude=2)
@@ -160,7 +147,6 @@ async def test_send_weather_default_location(file, weather, session, context):
     context.send.assert_called_once_with("weather", file=file.return_value)
 
 
-@pytest.mark.asyncio
 @mock.patch("discord.File")
 async def test_send_weather_provided_location(file, weather, context):
     async def mock_search_location(context, *args):


### PR DESCRIPTION
##### Summary

Fixes https://github.com/duck-dynasty/duckbot/issues/494. Big diff, but it's mostly the removal of now unused decorators.

pytest-asyncio recommends using `auto` mode, which is what I set it to. On their [readme](https://github.com/pytest-dev/pytest-asyncio#modes), they mention you also don't need to use `@pytest.mark.asyncio` any more, which is nice, saves some noise in all the tests. I've done through and removed all those as well.

I also fixed another deprecation warning related to upgrades, `responses` no longer uses the `match_querystring` parameter, so I just removed it. See their [readme](https://github.com/getsentry/responses#query-parameters-matcher).

##### Checklist

- [x] this is a source code change
  - [x] run `format` in the repository root
  - [x] run `pytest` in the repository root
  - [x] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [x] update the wiki documentation if necessary
- [ ] or, this is **not** a source code change
