### PR TITLE
⬆️ Bump pytest_sugar from 0.9.5 to 0.9.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ if __name__ == "__main__":
                 "mdformat-black==0.1.1",
                 "responses==0.22.0",
                 "pytest-blockage==0.2.4",
-                "pytest-sugar==0.9.5",
+                "pytest-sugar==0.9.6",
                 "pytest-icdiff==0.6",
                 "pytest-cov==4.0.0",
                 "pytest-lazy-fixture==0.6.3",


### PR DESCRIPTION
##### Summary

Update pytest sugar from 0.9.5 to 0.9.6. 

Pytest kept crashing on my comp, but after this update, everything was fine. 

Idk if this will screw with dependabot. 

##### Checklist

- [x] this is a source code change
  - [x] run `format` in the repository root
  - [x] run `pytest` in the repository root
  - [ ] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [ ] update the wiki documentation if necessary
- [ ] or, this is **not** a source code change


