### PR TITLE
🚀 change ec2 instance type to t3.nano

### DIFF
--- a/.aws/duckdeploy/stack.py
+++ b/.aws/duckdeploy/stack.py
@@ -23,7 +23,7 @@ class DuckBotStack(core.Stack):
         file_system = aws_efs.FileSystem(self, "PostgresFileSystem", vpc=vpc, encrypted=True, file_system_name=postgres_volume_name, removal_policy=core.RemovalPolicy.DESTROY)
         file_system.node.default_child.override_logical_id("FileSystem")  # rename for compatibility with legacy cloudformation template
 
-        task_definition = aws_ecs.TaskDefinition(self, "TaskDefinition", compatibility=aws_ecs.Compatibility.EC2, family="duckbot", memory_mib="960", network_mode=aws_ecs.NetworkMode.BRIDGE)
+        task_definition = aws_ecs.TaskDefinition(self, "TaskDefinition", compatibility=aws_ecs.Compatibility.EC2, family="duckbot", memory_mib="475", network_mode=aws_ecs.NetworkMode.BRIDGE)
 
         postgres_data_path = "/data/postgres"
         postgres = task_definition.add_container(

--- a/.aws/duckdeploy/stack.py
+++ b/.aws/duckdeploy/stack.py
@@ -80,7 +80,7 @@ class DuckBotStack(core.Stack):
             max_capacity=1,
             desired_capacity=1,
             machine_image=aws_ecs.EcsOptimizedImage.amazon_linux2(),
-            instance_type=aws_ec2.InstanceType("t2.micro"),
+            instance_type=aws_ec2.InstanceType.of(instance_class=aws_ec2.InstanceClass.T3, instance_size=aws_ec2.InstanceSize.NANO),
             key_name="duckbot",  # needs to be created manually
             instance_monitoring=aws_autoscaling.Monitoring.BASIC,
             vpc=vpc,


### PR DESCRIPTION
##### Summary

Fixes #357

Don't merge yet -- waiting until Sept 30th to squeeze as much of the free tier as possible.

Context for the image sizing is in the issue.

**Update**; the new host only has 500mb of memory, but the ECS task will still try to allociate ~1gb. Reducing that to the ~0.5gb.

`cdk diff` produces:
```
Resources
[~] AWS::ECS::TaskDefinition TaskDefinition TaskDefinitionB36D86D9 replace
 ├─ [~] ContainerDefinitions (requires replacement)
 │   └─ @@ -70,7 +70,7 @@
 │      [ ]   "StartPeriod": 30,
 │      [ ]   "Timeout": 10
 │      [ ] },
 │      [-] "Image": "duckdynasty/duckbot:9f24417",
 │      [+] "Image": "duckdynasty/duckbot:latest",
 │      [ ] "Links": [
 │      [ ]   "postgres"
 │      [ ] ],
 └─ [~] Memory (requires replacement)
     ├─ [-] 960
     └─ [+] 475
[~] AWS::AutoScaling::LaunchConfiguration AutoScalingGroup/LaunchConfig AutoScalingGroupLaunchConfigDEEB160C replace
 └─ [~] InstanceType (requires replacement)
     ├─ [-] t2.micro
     └─ [+] t3.nano
```
The image difference is also expected, since I did not specify a commit to deploy, so the script picks `latest`.

##### Checklist

- [x] this is a source code change
  - [x] run `format` in the repository root
  - [x] run `pytest` in the repository root
  - [x] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [x] update the wiki documentation if necessary
- [ ] or, this is **not** a source code change
