### PR TITLE
🔥remove offensive fortunes and cowsay

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update && apt-get -y install \
     ffmpeg \
     libpq-dev \
     libatlas-base-dev \
-    fortune-mod fortunes fortunes-off cowsay cowsay-off \
+    fortune-mod fortunes cowsay \
   && apt-get clean && rm -rf /var/lib/apt/lists/*
 ENV PATH "$PATH:/usr/games"
 ENV VIRTUAL_ENV "/opt/venv"


### PR DESCRIPTION
##### Summary

Docker image builds are failing due to `fortunes-off` no longer being found during installation. I was at my computer so I figured I'd author this quickly as a quick fix. /shrug

##### Checklist

- [ ] this is a source code change
  - [ ] run `format` in the repository root
  - [ ] run `pytest` in the repository root
  - [ ] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [ ] update the wiki documentation if necessary
- [x] or, this is **not** a source code change
