### PR TITLE
🚀 reduce ebs storage size to 10gb

### DIFF
--- a/.aws/duckdeploy/stack.py
+++ b/.aws/duckdeploy/stack.py
@@ -81,6 +81,7 @@ class DuckBotStack(core.Stack):
             desired_capacity=1,
             machine_image=aws_ecs.EcsOptimizedImage.amazon_linux2(),
             instance_type=aws_ec2.InstanceType("t2.micro"),
+            block_devices=(aws_ec2.BlockDevice(device_name="/dev/xvda", volume=aws_ec2.BlockDeviceVolume.ebs(volume_size=15, volume_type=aws_ec2.EbsDeviceVolumeType.GP3))),
             key_name="duckbot",  # needs to be created manually
             instance_monitoring=aws_autoscaling.Monitoring.BASIC,
             vpc=vpc,

--- a/.aws/duckdeploy/stack.py
+++ b/.aws/duckdeploy/stack.py
@@ -1,6 +1,12 @@
 from typing import List
 
-from aws_cdk import aws_autoscaling, aws_ec2, aws_ecs, aws_efs, aws_logs, aws_ssm, core
+from aws_cdk import aws_autoscaling as autoscaling
+from aws_cdk import aws_ec2 as ec2
+from aws_cdk import aws_ecs as ecs
+from aws_cdk import aws_efs as efs
+from aws_cdk import aws_logs as logs
+from aws_cdk import aws_ssm as ssm
+from aws_cdk import core
 
 from .secret import Secret
 
@@ -9,93 +15,93 @@ class DuckBotStack(core.Stack):
     def __init__(self, scope: core.Construct, construct_id: str, *, secrets: List[Secret]):
         super().__init__(scope, construct_id)
 
