### PR TITLE
:bug: correct Lief Erikson Day to be oct 9th

### DIFF
--- a/duckbot/cogs/announce_day/special_days.py
+++ b/duckbot/cogs/announce_day/special_days.py
@@ -42,7 +42,7 @@ class SpecialDays(holidays.Canada):
         self[date(year, 9, 8)] = f"Dan's Birthday. He {year-1989} old. :headstone: to a legend"
         self[date(year, 9, 26)] = f"Tom's Birthday. He's {year-1990} years old. How he made it this far, we'll never know"
         self[date(year, 10, 7)] = f"Delta's Birthday. He's {year-2015} years old and is a good boy"
-        self[date(year, 10, 11)] = "Leif Erikson Day. Hinga Dinga Durgen! https://tenor.com/view/viking-spongebob-squarepants-durgen-fall-down-hard-gif-7302846 "  # intentional trailing space for gif
+        self[date(year, 10, 9)] = "Leif Erikson Day. Hinga Dinga Durgen! https://tenor.com/view/viking-spongebob-squarepants-durgen-fall-down-hard-gif-7302846 "  # intentional trailing space for gif
         self[date(year, 10, 31)] = "Halloween"
         self[date(year, 11, 10)] = f"Tom and Kelly's fake wedding anniversary. They've been fake together for {year-2014} years"
         self[date(year, 11, 12)] = f"Sabrina's Birthday. She is {year-1996} years old. Good work on surviving"


### PR DESCRIPTION
Update Lief Erikson day to not be completely wrong

##### Summary

Lief Erikson day is the 9th of October, not the 11th
[fixes 603](https://github.com/duck-dynasty/duckbot/issues/603)

##### Checklist

- [x] this is a source code change
  - [ ] run `format` in the repository root
  - [ ] run `pytest` in the repository root
  - [x] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [ ] update the wiki documentation if necessary
- [ ] or, this is **not** a source code change
