### PR TITLE
:bug: Readme --- Fix badge url :microscope: 

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![GitHub License](https://img.shields.io/github/license/duck-dynasty/duckbot)](https://github.com/duck-dynasty/duckbot/blob/main/LICENSE)
 [![GitHub Issues](https://img.shields.io/github/issues/duck-dynasty/duckbot)](https://github.com/duck-dynasty/duckbot/issues)
-[![Build Status](https://img.shields.io/github/workflow/status/duck-dynasty/duckbot/DuckBot%20CI)](https://github.com/duck-dynasty/duckbot/actions/workflows/python-package.yml)
+[![Build Status](https://img.shields.io/github/actions/workflow/status/duck-dynasty/duckbot/python-package.yml?branch=main)](https://github.com/duck-dynasty/duckbot/actions/workflows/python-package.yml)
 [![codecov](https://codecov.io/gh/duck-dynasty/duckbot/branch/main/graph/badge.svg?token=FX4DT5MWBW)](https://codecov.io/gh/duck-dynasty/duckbot)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![Imports: isort](https://img.shields.io/badge/%20imports-isort-%231674b1?style=flat&labelColor=ef8336)](https://pycqa.github.io/isort/)


### PR DESCRIPTION
##### Summary

- Closes #646 
- Update README to have the fancy badges work correctly based on external changes 
- Update the badge URL to what was said here https://github.com/badges/shields/issues/8671
- I ran format again because 
- Checked the branch, looks good:
![image](https://user-images.githubusercontent.com/1328048/209849576-19d4ca47-356a-4db8-b520-4e6a0f9fd82d.png)


##### Checklist

- [x] or, this is **not** a source code change
- [ ] this is a source code change
  - [x] run `format` in the repository root
  - [ ] run `pytest` in the repository root
  - [x] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [ ] update the wiki documentation if necessary