-        vpc = aws_ec2.Vpc(
+        vpc = ec2.Vpc(
             self,
             "Vpc",
             enable_dns_support=True,
             enable_dns_hostnames=True,
             max_azs=3,
             nat_gateways=0,
-            subnet_configuration=[aws_ec2.SubnetConfiguration(name="Public", subnet_type=aws_ec2.SubnetType.PUBLIC)],
+            subnet_configuration=[ec2.SubnetConfiguration(name="Public", subnet_type=ec2.SubnetType.PUBLIC)],
         )
 
         postgres_volume_name = "duckbot_dbdata"
-        file_system = aws_efs.FileSystem(self, "PostgresFileSystem", vpc=vpc, encrypted=True, file_system_name=postgres_volume_name, removal_policy=core.RemovalPolicy.DESTROY)
+        file_system = efs.FileSystem(self, "PostgresFileSystem", vpc=vpc, encrypted=True, file_system_name=postgres_volume_name, removal_policy=core.RemovalPolicy.DESTROY)
         file_system.node.default_child.override_logical_id("FileSystem")  # rename for compatibility with legacy cloudformation template
 
-        task_definition = aws_ecs.TaskDefinition(self, "TaskDefinition", compatibility=aws_ecs.Compatibility.EC2, family="duckbot", memory_mib="960", network_mode=aws_ecs.NetworkMode.BRIDGE)
+        task_definition = ecs.TaskDefinition(self, "TaskDefinition", compatibility=ecs.Compatibility.EC2, family="duckbot", memory_mib="960", network_mode=ecs.NetworkMode.BRIDGE)
 
         postgres_data_path = "/data/postgres"
         postgres = task_definition.add_container(
             "postgres",
             container_name="postgres",
-            image=aws_ecs.ContainerImage.from_registry("postgres:13.2"),
+            image=ecs.ContainerImage.from_registry("postgres:13.2"),
             essential=False,
             environment={
                 "POSTGRES_USER": "duckbot",
                 "POSTGRES_PASSWORD": "pond",
                 "PGDATA": postgres_data_path,
             },
-            health_check=aws_ecs.HealthCheck(
+            health_check=ecs.HealthCheck(
                 command=["CMD", "pg_isready", "-U", "duckbot"],
                 interval=core.Duration.seconds(30),
                 timeout=core.Duration.seconds(5),
                 retries=3,
                 start_period=core.Duration.seconds(30),
             ),
-            logging=aws_ecs.LogDriver.aws_logs(stream_prefix="ecs", log_retention=aws_logs.RetentionDays.ONE_MONTH),
+            logging=ecs.LogDriver.aws_logs(stream_prefix="ecs", log_retention=logs.RetentionDays.ONE_MONTH),
             memory_reservation_mib=128,
         )
-        task_definition.add_volume(name=postgres_volume_name, efs_volume_configuration=aws_ecs.EfsVolumeConfiguration(file_system_id=file_system.file_system_id, root_directory="/"))
-        postgres.add_mount_points(aws_ecs.MountPoint(source_volume=postgres_volume_name, container_path=postgres_data_path, read_only=False))
+        task_definition.add_volume(name=postgres_volume_name, efs_volume_configuration=ecs.EfsVolumeConfiguration(file_system_id=file_system.file_system_id, root_directory="/"))
+        postgres.add_mount_points(ecs.MountPoint(source_volume=postgres_volume_name, container_path=postgres_data_path, read_only=False))
 
         secrets_as_parameters = {
             # note, parameter version is required by cdk, but does not make it into the template; specify version 1 for simplicity
-            x.environment_name: aws_ssm.StringParameter.from_secure_string_parameter_attributes(self, x.environment_name, parameter_name=x.parameter_name, version=1)
+            x.environment_name: ssm.StringParameter.from_secure_string_parameter_attributes(self, x.environment_name, parameter_name=x.parameter_name, version=1)
             for x in secrets
         }
         duckbot = task_definition.add_container(
             "duckbot",
             container_name="duckbot",
             essential=True,
-            image=aws_ecs.ContainerImage.from_registry(self.node.try_get_context("duckbot_image")),
+            image=ecs.ContainerImage.from_registry(self.node.try_get_context("duckbot_image")),
             environment={"STAGE": "prod"},
-            secrets={k: aws_ecs.Secret.from_ssm_parameter(v) for k, v in secrets_as_parameters.items()},
-            health_check=aws_ecs.HealthCheck(
+            secrets={k: ecs.Secret.from_ssm_parameter(v) for k, v in secrets_as_parameters.items()},
+            health_check=ecs.HealthCheck(
                 command=["CMD", "python", "-m", "duckbot.health"],
                 interval=core.Duration.seconds(30),
                 timeout=core.Duration.seconds(10),
                 retries=3,
                 start_period=core.Duration.seconds(30),
             ),
-            logging=aws_ecs.LogDriver.aws_logs(stream_prefix="ecs", log_retention=aws_logs.RetentionDays.ONE_MONTH),
+            logging=ecs.LogDriver.aws_logs(stream_prefix="ecs", log_retention=logs.RetentionDays.ONE_MONTH),
             memory_reservation_mib=128,
         )
         duckbot.add_link(postgres)
 
-        asg = aws_autoscaling.AutoScalingGroup(
+        asg = autoscaling.AutoScalingGroup(
             self,
             "AutoScalingGroup",
             min_capacity=0,
             max_capacity=1,
             desired_capacity=1,
-            machine_image=aws_ecs.EcsOptimizedImage.amazon_linux2(),
-            instance_type=aws_ec2.InstanceType("t2.micro"),
-            block_devices=(aws_ec2.BlockDevice(device_name="/dev/xvda", volume=aws_ec2.BlockDeviceVolume.ebs(volume_size=15, volume_type=aws_ec2.EbsDeviceVolumeType.GP3))),
+            machine_image=ecs.EcsOptimizedImage.amazon_linux2(),
+            instance_type=ec2.InstanceType("t2.micro"),
+            block_devices=[autoscaling.BlockDevice(device_name="/dev/xvda", volume=autoscaling.BlockDeviceVolume.ebs(volume_size=10, volume_type=autoscaling.EbsDeviceVolumeType.GP3))],
             key_name="duckbot",  # needs to be created manually
-            instance_monitoring=aws_autoscaling.Monitoring.BASIC,
+            instance_monitoring=autoscaling.Monitoring.BASIC,
             vpc=vpc,
         )
 
         asg.connections.allow_to_default_port(file_system)
-        asg.connections.allow_from(aws_ec2.Peer.any_ipv4(), aws_ec2.Port.tcp(22))
-        asg.connections.allow_from(aws_ec2.Peer.any_ipv4(), aws_ec2.Port.tcp(80))
-        asg.connections.allow_from(aws_ec2.Peer.any_ipv4(), aws_ec2.Port.tcp(443))
+        asg.connections.allow_from(ec2.Peer.any_ipv4(), ec2.Port.tcp(22))
+        asg.connections.allow_from(ec2.Peer.any_ipv4(), ec2.Port.tcp(80))
+        asg.connections.allow_from(ec2.Peer.any_ipv4(), ec2.Port.tcp(443))
 
-        cluster = aws_ecs.Cluster(self, "Cluster", cluster_name="duckbot", vpc=vpc)
-        cluster.add_asg_capacity_provider(aws_ecs.AsgCapacityProvider(cluster, "AsgCapacityProvider", auto_scaling_group=asg), can_containers_access_instance_role=True)
+        cluster = ecs.Cluster(self, "Cluster", cluster_name="duckbot", vpc=vpc)
+        cluster.add_asg_capacity_provider(ecs.AsgCapacityProvider(cluster, "AsgCapacityProvider", auto_scaling_group=asg), can_containers_access_instance_role=True)
 
-        aws_ecs.Ec2Service(
+        ecs.Ec2Service(
             self,
             "Service",
             service_name="duckbot",


### PR DESCRIPTION
##### Summary

Fixes #405 ; Similar to #581, don't merge until ~sept 30, as we can still take advantage of the free tier for a bit longer.

Note, unrelated to this, I aliased names like `aws_whatever` to `whatever`. It adds some noise to the diff.

By default, ec2 provisions 30gb storage, but we don't need anywhere near that much storage, and we have to pay for the storage provisioned. This change should override the default storage (`/dev/xvda` ; see link in issue for details) with a smaller one. I also changed the type of storage to `gp3` instead of the default `gp2` (_general purpose generation n_). Third generation is a bit cheaper (it allows for provisioning more IO throughout on the drive, but whatever comes with it by default is more than sufficient).

`cdk diff` produces:

```
Resources
[~] AWS::ECS::TaskDefinition TaskDefinition TaskDefinitionB36D86D9 replace
 └─ [~] ContainerDefinitions (requires replacement)
     └─ @@ -70,7 +70,7 @@
        [ ]   "StartPeriod": 30,
        [ ]   "Timeout": 10
        [ ] },
        [-] "Image": "duckdynasty/duckbot:9f24417",
        [+] "Image": "duckdynasty/duckbot:latest",
        [ ] "Links": [
        [ ]   "postgres"
        [ ] ],
[~] AWS::AutoScaling::LaunchConfiguration AutoScalingGroup/LaunchConfig AutoScalingGroupLaunchConfigDEEB160C replace
 └─ [+] BlockDeviceMappings (requires replacement)
     └─ [{"DeviceName":"/dev/xvda","Ebs":{"VolumeSize":10,"VolumeType":"gp3"}}]
```
The image difference is also expected, since I did not specify a commit to deploy, so the script picks `latest`.

##### Checklist

- [x] this is a source code change
  - [x] run `format` in the repository root
  - [x] run `pytest` in the repository root
  - [x] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [x] update the wiki documentation if necessary
- [ ] or, this is **not** a source code change
