### PR TITLE
:broom: Rename/correct duck test names

### DIFF
--- a/tests/cogs/duck/duck_test.py
+++ b/tests/cogs/duck/duck_test.py
@@ -5,14 +5,14 @@ from duckbot.util.emojis import regional_indicator
 
 
 @mock.patch("random.random", return_value=0.0001)
-async def test_react_duck_random_passes(random, bot, message):
+async def test_react_duck_random_fails(random, bot, message):
     clazz = Duck(bot)
     await clazz.react_duck(message)
     message.add_reaction.assert_not_called()
 
 
 @mock.patch("random.random", return_value=0.000009)
-async def test_react_duck_random_fails(random, bot, message):
+async def test_react_duck_random_passes(random, bot, message):
     clazz = Duck(bot)
     await clazz.react_duck(message)
     message.add_reaction.assert_called_once_with("\U0001F986")


### PR DESCRIPTION
##### Summary

Swap the test names for duck react (pass/fail) since they were backwards. 

##### Checklist

- [x] this is a source code change
  - [x] run `format` in the repository root
  - [x] run `pytest` in the repository root
  - [ ] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [ ] update the wiki documentation if necessary
- [ ] or, this is **not** a source code change


