### PR TITLE
💬 change typo correction message

### DIFF
--- a/duckbot/cogs/corrections/typos.py
+++ b/duckbot/cogs/corrections/typos.py
@@ -15,7 +15,7 @@ class Typos(commands.Cog):
             if prev is not None:
                 c = self.correct(prev.content)
                 if c != prev.content:
-                    await prev.reply(f"> {c}\nThink I fixed it, {message.author.display_name}!")
+                    await prev.reply(f"> {c}\nI fixed it, {message.author.display_name}. :microphone: :wave:")
                 else:
                     await message.reply(f"There's no need for harsh words, {message.author.display_name}.")
 

--- a/tests/cogs/corrections/typos_test.py
+++ b/tests/cogs/corrections/typos_test.py
@@ -53,4 +53,4 @@ async def test_correct_typos_sends_correction(textblob, prev_message, bot, messa
     textblob.return_value.correct.return_value = TextBlob("hello")
     clazz = Typos(bot)
     await clazz.correct_typos(message)
-    prev_message.reply.assert_called_once_with(f"> hello\nThink I fixed it, {message.author.display_name}!")
+    prev_message.reply.assert_called_once_with(f"> hello\nI fixed it, {message.author.display_name}. :microphone: :wave:")


### PR DESCRIPTION
##### Summary

Small change I thought of while letting my mind wander on a walkies. Corrections are rarely correct, so I figured it'd be a little funnier if duckbot was more arrogant about the corrections made. A mic gets dropped.

Note, the wiki does contain info about typo correction, but the example message there was already slightly different from reality. I figure the meat of the documentation is still valid, so no update is actually required.

##### Checklist

- [x] this is a source code change
  - [x] run `format` in the repository root
  - [x] run `pytest` in the repository root
  - [x] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [ ] update the wiki documentation if necessary
- [ ] or, this is **not** a source code change
