### PR TITLE
🚀 point ecs to manually created ami

### DIFF
--- a/.aws/duckdeploy/stack.py
+++ b/.aws/duckdeploy/stack.py
@@ -85,9 +85,9 @@ class DuckBotStack(core.Stack):
             min_capacity=0,
             max_capacity=1,
             desired_capacity=1,
-            machine_image=ecs.EcsOptimizedImage.amazon_linux2(),
+            machine_image=ec2.MachineImage.generic_linux(ami_map={"us-east-1": "ami-0c90bcaed0062d19b"}),  # custom ECS AMI created manually via https://github.com/aws/amazon-ecs-ami
             instance_type=ec2.InstanceType.of(instance_class=ec2.InstanceClass.T3, instance_size=ec2.InstanceSize.NANO),
-            block_devices=[autoscaling.BlockDevice(device_name="/dev/xvda", volume=autoscaling.BlockDeviceVolume.ebs(volume_size=10, volume_type=autoscaling.EbsDeviceVolumeType.GP3))],
+            block_devices=[autoscaling.BlockDevice(device_name="/dev/xvda", volume=autoscaling.BlockDeviceVolume.ebs(volume_size=8, volume_type=autoscaling.EbsDeviceVolumeType.GP3))],
             key_name="duckbot",  # needs to be created manually
             instance_monitoring=autoscaling.Monitoring.BASIC,
             vpc=vpc,


### PR DESCRIPTION
##### Summary

The AMI that we use for ECS requires a 30GB EBS volume provisioned for it. I don't want to pay for that, so I created a custom AMI which uses a smaller volume (https://github.com/aws/amazon-ecs-ami). The new AMI was manually created, I can't put it in the deployment scripts as far as I know.

Tested by actually deploying this change to prod. Sue me.

##### Checklist

- [x] this is a source code change
  - [x] run `format` in the repository root
  - [x] run `pytest` in the repository root
  - [x] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [x] update the wiki documentation if necessary
- [ ] or, this is **not** a source code change
