### PR TITLE
👷 address github actions set-output deprecation

### DIFF
--- a/.github/actions/build-push-docker-image/action.yml
+++ b/.github/actions/build-push-docker-image/action.yml
@@ -27,17 +27,17 @@ runs:
       echo "commit=duckdynasty/duckbot:$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
   - name: Set up Docker Buildx
-    uses: docker/setup-buildx-action@v1
+    uses: docker/setup-buildx-action@v2
 
   - name: Set up Docker Build Cache
-    uses: actions/cache@v2
+    uses: actions/cache@v3
     with:
       path: /tmp/.buildx-cache
       key: ${{ runner.os }}-buildx-${{ github.sha }}
       restore-keys: ${{ runner.os }}-buildx-
 
   - name: Login to Docker
-    uses: docker/login-action@v1
+    uses: docker/login-action@v2
     with:
       username: duckdynasty
       password: ${{ inputs.docker-pass }}

--- a/.github/actions/build-push-docker-image/action.yml
+++ b/.github/actions/build-push-docker-image/action.yml
@@ -17,7 +17,7 @@ outputs:
 runs:
   using: composite
   steps:
-  - uses: actions/checkout@v2
+  - uses: actions/checkout@v3
 
   - name: Create Docker Image Tags
     id: image

--- a/.github/actions/build-push-docker-image/action.yml
+++ b/.github/actions/build-push-docker-image/action.yml
@@ -23,8 +23,8 @@ runs:
     id: image
     shell: bash
     run: |
-      echo "::set-output name=latest::duckdynasty/duckbot:latest"
-      echo "::set-output name=commit::duckdynasty/duckbot:$(git rev-parse --short HEAD)"
+      echo "latest=duckdynasty/duckbot:latest" >> $GITHUB_OUTPUT
+      echo "commit=duckdynasty/duckbot:$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
   - name: Set up Docker Buildx
     uses: docker/setup-buildx-action@v1

--- a/.github/actions/setup-aws-cdk/action.yml
+++ b/.github/actions/setup-aws-cdk/action.yml
@@ -19,7 +19,7 @@ runs:
       path: cdk
 
   - name: Set up Node.js
-    uses: actions/setup-node@v2.5.1
+    uses: actions/setup-node@v3
     with:
       node-version: 16.x
 

--- a/.github/actions/setup-aws-cdk/action.yml
+++ b/.github/actions/setup-aws-cdk/action.yml
@@ -9,7 +9,7 @@ outputs:
 runs:
   using: composite
   steps:
-  - uses: actions/checkout@v2
+  - uses: actions/checkout@v3
 
   - name: Set up Python Environment
     id: venv

--- a/.github/actions/setup-python-venv/action.yml
+++ b/.github/actions/setup-python-venv/action.yml
@@ -28,7 +28,7 @@ runs:
   - name: Create path Output
     id: path
     shell: bash
-    run: echo "::set-output name=path::${{ inputs.path }}"
+    run: echo "path=${{ inputs.path }}" >> $GITHUB_OUTPUT
 
   - name: Set up Virtual Environment Cache
     id: venv

--- a/.github/actions/setup-python-venv/action.yml
+++ b/.github/actions/setup-python-venv/action.yml
@@ -19,7 +19,7 @@ outputs:
 runs:
   using: composite
   steps:
-  - uses: actions/checkout@v2
+  - uses: actions/checkout@v3
   - name: Set up Python 3.8
     uses: actions/setup-python@v2
     with:

--- a/.github/actions/setup-python-venv/action.yml
+++ b/.github/actions/setup-python-venv/action.yml
@@ -21,7 +21,7 @@ runs:
   steps:
   - uses: actions/checkout@v3
   - name: Set up Python 3.8
-    uses: actions/setup-python@v2
+    uses: actions/setup-python@v4
     with:
       python-version: '3.8'
 
@@ -32,7 +32,7 @@ runs:
 
   - name: Set up Virtual Environment Cache
     id: venv
-    uses: actions/cache@v2
+    uses: actions/cache@v3
     with:
       path: ${{ steps.path.outputs.path }}
       key: ${{ env.pythonLocation }}-${{ inputs.extras }}-${{ hashFiles('setup.py', 'pyproject.toml') }}

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -89,7 +89,7 @@ jobs:
       uses: ./.github/actions/setup-aws-cdk
 
     - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@v1
+      uses: aws-actions/configure-aws-credentials@v1-node16
       with:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
##### Summary

Our actions have a fair bit of warnings on them, [example run](https://github.com/duck-dynasty/duckbot/actions/runs/3463322710). `set-output` is being deprecated for whatever reason.

There are several other warnings, but they seem to be from other actions we depend on, like `setup-python`. The `deploy` step for example:
```
Please update the following actions to use Node.js 16: actions/checkout, docker/setup-buildx-action, actions/cache, docker/login-action, actions/checkout, actions/checkout, actions/setup-python, actions/cache, actions/setup-node, aws-actions/configure-aws-credentials, aws-actions/configure-aws-credentials, actions/cache, actions/setup-python, actions/checkout, actions/setup-node, actions/checkout, docker/login-action, actions/cache, docker/setup-buildx-action, actions/checkout
```
~~Dependabot should [update these automatically](https://github.com/duck-dynasty/duckbot/blob/main/.github/dependabot.yml#L9). I imagine these are also what all the `save-state` deprecation warnings are from too -- we don't use that command.~~  
It seems dependabot does not update these nested actions. I've updated the ones that have updates.

See [blog post](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) about the deprecation.

##### Checklist

- [ ] this is a source code change
  - [ ] run `format` in the repository root
  - [ ] run `pytest` in the repository root
  - [ ] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [ ] update the wiki documentation if necessary
- [x] or, this is **not** a source code change
