### PR TITLE
🚀 allow autoscaling to scale in instances

### DIFF
--- a/.aws/duckdeploy/stack.py
+++ b/.aws/duckdeploy/stack.py
@@ -85,6 +85,7 @@ class DuckBotStack(core.Stack):
             min_capacity=0,
             max_capacity=1,
             desired_capacity=1,
+            new_instances_protected_from_scale_in=False,
             machine_image=ec2.MachineImage.generic_linux(ami_map={"us-east-1": "ami-0c90bcaed0062d19b"}),  # custom ECS AMI created manually via https://github.com/aws/amazon-ecs-ami
             instance_type=ec2.InstanceType.of(instance_class=ec2.InstanceClass.T3, instance_size=ec2.InstanceSize.MICRO),
             spot_price="0.0052",  # t3.nano on-demand price

--- a/.aws/duckdeploy/stack.py
+++ b/.aws/duckdeploy/stack.py
@@ -102,7 +102,7 @@ class DuckBotStack(core.Stack):
 
         cluster = ecs.Cluster(self, "Cluster", cluster_name="duckbot", vpc=vpc)
         cluster.add_asg_capacity_provider(
-            ecs.AsgCapacityProvider(cluster, "AsgCapacityProvider", auto_scaling_group=asg), can_containers_access_instance_role=True, enable_managed_termination_protection=False
+            ecs.AsgCapacityProvider(cluster, "AsgCapacityProvider", auto_scaling_group=asg, enable_managed_termination_protection=False), can_containers_access_instance_role=True
         )
 
         ecs.Ec2Service(

--- a/.aws/duckdeploy/stack.py
+++ b/.aws/duckdeploy/stack.py
@@ -102,7 +102,8 @@ class DuckBotStack(core.Stack):
 
         cluster = ecs.Cluster(self, "Cluster", cluster_name="duckbot", vpc=vpc)
         cluster.add_asg_capacity_provider(
-            ecs.AsgCapacityProvider(cluster, "AsgCapacityProvider", auto_scaling_group=asg, enable_managed_termination_protection=False), can_containers_access_instance_role=True
+            ecs.AsgCapacityProvider(cluster, "AsgCapacityProvider", auto_scaling_group=asg, enable_managed_termination_protection=False, enable_managed_scaling=False),
+            can_containers_access_instance_role=True,
         )
 
         ecs.Ec2Service(

--- a/.aws/duckdeploy/stack.py
+++ b/.aws/duckdeploy/stack.py
@@ -107,10 +107,9 @@ class DuckBotStack(core.Stack):
                 "AsgCapacityProvider",
                 auto_scaling_group=asg,
                 enable_managed_termination_protection=False,
-                enable_managed_scaling=False,
-                task_drain_time=core.Duration.seconds(0),
             ),
             can_containers_access_instance_role=True,
+            task_drain_time=core.Duration.seconds(0),
         )
 
         ecs.Ec2Service(

--- a/.aws/duckdeploy/stack.py
+++ b/.aws/duckdeploy/stack.py
@@ -100,7 +100,9 @@ class DuckBotStack(core.Stack):
         asg.connections.allow_from(ec2.Peer.any_ipv4(), ec2.Port.tcp(443))
 
         cluster = ecs.Cluster(self, "Cluster", cluster_name="duckbot", vpc=vpc)
-        cluster.add_asg_capacity_provider(ecs.AsgCapacityProvider(cluster, "AsgCapacityProvider", auto_scaling_group=asg), can_containers_access_instance_role=True)
+        cluster.add_asg_capacity_provider(
+            ecs.AsgCapacityProvider(cluster, "AsgCapacityProvider", auto_scaling_group=asg), can_containers_access_instance_role=True, enable_managed_termination_protection=False
+        )
 
         ecs.Ec2Service(
             self,

--- a/.aws/duckdeploy/stack.py
+++ b/.aws/duckdeploy/stack.py
@@ -102,7 +102,14 @@ class DuckBotStack(core.Stack):
 
         cluster = ecs.Cluster(self, "Cluster", cluster_name="duckbot", vpc=vpc)
         cluster.add_asg_capacity_provider(
-            ecs.AsgCapacityProvider(cluster, "AsgCapacityProvider", auto_scaling_group=asg, enable_managed_termination_protection=False, enable_managed_scaling=False),
+            ecs.AsgCapacityProvider(
+                cluster,
+                "AsgCapacityProvider",
+                auto_scaling_group=asg,
+                enable_managed_termination_protection=False,
+                enable_managed_scaling=False,
+                task_drain_time=core.Duration.seconds(0),
+            ),
             can_containers_access_instance_role=True,
         )
 


### PR DESCRIPTION
##### Summary

CDK for ECS decided to override the default behaviour of autoscaling groups, in that they can downscale when required. This is kinda non-sensical, and prevents updates to the autoscaling group (such as the instance type) from actually taking place automatically.

`cdk diff` produces:
```
Stack duckbot
Resources
[~] AWS::ECS::TaskDefinition TaskDefinition TaskDefinitionB36D86D9 replace
 └─ [~] ContainerDefinitions (requires replacement)
     └─ @@ -70,7 +70,7 @@
        [ ]   "StartPeriod": 30,
        [ ]   "Timeout": 10
        [ ] },
        [-] "Image": "duckdynasty/duckbot:81448ca",
        [+] "Image": "duckdynasty/duckbot:latest",
        [ ] "Links": [
        [ ]   "postgres"
        [ ] ],
[~] AWS::AutoScaling::AutoScalingGroup AutoScalingGroup/ASG AutoScalingGroupASG804C35BE 
 └─ [~] NewInstancesProtectedFromScaleIn
[~] AWS::ECS::CapacityProvider Cluster/AsgCapacityProvider/AsgCapacityProvider ClusterAsgCapacityProviderE9FF1439 
 └─ [~] AutoScalingGroupProvider
     └─ [~] .ManagedTerminationProtection:
         ├─ [-] ENABLED
         └─ [+] DISABLED
```

` [~] NewInstancesProtectedFromScaleIn` isn't super helpful, I also ran:
```
(duckbot) lemon@lemonade:~/git/duckbot/.aws$ cdk synth | grep -C 2 New
      LaunchConfigurationName:
        Ref: AutoScalingGroupLaunchConfigDEEB160C
      NewInstancesProtectedFromScaleIn: false
      Tags:
        - Key: Name
```

##### Checklist

- [x] this is a source code change
  - [x] run `format` in the repository root
  - [x] run `pytest` in the repository root
  - [x] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [x] update the wiki documentation if necessary
- [ ] or, this is **not** a source code change
