### PR TITLE
:bug: add missing parameter to `Command#to_dict`

### DIFF
--- a/duckbot/slash/sync_command_tree.py
+++ b/duckbot/slash/sync_command_tree.py
@@ -13,7 +13,7 @@ class SyncCommandTree(Cog):
 
     @Cog.listener("on_ready")
     async def sync_command_tree(self):
-        commands = [x.to_dict() for x in self.bot.tree.get_commands()]
+        commands = [x.to_dict(self.bot.tree) for x in self.bot.tree.get_commands()]
         log.info("registering global slash commands=%s", commands)
         await self.bot.tree.sync()
 


### PR DESCRIPTION
##### Summary

This was breaking recently, see below error. Nothing was actually affected, slash commands just weren't synced. But there was nothing to sync.

```
$ python -m duckbot
2024-08-22 18:43:42,982:INFO:discord.client: logging in using static token
DuckBot online
2024-08-22 18:43:43,853:INFO:discord.gateway: Shard ID None has connected to Gateway (Session ID: 61807c21d9c18718abd20d6847d2f307).
2024-08-22 18:43:45,861:ERROR:duckbot: on_ready(, )
Traceback (most recent call last):
  File "/home/lemon/git/duckbot/venv/lib/python3.10/site-packages/discord/client.py", line 449, in _run_event
    await coro(*args, **kwargs)
  File "/home/lemon/git/duckbot/duckbot/slash/sync_command_tree.py", line 16, in sync_command_tree
    commands = [x.to_dict() for x in self.bot.tree.get_commands()]
  File "/home/lemon/git/duckbot/duckbot/slash/sync_command_tree.py", line 16, in <listcomp>
    commands = [x.to_dict() for x in self.bot.tree.get_commands()]
TypeError: Command.to_dict() missing 1 required positional argument: 'tree'
```

Apparently `to_dict` is an internal API as it doesn't appear in the reference docs. But /shrug, adding this param makes it work again.

```
$ python -m duckbot
2024-08-22 18:44:41,224:INFO:discord.client: logging in using static token
DuckBot online
2024-08-22 18:44:41,815:INFO:discord.gateway: Shard ID None has connected to Gateway (Session ID: b4f977cb14dbba6cf4e7cc6254d4e182).
2024-08-22 18:44:43,820:INFO:duckbot.slash.sync_command_tree: registering global slash commands=[{'name': 'start', 'description': 'Start playing "music" in whatever voice channel you are currently in.', 'type': 1, 'options': [], 'nsfw': False, 'dm_permission': True, 'default_member_permissions': None, 'contexts': None, 'integration_types': None}, {'name': 'stop', 'description': 'Stop playing "music" entirely.', 'type': 1, 'options': [], 'nsfw': False, 'dm_permission': True, 'default_member_permissions': None, 'contexts': None, 'integration_types': None}, {'name': 'dog', 'description': "Show a random dog you probably don't know", 'type': 1, 'options': [{'type': 3, 'name': 'breed', 'description': 'The specific breed of dog to show. Defaults to any breed.', 'required': False}], 'nsfw': False, 'dm_permission': True, 'default_member_permissions': None, 'contexts': None, 'integration_types': None}, {'name': 'eightball', 'description': 'Ask the magic 8 ball a question!', 'type': 1, 'options': [{'type': 3, 'name': 'question', 'description': 'The question to ask the magic 8 ball.', 'required': False}], 'nsfw': False, 'dm_permission': True, 'default_member_permissions': None, 'contexts': None, 'integration_types': None}, {'name': 'roll', 'description': 'Roll some Dungeons & Dragons style dice!', 'type': 1, 'options': [{'type': 3, 'name': 'expression', 'description': 'The number and type of dice to roll. Default is 1d20', 'required': False}], 'nsfw': False, 'dm_permission': True, 'default_member_permissions': None, 'contexts': None, 'integration_types': None}, {'name': 'recipe', 'description': 'Get a random recipe for something.', 'type': 1, 'options': [{'type': 3, 'name': 'search_term', 'description': 'Search terms for the recipe', 'required': False}], 'nsfw': False, 'dm_permission': True, 'default_member_permissions': None, 'contexts': None, 'integration_types': None}, {'name': 'define', 'description': 'Define a brother, word.', 'type': 1, 'options': [{'type': 3, 'name': 'word', 'description': 'The word to define.', 'required': False}], 'nsfw': False, 'dm_permission': True, 'default_member_permissions': None, 'contexts': None, 'integration_types': None}, {'name': 'weather', 'description': '…', 'type': 1, 'options': [{'name': 'get', 'description': 'Gives weather information for your default location or the provided city.', 'type': 1, 'options': [{'type': 3, 'name': 'city', 'description': 'The city name to get the weather for.', 'required': False}, {'type': 3, 'name': 'country', 'description': 'The two letter country code (eg CA for Canada), or two letter US state code.', 'required': False}, {'type': 4, 'name': 'index', 'description': 'Index to disambiguate city when city/country are not enough.', 'required': False}]}, {'name': 'set', 'description': 'Updates your default location for /weather get', 'type': 1, 'options': [{'type': 3, 'name': 'city', 'description': 'The city name to get the weather for.', 'required': False}, {'type': 3, 'name': 'country', 'description': 'The two letter country code (eg CA for Canada), or two letter US state code.', 'required': False}, {'type': 4, 'name': 'index', 'description': 'Index to disambiguate city when city/country are not enough.', 'required': False}]}], 'nsfw': False, 'dm_permission': True, 'default_member_permissions': None, 'contexts': None, 'integration_types': None}]
```

##### Checklist

- [x] this is a source code change
  - [x] run `format` in the repository root
  - [x] run `pytest` in the repository root
  - [ ] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [ ] update the wiki documentation if necessary
- [ ] or, this is **not** a source code change
