### PR TITLE
:arrow_up: bump python from 3.8 to 3.10

### DIFF
--- a/.github/actions/setup-python-venv/action.yml
+++ b/.github/actions/setup-python-venv/action.yml
@@ -23,7 +23,7 @@ runs:
   - name: Set up Python
     uses: actions/setup-python@v4
     with:
-      python-version: '3.11'
+      python-version: '3.10'
 
   - name: Create path Output
     id: path

--- a/.github/actions/setup-python-venv/action.yml
+++ b/.github/actions/setup-python-venv/action.yml
@@ -23,7 +23,7 @@ runs:
   - name: Set up Python
     uses: actions/setup-python@v4
     with:
-      python-version: '3.12'
+      python-version: '3.11'
 
   - name: Create path Output
     id: path

--- a/.github/actions/setup-python-venv/action.yml
+++ b/.github/actions/setup-python-venv/action.yml
@@ -20,10 +20,10 @@ runs:
   using: composite
   steps:
   - uses: actions/checkout@v4
-  - name: Set up Python 3.8
+  - name: Set up Python
     uses: actions/setup-python@v4
     with:
-      python-version: '3.8'
+      python-version: '3.12'
 
   - name: Create path Output
     id: path

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -27,6 +27,11 @@ jobs:
       if: ${{ always() }}
       uses: codecov/codecov-action@v3
 
+    - name: Run Linter
+      run: |
+        . ${{ steps.venv.outputs.path }}/bin/activate
+        flake8 duckbot tests
+
   sanity:
     runs-on: ubuntu-latest
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # collect pip dependencies into a virtualenv, which we'll copy into the prod stage
-FROM python:3.8 as pip-dependencies
+FROM python:3.12 as pip-dependencies
 ENV VIRTUAL_ENV "/opt/venv"
 RUN python -m venv $VIRTUAL_ENV
 ENV PATH "$VIRTUAL_ENV/bin:$PATH"
@@ -13,7 +13,7 @@ COPY pyproject.toml .
 COPY setup.py .
 RUN pip install .
 
-FROM python:3.8-slim as prod
+FROM python:3.12-slim as prod
 # ffmpeg: for discord audio
 # libpq-dev: postgres client libraries
 # libatlas-base-dev: matplotlib dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # collect pip dependencies into a virtualenv, which we'll copy into the prod stage
-FROM python:3.12 as pip-dependencies
+FROM python:3.10 as pip-dependencies
 ENV VIRTUAL_ENV "/opt/venv"
 RUN python -m venv $VIRTUAL_ENV
 ENV PATH "$VIRTUAL_ENV/bin:$PATH"
@@ -13,7 +13,7 @@ COPY pyproject.toml .
 COPY setup.py .
 RUN pip install .
 
-FROM python:3.12-slim as prod
+FROM python:3.10-slim as prod
 # ffmpeg: for discord audio
 # libpq-dev: postgres client libraries
 # libatlas-base-dev: matplotlib dependencies

--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ https://user-images.githubusercontent.com/3149083/135654217-244d7457-9db9-4c30-a
 
 ## Development
 
-Before running DuckBot, you want to create a virtualenv to develop in. DuckBot runs on `python3.8`, so prefer to use that.
+Before running DuckBot, you want to create a virtualenv to develop in. DuckBot runs on `python3.12`, so prefer to use that.
 
 ```sh
-python3.8 -m venv --clear --prompt duckbot venv
+python3.12 -m venv --clear --prompt duckbot venv
 . venv/bin/activate
 pip install --upgrade pip setuptools wheel
 SETUPTOOLS_ENABLE_FEATURES="legacy-editable" pip install --editable .[dev]

--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ https://user-images.githubusercontent.com/3149083/135654217-244d7457-9db9-4c30-a
 
 ## Development
 
-Before running DuckBot, you want to create a virtualenv to develop in. DuckBot runs on `python3.12`, so prefer to use that.
+Before running DuckBot, you want to create a virtualenv to develop in. DuckBot runs on `python3.10`, so prefer to use that.
 
 ```sh
