### PR TITLE
Commands --- Add `!wiki` as an alias for `!help` :microscope: 

### DIFF
--- a/duckbot/cogs/duck/duck.py
+++ b/duckbot/cogs/duck/duck.py
@@ -30,7 +30,7 @@ class Duck(commands.Cog):
     async def github(self, context):
         await context.send("https://github.com/duck-dynasty/duckbot")
 
-    @commands.command(name="help")
+    @commands.command(name="help", aliases=["wiki"])
     async def wiki_command(self, context):
         await self.wiki(context)
 

--- a/wiki/Commands.md
+++ b/wiki/Commands.md
@@ -17,7 +17,7 @@
 |        [`!roll`](#dice)        | rolls Dungeons and Dragons style dice              |
 |            `!coin`             | flips a coin. in real life                         |
 | [`!yolo`](#yolo-pull-requests) | list open pull requests in this repo               |
-|            `!help`             | gives a link to this wiki                          |
+|       `!help` or `!wiki`       | gives a link to this wiki                          |
 |            `!duck`             | gives a link to this repo                          |
 
 ## Day Announcements


### PR DESCRIPTION
##### Summary

- Add `!wiki` as an alias for `!help`
- @twentylemon suggested an alias after I spammed `!wiki` expecting `!help`'s functionality
- Uses the `aliases` attribute for the command decorator object 
- No new tests required. Checked that alias worked manually
- Updated wiki. Although a comma (`,`) was used to indicate more than one command on a line in the table, that was for the music, and the 2 commands have different funcationay (`!start` and `!stop`). I opted for "or" since that makes more sense for the alias. 


##### Checklist

- [x] this is a source code change
  - [x] run `format` in the repository root
  - [x] run `pytest` in the repository root
  - [ ] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [x] update the wiki documentation if necessary
- [ ] or, this is **not** a source code change
