### PR TITLE
📌 pin discord.py to when they froze development

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ if __name__ == "__main__":
         packages=find_packages(),
         cmdclass={"develop": PostDevelop, "install": PostInstall},
         install_requires=[
-            "discord.py[voice] @ git+https://github.com/Rapptz/discord.py",
+            "discord.py[voice] @ git+https://github.com/duck-dynasty/discord.py@2.0a-freeze",
             "beautifulsoup4==4.10.0",
             "requests==2.27.1",
             "pytz==2021.3",


### PR DESCRIPTION
##### Summary

Discord.py restarted development recently and ended up releasing a bunch of breaking changes. To remove the dev pressure from us, I've gone ahead and forked their repo and made a [branch](https://github.com/duck-dynasty/discord.py/tree/2.0a-freeze) that is pinned at the commit when they stopped development last August, and changed our dependencies to use our fork instead.

I'll eventually address the breaking changes, but I'll likely wait for discord.py to release 2.0 on pypi. I'd rather not pull directly from a git repo.

(my chromebook is slow nowadays, so I'm letting github actions run `pytest`)

##### Checklist

- [x] this is a source code change
  - [x] run `format` in the repository root
  - [ ] run `pytest` in the repository root
  - [x] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [x] update the wiki documentation if necessary
- [ ] or, this is **not** a source code change
