### PR TITLE
🐛 fix `format_exception` usage

### DIFF
--- a/duckbot/logs/logging.py
+++ b/duckbot/logs/logging.py
@@ -46,7 +46,7 @@ class Logging(commands.Cog):
     @commands.Cog.listener("on_command_error")
     async def log_command_exceptions(self, context: commands.Context, exception):
         name = context.cog.__module__ if context.cog else context.bot.__module__
-        trace = "".join(traceback.format_exception(etype=type(exception), value=exception, tb=exception.__traceback__))
+        trace = "".join(traceback.format_exception(exception, value=exception, tb=exception.__traceback__))
         logging.getLogger(name).error(f"{self.format_function(context.command.name, context.args, context.kwargs, context.message)}\n{trace}")
 
     async def log_event_exceptions(self, event: str, *args, **kwargs):
@@ -74,7 +74,7 @@ def loop_replacement(*args, **kwargs):
             bot_self = error_args[0]  # may be the same as exception, but is typically the `self` parameter in the method, ie the cog/bot instance
             exception = error_args[-1]
             name = "duckbot" if bot_self == exception else bot_self.__module__
-            trace = "".join(traceback.format_exception(etype=type(exception), value=exception, tb=exception.__traceback__))
+            trace = "".join(traceback.format_exception(exception, value=exception, tb=exception.__traceback__))
             logging.getLogger(name).error(f"{loop.coro.__name__}\n{trace}")
 
         return loop


### PR DESCRIPTION
##### Summary

I was looking into why the `/define` command stopped working recently, but when looking into logs I found this was missed during the python 3.10 update.

Unfortunately, I wasn't able to figure out what was wrong with the oxford api. It's just giving me authorization errors with no details. I may try making a new account.

##### Checklist

- [x] this is a source code change
  - [x] run `format` in the repository root
  - [x] run `pytest` in the repository root
  - [ ] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [ ] update the wiki documentation if necessary
- [ ] or, this is **not** a source code change
