### PR TITLE
💚 use `docker compose` instead of `docker-compose`

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -40,7 +40,7 @@ jobs:
     - uses: actions/checkout@v4
     - name: Test Connection to Discord
       run: |
-        docker-compose run --rm \
+        docker compose run --rm \
           -e 'DUCKBOT_ARGS=connection-test' \
           -e "DISCORD_TOKEN=$(cat .github/workflows/test-token.txt | base64 --decode)" \
           duckbot


### PR DESCRIPTION
##### Summary

Recent [actions](https://github.com/duck-dynasty/duckbot/actions/runs/10475547764/job/29029624356?pr=898) have been failing. According to [thread](https://github.com/orgs/community/discussions/116610), it's because `docker-compose` is dead, long live `docker compose`. The thread indicates it's old, not sure why we haven't really been affected until now.

##### Checklist

- [ ] this is a source code change
  - [ ] run `format` in the repository root
  - [ ] run `pytest` in the repository root
  - [ ] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [ ] update the wiki documentation if necessary
- [x] or, this is **not** a source code change
