### PR TITLE
:bug: Special Days --- Fix duckbot's inception day seconds calculation

### DIFF
--- a/duckbot/cogs/announce_day/special_days.py
+++ b/duckbot/cogs/announce_day/special_days.py
@@ -49,5 +49,5 @@ class SpecialDays(holidays.Canada):
         self[date(year, 11, 14)] = f"Male Kelly's birthday... Maybe... idk. He's around {year - 1989} years old now."
         self[date(year, 11, 1) + rd(weekday=FR(+4))] = "Black Friday. I hope I can get some new socks"
         self[date(year, 12, 2)] = f"Female Kelly's Birthday. She's {year-1989} years old"
-        self[date(year, 12, 3)] = f"DuckBot's Inception Day. I'm about {(now()-datetime(2020, 12, 3, 10, 39, tzinfo=timezone())).seconds}s old"
+        self[date(year, 12, 3)] = f"DuckBot's Inception Day. I'm about {(now()-datetime(2020, 12, 3, 10, 39, tzinfo=timezone())).total_seconds()}s old"
         self[date(year, 12, 5)] = f"Taras' Birthday. He's {year-1989} years old"

--- a/tests/cogs/announce_day/special_days_test.py
+++ b/tests/cogs/announce_day/special_days_test.py
@@ -35,10 +35,11 @@ def test_populate_black_friday(bot, date):
 
 
 @mock.patch("duckbot.cogs.announce_day.special_days.now")
-@pytest.mark.parametrize("time", [datetime(2021, 12, 3, 11, tzinfo=timezone()), datetime(2022, 12, 3, 7, tzinfo=timezone())])
-def test_populate_duckbot_day(now, bot, time):
-    initial_commit_datetime = datetime(2020, 12, 3, 10, 39, tzinfo=timezone())
-    seconds_since_commit = (time - initial_commit_datetime).seconds
+@pytest.mark.parametrize(
+    "time, seconds",
+    [(datetime(2020, 12, 3, 10, 39, tzinfo=timezone()), 0.0), (datetime(2021, 12, 3, 10, 39, tzinfo=timezone()), 31536000.0), (datetime(2022, 12, 3, 10, 39, tzinfo=timezone()), 63072000.0)],
+)
+def test_populate_duckbot_day(now, bot, time, seconds):
     now.return_value = time
     clazz = SpecialDays(bot)
-    assert clazz.get_list(time) == [f"DuckBot's Inception Day. I'm about {seconds_since_commit}s old"]
+    assert clazz.get_list(time) == [f"DuckBot's Inception Day. I'm about {seconds}s old"]


### PR DESCRIPTION
##### Summary

Closes #640 

- Fix the duckbot total seconds alive calculation by using the `totalSeconds()` method 
- Update the unittest to have hardcoded values. 

**NOTE** I kinda hate how format formatted the stuff in the parameterized test annotation 

##### Checklist

- [x] this is a source code change
  - [x] run `format` in the repository root
  - [x] run `pytest` in the repository root
  - [x] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [ ] update the wiki documentation if necessary
- [ ] or, this is **not** a source code change
