### PR TITLE
🚀  use "standard mode" instance to avoid accruing additional ec2 costs

### DIFF
--- a/.aws/duckdeploy/stack.py
+++ b/.aws/duckdeploy/stack.py
@@ -4,6 +4,7 @@ from aws_cdk import aws_autoscaling as autoscaling
 from aws_cdk import aws_ec2 as ec2
 from aws_cdk import aws_ecs as ecs
 from aws_cdk import aws_efs as efs
+from aws_cdk import aws_iam as iam
 from aws_cdk import aws_logs as logs
 from aws_cdk import aws_ssm as ssm
 from aws_cdk import core
@@ -85,9 +86,12 @@ class DuckBotStack(core.Stack):
             block_devices=[ec2.BlockDevice(device_name="/dev/xvda", volume=ec2.BlockDeviceVolume.ebs(volume_size=8, volume_type=ec2.EbsDeviceVolumeType.GP3))],
             instance_type=ec2.InstanceType.of(instance_class=ec2.InstanceClass.T3, instance_size=ec2.InstanceSize.MICRO),
             spot_options=ec2.LaunchTemplateSpotOptions(max_price=0.0052),  # $0.0052 is t3.nano on-demand price
+            cpu_credits=ec2.CpuCredits.STANDARD,
             key_name="duckbot",  # needs to be created manually
             machine_image=ec2.MachineImage.generic_linux(ami_map={"us-east-1": "ami-0c90bcaed0062d19b"}),  # custom ECS AMI created manually via https://github.com/aws/amazon-ecs-ami
             security_group=ec2.SecurityGroup(self, "HostSecurityGroup", vpc=vpc),
+            role=iam.Role(self, "AsgRole", assumed_by=iam.ServicePrincipal("ec2.amazonaws.com")),
+            user_data=ec2.UserData.for_linux(),
         )
         launch_template.connections.allow_to_default_port(file_system)
         launch_template.connections.allow_from(ec2.Peer.any_ipv4(), ec2.Port.tcp(22))
@@ -104,11 +108,6 @@ class DuckBotStack(core.Stack):
             instance_monitoring=autoscaling.Monitoring.BASIC,
             vpc=vpc,
         )
-
-        asg.connections.allow_to_default_port(file_system)
-        asg.connections.allow_from(ec2.Peer.any_ipv4(), ec2.Port.tcp(22))
-        asg.connections.allow_from(ec2.Peer.any_ipv4(), ec2.Port.tcp(80))
-        asg.connections.allow_from(ec2.Peer.any_ipv4(), ec2.Port.tcp(443))
 
         cluster = ecs.Cluster(self, "Cluster", cluster_name="duckbot", vpc=vpc)
         cluster.add_asg_capacity_provider(ecs.AsgCapacityProvider(cluster, "AsgCapacityProvider", auto_scaling_group=asg), can_containers_access_instance_role=True)

--- a/.aws/duckdeploy/stack.py
+++ b/.aws/duckdeploy/stack.py
@@ -84,6 +84,7 @@ class DuckBotStack(core.Stack):
             "LaunchTemplate",
             block_devices=[ec2.BlockDevice(device_name="/dev/xvda", volume=ec2.BlockDeviceVolume.ebs(volume_size=8, volume_type=ec2.EbsDeviceVolumeType.GP3))],
             instance_type=ec2.InstanceType.of(instance_class=ec2.InstanceClass.T3, instance_size=ec2.InstanceSize.MICRO),
+            spot_options=ec2.LaunchTemplateSpotOptions(max_price=0.0052),  # $0.0052 is t3.nano on-demand price
             key_name="duckbot",  # needs to be created manually
             machine_image=ec2.MachineImage.generic_linux(ami_map={"us-east-1": "ami-0c90bcaed0062d19b"}),  # custom ECS AMI created manually via https://github.com/aws/amazon-ecs-ami
             security_group=ec2.SecurityGroup(self, "HostSecurityGroup", vpc=vpc),