-python3.12 -m venv --clear --prompt duckbot venv
+python3.10 -m venv --clear --prompt duckbot venv
 . venv/bin/activate
 pip install --upgrade pip setuptools wheel
 SETUPTOOLS_ENABLE_FEATURES="legacy-editable" pip install --editable .[dev]

--- a/duckbot/cogs/text/mock_text.py
+++ b/duckbot/cogs/text/mock_text.py
@@ -1,6 +1,6 @@
 from discord.ext import commands
 
-from duckbot.util.messages import get_message_reference, try_delete
+import duckbot.util.messages
 
 
 class MockText(commands.Cog):
@@ -16,7 +16,7 @@ class MockText(commands.Cog):
             mocked_text = await self.mockify(f"{context.message.author.display_name}, based on this, I should mock you... I need text dude.")
         else:
             mocked_text = await self.mockify(text.strip())
-        reply = await get_message_reference(context.message)
+        reply = await duckbot.util.messages.get_message_reference(context.message)
         if reply:
             await reply.reply(mocked_text)
         else:
@@ -35,4 +35,4 @@ class MockText(commands.Cog):
 
     @mock_text_command.after_invoke
     async def delete_command_message(self, context: commands.Context):
-        await try_delete(context.message)
+        await duckbot.util.messages.try_delete(context.message)

--- a/duckbot/cogs/tito/tito.py
+++ b/duckbot/cogs/tito/tito.py
@@ -13,7 +13,7 @@ class Tito(commands.Cog):
     async def react_to_tito_with_yugoslavia(self, message):
         """Adds reactions for all formally Yugoslavian country flags when :tito: is sent."""
         if ":tito:" in message.content:
-            await asyncio.wait([message.add_reaction(f) for f in flags])
+            await asyncio.gather(*[message.add_reaction(f) for f in flags])
 
     @commands.Cog.listener("on_raw_reaction_add")
     async def react_to_tito_reaction(self, payload):
@@ -21,4 +21,4 @@ class Tito(commands.Cog):
         if payload.emoji.name == "tito":
             channel = await self.bot.fetch_channel(payload.channel_id)
             message = await channel.fetch_message(payload.message_id)
-            await asyncio.wait([message.add_reaction(f) for f in flags])
+            await asyncio.gather(*[message.add_reaction(f) for f in flags])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.black]
 line-length = 200
-target-version = ["py38"]
+target-version = ["py312"]
 
 [tool.isort]
 profile = "black"
@@ -13,7 +13,6 @@ multi_line_output = 3
 [tool.pytest.ini_options]
 addopts = """\
     -ra \
-    --flake8 \
     --mdformat \
     -n auto \
     --blockage"""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.black]
 line-length = 200
-target-version = ["py312"]
+target-version = ["py310"]
 
 [tool.isort]
 profile = "black"

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ if __name__ == "__main__":
         name="duckbot",
         version="1.0",
         url="https://github.com/duck-dynasty/duckbot",
