### PR TITLE
🐛 wrap `/define` in typing

### DIFF
--- a/duckbot/cogs/text/dictionary.py
+++ b/duckbot/cogs/text/dictionary.py
@@ -17,7 +17,8 @@ class Dictionary(commands.Cog):
         """
         :param word: The word to define.
         """
-        await self.define(context, word)
+        async with context.typing():
+            await self.define(context, word)
 
     async def define(self, context: commands.Context, word: str):
         roots = self.get_root_words(word.lower()) or ["why"]


### PR DESCRIPTION
##### Summary

I used `/define` and got no response recently, may be because discord demands any response from a slash command within like 3 seconds iirc. Sending "thinking" is a valid response we use in a lot of other commands, so adding it to `/define` as well. 

##### Checklist

- [x] this is a source code change
  - [x] run `format` in the repository root
  - [x] run `pytest` in the repository root
  - [x] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [x] update the wiki documentation if necessary
- [ ] or, this is **not** a source code change
