### PR TITLE
🐛 remove `loop` parameter from health check service

### DIFF
--- a/duckbot/health/health_check.py
+++ b/duckbot/health/health_check.py
@@ -10,7 +10,7 @@ class HealthCheck(commands.Cog):
 
     @commands.Cog.listener("on_ready")
     async def start_health_check_tasks(self):
-        await asyncio.start_server(self.healthcheck, host="127.0.0.1", port=8008, loop=self.bot.loop)
+        await asyncio.start_server(self.healthcheck, host="127.0.0.1", port=8008)
 
     def healthcheck(self, reader, writer):
         if self.bot.user is None or not self.bot.is_ready() or self.bot.is_closed() or self.bot.latency > 1.0:


### PR DESCRIPTION
##### Summary

`loop` parameter was removed in 3.10 [docs](https://docs.python.org/3.10/library/asyncio-stream.html?highlight=start_server#asyncio.start_server). This didn't affect duckbot's running, but deployments would fail since they wait for the service to be healthy, and it never was.

Tested locally by running `python -m duckbot.health` in the docker container. It was unhealthy before this change, now it returns healthy.

##### Checklist

- [x] this is a source code change
  - [x] run `format` in the repository root
  - [x] run `pytest` in the repository root
  - [x] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [x] update the wiki documentation if necessary
- [ ] or, this is **not** a source code change