@@ -99,11 +100,7 @@ class DuckBotStack(core.Stack):
             min_capacity=0,
             max_capacity=1,
             desired_capacity=1,
-            machine_image=ec2.MachineImage.generic_linux(ami_map={"us-east-1": "ami-0c90bcaed0062d19b"}),  # custom ECS AMI created manually via https://github.com/aws/amazon-ecs-ami
-            instance_type=ec2.InstanceType.of(instance_class=ec2.InstanceClass.T3, instance_size=ec2.InstanceSize.MICRO),
-            spot_price="0.0052",  # t3.nano on-demand price
-            block_devices=[autoscaling.BlockDevice(device_name="/dev/xvda", volume=autoscaling.BlockDeviceVolume.ebs(volume_size=8, volume_type=autoscaling.EbsDeviceVolumeType.GP3))],
-            key_name="duckbot",  # needs to be created manually
+            launch_template=launch_template,
             instance_monitoring=autoscaling.Monitoring.BASIC,
             vpc=vpc,
         )

--- a/.aws/duckdeploy/stack.py
+++ b/.aws/duckdeploy/stack.py
@@ -90,7 +90,7 @@ class DuckBotStack(core.Stack):
             key_name="duckbot",  # needs to be created manually
             machine_image=ec2.MachineImage.generic_linux(ami_map={"us-east-1": "ami-0c90bcaed0062d19b"}),  # custom ECS AMI created manually via https://github.com/aws/amazon-ecs-ami
             security_group=ec2.SecurityGroup(self, "HostSecurityGroup", vpc=vpc),
-            role=iam.Role(self, "AsgRole", assumed_by=iam.ServicePrincipal("ec2.amazonaws.com")),
+            role=iam.Role(self, "HostRole", assumed_by=iam.ServicePrincipal("ec2.amazonaws.com")),
             user_data=ec2.UserData.for_linux(),
         )
         launch_template.connections.allow_to_default_port(file_system)


### PR DESCRIPTION
##### Summary

EC2 offers "unlimited" mode by default on T3 instances, which we're using now ([docs](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/burstable-performance-instances.html)). TLDR, this means we accrue CPU credits over time and use them during spikes, but if we run out, "unlimited" allows us to go over and charges us. I'd rather not, so this change forces the hosts to be started in "standard" mode. Using spot instances as well can exacerbate these costs, since hosts may be removed depending on reserve availability.

This required the creation of an ec2 launch template, instead of the old style launch configuration that CDK provides automatically for us. The behaviour should be identical here, just with the "standard" mode launch.

`cdk diff` produces:

```
Stack duckbot
IAM Statement Changes
┌───┬─────────────────┬────────┬────────────────────────────────────────────────────────────────────────────────────────┬─────────────────────────────────────────────┬──────────────────────────────────────────────────┐
│   │ Resource        │ Effect │ Action                                                                                 │ Principal                                   │ Condition                                        │
├───┼─────────────────┼────────┼────────────────────────────────────────────────────────────────────────────────────────┼─────────────────────────────────────────────┼──────────────────────────────────────────────────┤
│ - │ ${Cluster.Arn}  │ Allow  │ ecs:DeregisterContainerInstance                                                        │ AWS:${AutoScalingGroupInstanceRoleDC70D128} │                                                  │
│   │                 │        │ ecs:RegisterContainerInstance                                                          │                                             │                                                  │
│   │                 │        │ ecs:Submit*                                                                            │                                             │                                                  │
├───┼─────────────────┼────────┼────────────────────────────────────────────────────────────────────────────────────────┼─────────────────────────────────────────────┼──────────────────────────────────────────────────┤
│ - │ *               │ Allow  │ ecs:Poll                                                                               │ AWS:${AutoScalingGroupInstanceRoleDC70D128} │ "ArnEquals": {                                   │
│   │                 │        │ ecs:StartTelemetrySession                                                              │                                             │   "ecs:cluster": "${Cluster.Arn}"                │
│   │                 │        │                                                                                        │                                             │ }                                                │
│ - │ *               │ Allow  │ ecr:GetAuthorizationToken                                                              │ AWS:${AutoScalingGroupInstanceRoleDC70D128} │                                                  │
│   │                 │        │ ecs:DiscoverPollEndpoint                                                               │                                             │                                                  │
│   │                 │        │ logs:CreateLogStream                                                                   │                                             │                                                  │
│   │                 │        │ logs:PutLogEvents                                                                      │                                             │                                                  │
├───┼─────────────────┼────────┼────────────────────────────────────────────────────────────────────────────────────────┼─────────────────────────────────────────────┼──────────────────────────────────────────────────┤
│ + │ ${Cluster.Arn}  │ Allow  │ ecs:DeregisterContainerInstance                                                        │ AWS:${HostRole}                             │                                                  │
│   │                 │        │ ecs:RegisterContainerInstance                                                          │                                             │                                                  │
│   │                 │        │ ecs:Submit*                                                                            │                                             │                                                  │
├───┼─────────────────┼────────┼────────────────────────────────────────────────────────────────────────────────────────┼─────────────────────────────────────────────┼──────────────────────────────────────────────────┤
│ + │ ${HostRole.Arn} │ Allow  │ sts:AssumeRole                                                                         │ Service:ec2.${AWS::URLSuffix}               │                                                  │
├───┼─────────────────┼────────┼────────────────────────────────────────────────────────────────────────────────────────┼─────────────────────────────────────────────┼──────────────────────────────────────────────────┤
│ + │ *               │ Allow  │ ecs:Poll                                                                               │ AWS:${HostRole}                             │ "ArnEquals": {                                   │
│   │                 │        │ ecs:StartTelemetrySession                                                              │                                             │   "ecs:cluster": "${Cluster.Arn}"                │
│   │                 │        │                                                                                        │                                             │ }                                                │
│ + │ *               │ Allow  │ ecr:GetAuthorizationToken                                                              │ AWS:${HostRole}                             │                                                  │
│   │                 │        │ ecs:DiscoverPollEndpoint                                                               │                                             │                                                  │
│   │                 │        │ logs:CreateLogStream                                                                   │                                             │                                                  │
│   │                 │        │ logs:PutLogEvents                                                                      │                                             │                                                  │
└───┴─────────────────┴────────┴────────────────────────────────────────────────────────────────────────────────────────┴─────────────────────────────────────────────┴──────────────────────────────────────────────────┘
Security Group Changes
┌───┬────────────────────────────────────────────────┬─────┬────────────┬──────────────────────────────────────────────────────────┐
│   │ Group                                          │ Dir │ Protocol   │ Peer                                                     │
├───┼────────────────────────────────────────────────┼─────┼────────────┼──────────────────────────────────────────────────────────┤
│ - │ ${PostgresFileSystem/EfsSecurityGroup.GroupId} │ In  │ TCP 2049   │ ${AutoScalingGroupInstanceSecurityGroup9D2E0C5E.GroupId} │
├───┼────────────────────────────────────────────────┼─────┼────────────┼──────────────────────────────────────────────────────────┤
│ + │ ${HostSecurityGroup.GroupId}                   │ In  │ TCP 22     │ Everyone (IPv4)                                          │
│ + │ ${HostSecurityGroup.GroupId}                   │ In  │ TCP 80     │ Everyone (IPv4)                                          │
│ + │ ${HostSecurityGroup.GroupId}                   │ In  │ TCP 443    │ Everyone (IPv4)                                          │
│ + │ ${HostSecurityGroup.GroupId}                   │ Out │ Everything │ Everyone (IPv4)                                          │
├───┼────────────────────────────────────────────────┼─────┼────────────┼──────────────────────────────────────────────────────────┤
│ + │ ${PostgresFileSystem/EfsSecurityGroup.GroupId} │ In  │ TCP 2049   │ ${HostSecurityGroup.GroupId}                             │
└───┴────────────────────────────────────────────────┴─────┴────────────┴──────────────────────────────────────────────────────────┘
(NOTE: There may be security-related changes not in this list. See https://github.com/aws/aws-cdk/issues/1299)

Mappings
[-] Mapping AutoScalingGroupAmiMap55901487: {"us-east-1":{"ami":"ami-0c90bcaed0062d19b"}}
[+] Mapping LaunchTemplate/AmiMap LaunchTemplateAmiMapC82C2BFF: {"us-east-1":{"ami":"ami-0c90bcaed0062d19b"}}

Resources
[-] AWS::EC2::SecurityGroupIngress PostgresFileSystemEfsSecurityGroupfromduckbotAutoScalingGroupInstanceSecurityGroupCDC4835520495C008C3C destroy
[-] AWS::EC2::SecurityGroup AutoScalingGroupInstanceSecurityGroup9D2E0C5E destroy
[-] AWS::IAM::Role AutoScalingGroupInstanceRoleDC70D128 destroy
[-] AWS::IAM::Policy AutoScalingGroupInstanceRoleDefaultPolicy3DF09528 destroy
[-] AWS::IAM::InstanceProfile AutoScalingGroupInstanceProfile342FAC7C destroy
[-] AWS::AutoScaling::LaunchConfiguration AutoScalingGroupLaunchConfigDEEB160C destroy
[+] AWS::EC2::SecurityGroupIngress PostgresFileSystem/EfsSecurityGroup/from duckbotHostSecurityGroupB7A206BE:2049 PostgresFileSystemEfsSecurityGroupfromduckbotHostSecurityGroupB7A206BE204958E32FF0 
[+] AWS::EC2::SecurityGroup HostSecurityGroup HostSecurityGroupCA615E03 
[+] AWS::IAM::Role HostRole HostRole96745B4B 
[+] AWS::IAM::Policy HostRole/DefaultPolicy HostRoleDefaultPolicy61397894 
[+] AWS::IAM::InstanceProfile LaunchTemplate/Profile LaunchTemplateProfile94AA77CE 
[+] AWS::EC2::LaunchTemplate LaunchTemplate LaunchTemplate04EC5460 
[~] AWS::ECS::TaskDefinition TaskDefinition TaskDefinitionB36D86D9 replace
 └─ [~] ContainerDefinitions (requires replacement)
     └─ @@ -70,7 +70,7 @@
        [ ]   "StartPeriod": 30,
        [ ]   "Timeout": 10
        [ ] },
        [-] "Image": "duckdynasty/duckbot:81448ca",
        [+] "Image": "duckdynasty/duckbot:latest",
        [ ] "Links": [
        [ ]   "postgres"
        [ ] ],
[~] AWS::AutoScaling::AutoScalingGroup AutoScalingGroup/ASG AutoScalingGroupASG804C35BE 
 ├─ [-] LaunchConfigurationName
 │   └─ {"Ref":"AutoScalingGroupLaunchConfigDEEB160C"}
 ├─ [+] LaunchTemplate
 │   └─ {"LaunchTemplateId":{"Ref":"LaunchTemplate04EC5460"},"Version":{"Fn::GetAtt":["LaunchTemplate04EC5460","LatestVersionNumber"]}}
 └─ [-] Tags
     └─ [{"Key":"Name","PropagateAtLaunch":true,"Value":"duckbot/AutoScalingGroup"}]
```

##### Checklist

- [x] this is a source code change
  - [x] run `format` in the repository root
  - [x] run `pytest` in the repository root
  - [x] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [x] update the wiki documentation if necessary
- [ ] or, this is **not** a source code change
