### PR TITLE
💚 enable "legacy-editable" mode for setuptools

### DIFF
--- a/.github/actions/setup-python-venv/action.yml
+++ b/.github/actions/setup-python-venv/action.yml
@@ -44,4 +44,4 @@ runs:
       python -m venv --clear ${{ steps.path.outputs.path }}
       . ${{ steps.path.outputs.path }}/bin/activate
       pip install --upgrade pip setuptools wheel
-      pip install --editable .[${{ inputs.extras }}]
+      SETUPTOOLS_ENABLE_FEATURES="legacy-editable" pip install --editable .[${{ inputs.extras }}]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Before running DuckBot, you want to create a virtualenv to develop in. DuckBot r
 python3.8 -m venv --clear --prompt duckbot venv
 . venv/bin/activate
 pip install --upgrade pip setuptools wheel
-pip install --editable .[dev]
+SETUPTOOLS_ENABLE_FEATURES="legacy-editable" pip install --editable .[dev]
 ```
 
 The `dev` extras will also install development dependencies, like `pytest`. The installation commands should be run whenever you merge from upstream.
@@ -81,7 +81,7 @@ If your work doesn't need a full setup, you can just run `python -m duckbot` for
 Deployment scripts are written using [CDK](https://docs.aws.amazon.com/cdk/latest/guide/home.html), the AWS Cloud Development Kit. The CDK dependencies can be installed alongside DuckBot.
 
 ```sh
-pip install --editable .[dev,cdk]  # run from repository root
+SETUPTOOLS_ENABLE_FEATURES="legacy-editable" pip install --editable .[dev,cdk]  # run from repository root
 ```
 
 You'll then actually need CDK. It's a nodejs package, so you'll need that as well.


### PR DESCRIPTION
##### Summary

Setuptools updated recently and changed how editable mode works, which we use for development, see [docs](https://setuptools.pypa.io/en/latest/userguide/development_mode.html#legacy-behavior). Tested locally by running the updated commands in the readme + pytest.

The docker build was not affected, since it does not use an editable install. I also tested this locally.

##### Checklist

- [x] this is a source code change
  - [x] run `format` in the repository root
  - [x] run `pytest` in the repository root
  - [x] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [x] update the wiki documentation if necessary
- [ ] or, this is **not** a source code change