-        python_requires=">=3.11",
+        python_requires=">=3.10",
         packages=find_packages(),
         cmdclass={"develop": PostDevelop, "install": PostInstall},
         install_requires=[

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools.command.install import install
 
 
 def run_code_formatters():
-    for tool in ["isort .", "black .", "mdformat ."]:
+    for tool in ["isort .", "black .", "mdformat .", "flake8 duckbot tests"]:
         print(f"running `{tool}`")
         subprocess.run(tool, shell=True)
 
@@ -42,7 +42,7 @@ if __name__ == "__main__":
         name="duckbot",
         version="1.0",
         url="https://github.com/duck-dynasty/duckbot",
-        python_requires=">=3.8",
+        python_requires=">=3.12",
         packages=find_packages(),
         cmdclass={"develop": PostDevelop, "install": PostInstall},
         install_requires=[
@@ -69,13 +69,13 @@ if __name__ == "__main__":
                 "pytest==7.4.4",
                 "pytest-asyncio==0.23.3",
                 "pytest-xdist[psutil]==3.5.0",
-                "flake8==4.0.1",
+                "flake8==6.1.0",
                 "black==23.12.1",
                 "flake8-black==0.3.6",
                 "isort==5.13.2",
                 "flake8-isort==6.1.1",
                 "pep8-naming==0.13.2",
-                "pytest-flake8-v2==1.2.3",
+                # "pytest-flake8-v2==1.2.3",
                 "mdformat==0.7.17",
                 "mdformat-gfm==0.3.5",
                 "mdformat-black==0.1.1",

--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,6 @@ if __name__ == "__main__":
                 "isort==5.13.2",
                 "flake8-isort==6.1.1",
                 "pep8-naming==0.13.2",
-                # "pytest-flake8-v2==1.2.3",
                 "mdformat==0.7.17",
                 "mdformat-gfm==0.3.5",
                 "mdformat-black==0.1.1",

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ if __name__ == "__main__":
         name="duckbot",
         version="1.0",
         url="https://github.com/duck-dynasty/duckbot",
-        python_requires=">=3.12",
+        python_requires=">=3.11",
         packages=find_packages(),
         cmdclass={"develop": PostDevelop, "install": PostInstall},
         install_requires=[

--- a/tests/cogs/announce_day/announce_day_test.py
+++ b/tests/cogs/announce_day/announce_day_test.py
@@ -18,7 +18,7 @@ async def test_before_loop_waits_for_bot(bot, dog_photos):
     bot.wait_until_ready.assert_called()
 
 
-async def test_cog_unload_cancels_task(bot, dog_photos):
+def test_cog_unload_cancels_task(bot, dog_photos):
     clazz = AnnounceDay(bot, dog_photos)
     clazz.cog_unload()
     clazz.on_hour_loop.cancel.assert_called()
@@ -26,7 +26,7 @@ async def test_cog_unload_cancels_task(bot, dog_photos):
 
 @mock.patch("random.choice", side_effect=["today", "tomorrow", "yesterday", "{today} {tomorrow} {yesterday}"])
 @mock.patch("random.random", return_value=0.5)
-@mock.patch("duckbot.cogs.announce_day.announce_day.now", return_value=datetime.datetime(2002, 2, 2, hour=7))
+@mock.patch("duckbot.util.datetime.now", return_value=datetime.datetime(2002, 2, 2, hour=7))
 async def test_on_hour_7am_eastern_special_day(now, random, choice, bot, dog_photos, general_channel):
     clazz = AnnounceDay(bot, dog_photos)
     await clazz.on_hour()
@@ -35,7 +35,7 @@ async def test_on_hour_7am_eastern_special_day(now, random, choice, bot, dog_pho
 
 @mock.patch("random.choice", side_effect=["today", "tomorrow", "yesterday", "{today} {tomorrow} {yesterday}"])
 @mock.patch("random.random", return_value=0.5)
-@mock.patch("duckbot.cogs.announce_day.announce_day.now", return_value=datetime.datetime(2002, 1, 21, hour=7))
+@mock.patch("duckbot.util.datetime.now", return_value=datetime.datetime(2002, 1, 21, hour=7))
 async def test_on_hour_7am_eastern_not_special_day(now, random, choice, bot, dog_photos, general_channel):
     clazz = AnnounceDay(bot, dog_photos)
     await clazz.on_hour()
@@ -43,7 +43,7 @@ async def test_on_hour_7am_eastern_not_special_day(now, random, choice, bot, dog
 
 
 @mock.patch("random.random", side_effect=[0.09, 0.1])
-@mock.patch("duckbot.cogs.announce_day.announce_day.now", return_value=datetime.datetime(2002, 1, 21, hour=7))
+@mock.patch("duckbot.util.datetime.now", return_value=datetime.datetime(2002, 1, 21, hour=7))
 async def test_on_hour_7am_eastern_send_dog_photo(now, random, bot, dog_photos, general_channel):
     clazz = AnnounceDay(bot, dog_photos)
     await clazz.on_hour()
@@ -52,7 +52,7 @@ async def test_on_hour_7am_eastern_send_dog_photo(now, random, bot, dog_photos, 
 
 
 @mock.patch("random.random", side_effect=[0.09, 0.1])
-@mock.patch("duckbot.cogs.announce_day.announce_day.now", return_value=datetime.datetime(2002, 1, 21, hour=7))
+@mock.patch("duckbot.util.datetime.now", return_value=datetime.datetime(2002, 1, 21, hour=7))
 async def test_on_hour_7am_eastern_send_dog_photo_failure(now, random, bot, dog_photos, general_channel):
     dog_photos.get_dog_image.side_effect = RuntimeError("ded")
     clazz = AnnounceDay(bot, dog_photos)
@@ -62,7 +62,7 @@ async def test_on_hour_7am_eastern_send_dog_photo_failure(now, random, bot, dog_
 
 
 @mock.patch("random.random", side_effect=[0.1, 0.09])
-@mock.patch("duckbot.cogs.announce_day.announce_day.now", return_value=datetime.datetime(2002, 1, 25, hour=7))
+@mock.patch("duckbot.util.datetime.now", return_value=datetime.datetime(2002, 1, 25, hour=7))
 async def test_on_hour_7am_eastern_send_gif(now, random, bot, dog_photos, general_channel):
     clazz = AnnounceDay(bot, dog_photos)
     await clazz.on_hour()
@@ -70,19 +70,17 @@ async def test_on_hour_7am_eastern_send_gif(now, random, bot, dog_photos, genera
     dog_photos.get_dog_image.assert_not_called()
 
 
-@mock.patch("duckbot.cogs.announce_day.announce_day.days")
 @mock.patch("random.random", side_effect=[0.1, 0.09])
-@mock.patch("duckbot.cogs.announce_day.announce_day.now", return_value=datetime.datetime(2002, 1, 25, hour=7))
-async def test_on_hour_7am_eastern_no_gifs_to_send(now, random, days, bot, dog_photos, general_channel):
-    days.__getitem__.return_value = {"names": ["name"], "templates": [], "gifs": []}
-    clazz = AnnounceDay(bot, dog_photos)
+@mock.patch("duckbot.util.datetime.now", return_value=datetime.datetime(2002, 1, 25, hour=7))
+async def test_on_hour_7am_eastern_no_gifs_to_send(now, random, bot, dog_photos, general_channel):
+    clazz = AnnounceDay(bot, dog_photos, days={i: {"names": ["name"], "templates": [], "gifs": []} for i in range(7)})
     await clazz.on_hour()
     general_channel.send.assert_called_once()
     dog_photos.get_dog_image.assert_not_called()
 
 
 @pytest.mark.parametrize("hour", [h for h in range(0, 24) if h != 7])
-@mock.patch("duckbot.cogs.announce_day.announce_day.now")
+@mock.patch("duckbot.util.datetime.now")
 async def test_on_hour_not_7am(now, bot, dog_photos, hour):
     now.return_value = datetime.datetime(2002, 1, 1, hour=hour)
     clazz = AnnounceDay(bot, dog_photos)

--- a/tests/cogs/text/mock_text_test.py
+++ b/tests/cogs/text/mock_text_test.py
@@ -5,7 +5,7 @@ import discord
 from duckbot.cogs.text import MockText
 
 
-@mock.patch("duckbot.cogs.text.mock_text.get_message_reference", return_value=None)
+@mock.patch("duckbot.util.messages.get_message_reference", return_value=None)
 async def test_mock_text_mocks_message_not_reply(get_message_reference, bot, context):
     clazz = MockText(bot)
     await clazz.mock_text(context, "some' message% asd")
@@ -13,7 +13,7 @@ async def test_mock_text_mocks_message_not_reply(get_message_reference, bot, con
     get_message_reference.assert_called_once_with(context.message)
 
 
-@mock.patch("duckbot.cogs.text.mock_text.get_message_reference")
+@mock.patch("duckbot.util.messages.get_message_reference")
 async def test_mock_text_mocks_message_reply(get_message_reference, bot, context, autospec):
     reply = autospec.of(discord.Message)
     get_message_reference.return_value = reply
@@ -23,7 +23,7 @@ async def test_mock_text_mocks_message_reply(get_message_reference, bot, context
     get_message_reference.assert_called_once_with(context.message)
 
 
-@mock.patch("duckbot.cogs.text.mock_text.get_message_reference", return_value=None)
+@mock.patch("duckbot.util.messages.get_message_reference", return_value=None)
 async def test_mock_text_no_message_not_reply(get_message_reference, bot, context):
     context.message.author.display_name = "bob"
     clazz = MockText(bot)
@@ -32,7 +32,7 @@ async def test_mock_text_no_message_not_reply(get_message_reference, bot, contex
     get_message_reference.assert_called_once_with(context.message)
 
 
-@mock.patch("duckbot.cogs.text.mock_text.get_message_reference")
+@mock.patch("duckbot.util.messages.get_message_reference")
 async def test_mock_text_no_message_reply(get_message_reference, bot, context, autospec):
     reply = autospec.of(discord.Message)
     get_message_reference.return_value = reply

--- a/tests/fixtures/discord/bot.py
+++ b/tests/fixtures/discord/bot.py
@@ -2,7 +2,6 @@ import asyncio
 from unittest import mock
 
 import discord.ext.tasks
-import discord.http
 import pytest
 
 from duckbot import DuckBot
@@ -20,11 +19,12 @@ async def bot_spy() -> DuckBot:
 
 
 @pytest.fixture
-def bot(autospec, monkeypatch) -> DuckBot:
+async def bot(autospec, monkeypatch) -> DuckBot:
     """Returns a mock DuckBot instance. The default event loops are replaced by mocks."""
     b = autospec.of(DuckBot)
     b.command_prefix = "!"
-    b.loop = mock.Mock()
+    b.loop = mock.Mock(spec=asyncio.get_event_loop())
     # mock out loop, it uses `asyncio.get_event_loop()` by default
     monkeypatch.setattr(discord.ext.tasks, "Loop", mock.Mock(spec=discord.ext.tasks.Loop))
+    monkeypatch.setattr(discord.ext.tasks, "loop", mock.Mock(spec=discord.ext.tasks.loop))
     return b


### PR DESCRIPTION
##### Summary

3.8 is [dying soon](https://devguide.python.org/versions/), and a lot of dependency upgrades are leaving it behind. This bumps python a few versions to ~~3.12~~ 3.10 -- apparently 3.11+ fails to run on github actions runners. I don't want to deal with figuring out why.

`flake8` doesn't work with pytest any more, so I just removed that check entirely. I added it to the `format` script and to github actions instead.

Most of the change was uneventful, but for some reason the `AnnounceDay` and some other tests went haywire. The patches stopped working, and I don't really know why, there were no changes to that module in the python updates. There's some workarounds there essentially, flipping from relative to absolute imports, and injecting data instead of mocking it.  
For a lot of these, the errors were not consistent. Like 1/10 test runs would fail, and they'd never fail when you ran just the one module. Not really sure what was going on there.

Lastly, `asyncio.wait` was changed, `asyncio.gather(*list)` is the same behaviour.

##### Checklist

- [x] this is a source code change
  - [x] run `format` in the repository root
  - [x] run `pytest` in the repository root
  - [ ] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [ ] update the wiki documentation if necessary
- [ ] or, this is **not** a source code change
