### PR TITLE
🚀 don't protect instances from scale-in

### DIFF
--- a/.aws/duckdeploy/stack.py
+++ b/.aws/duckdeploy/stack.py
@@ -85,6 +85,7 @@ class DuckBotStack(core.Stack):
             min_capacity=0,
             max_capacity=1,
             desired_capacity=1,
+            new_instances_protected_from_scale_in=False,
             machine_image=ec2.MachineImage.generic_linux(ami_map={"us-east-1": "ami-0c90bcaed0062d19b"}),  # custom ECS AMI created manually via https://github.com/aws/amazon-ecs-ami
             instance_type=ec2.InstanceType.of(instance_class=ec2.InstanceClass.T3, instance_size=ec2.InstanceSize.MICRO),
             spot_price="0.0052",  # t3.nano on-demand price

--- a/.aws/duckdeploy/stack.py
+++ b/.aws/duckdeploy/stack.py
@@ -102,7 +102,7 @@ class DuckBotStack(core.Stack):
 
         cluster = ecs.Cluster(self, "Cluster", cluster_name="duckbot", vpc=vpc)
         cluster.add_asg_capacity_provider(
-            ecs.AsgCapacityProvider(cluster, "AsgCapacityProvider", auto_scaling_group=asg), can_containers_access_instance_role=True, enable_managed_termination_protection=False
+            ecs.AsgCapacityProvider(cluster, "AsgCapacityProvider", auto_scaling_group=asg, enable_managed_termination_protection=False), can_containers_access_instance_role=True
         )
 
         ecs.Ec2Service(

--- a/.aws/duckdeploy/stack.py
+++ b/.aws/duckdeploy/stack.py
@@ -100,7 +100,9 @@ class DuckBotStack(core.Stack):
         asg.connections.allow_from(ec2.Peer.any_ipv4(), ec2.Port.tcp(443))
 
         cluster = ecs.Cluster(self, "Cluster", cluster_name="duckbot", vpc=vpc)
-        cluster.add_asg_capacity_provider(ecs.AsgCapacityProvider(cluster, "AsgCapacityProvider", auto_scaling_group=asg), can_containers_access_instance_role=True)
+        cluster.add_asg_capacity_provider(
+            ecs.AsgCapacityProvider(cluster, "AsgCapacityProvider", auto_scaling_group=asg), can_containers_access_instance_role=True, enable_managed_termination_protection=False
+        )
 
         ecs.Ec2Service(
             self,


### PR DESCRIPTION
##### Summary

Docs mention this field is false by default, but it appears to actually be true by default. We want the autoscaling group to be able to terminate instances of it has to, that's kinda the point. 

##### Checklist

- [x] this is a source code change
  - [ ] run `format` in the repository root
  - [ ] run `pytest` in the repository root
  - [ ] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [ ] update the wiki documentation if necessary
- [ ] or, this is **not** a source code change
