### PR TITLE
:art: add factory summary to output

### DIFF
--- a/duckbot/cogs/games/satisfy/pretty.py
+++ b/duckbot/cogs/games/satisfy/pretty.py
@@ -1,0 +1,77 @@
+from dataclasses import dataclass
+from functools import reduce
+from math import isclose
+
+from discord import Embed
+
+from .factory import Factory
+from .item import Item
+from .recipe import Recipe
+
+
+def num_str(x: float) -> str:
+    return round(x, 4)
+
+
+def rate_str(rate: tuple[Item, float]) -> str:
+    return f"{num_str(rate[1])} {rate[0]}"
+
+
+def rates_str(rates: dict[Item, float]) -> str:
+    return " + ".join([rate_str(rate) for rate in rates.items()])
+
+
+def factory_embed(factory: Factory) -> Embed:
+    embed = Embed()
+
+    inputs = "\n".join([rate_str(rate) for rate in factory.inputs.items()]) if factory.inputs else "N/A"
+    embed.add_field(name="Inputs", value=inputs)
+
+    target = "\n".join([rate_str(rate) for rate in factory.targets.items()]) if factory.targets else "N/A"
+    embed.add_field(name="Target", value=target)
+
+    maxify = "\n".join([str(item) for item in factory.maximize]) if factory.maximize else "N/A"
+    embed.add_field(name="Maximize", value=maxify)
+
+    return embed
+
+
+def solution_embed(solution: dict[Recipe, float]) -> Embed:
+    embed = Embed()
+
+    for recipe, num in solution.items():
+        embed.add_field(name=recipe.name, value=f"{num_str(num)} {recipe.building}\n{inout_str(recipe.inputs, recipe.outputs, num)}", inline=False)
+
+    summary = solution_summary(solution)
+    embed.set_footer(text=f"{inout_str(summary.inputs, summary.outputs)}")
+    return embed
+
+
+def inout_str(inputs: dict[Item, float], outputs: dict[Item, float], scale_factor: float = 1.0) -> str:
+    inputs = rates_str(scale_rates(inputs, scale_factor))
+    output = rates_str(scale_rates(outputs, scale_factor))
+    return f"{inputs} -> {output}"
+
+
+def scale_rates(rates: dict[Item, float], scale_factor: float) -> dict[Item, float]:
+    return dict((k, scale_factor * v) for k, v in rates.items())
+
+
+@dataclass
+class SolutionSummary:
+    inputs: dict[Item, float]
+    outputs: dict[Item, float]
+
+
+def solution_summary(solution: dict[Recipe, float]) -> SolutionSummary:
+    inputs = reduce(sum_by_item, [scale_rates(r.inputs, -v) for r, v in solution.items()], dict())
+    outputs = reduce(sum_by_item, [scale_rates(r.outputs, v) for r, v in solution.items()], dict())
+    totals = sum_by_item(inputs, outputs)
+    return SolutionSummary(
+        inputs=dict((k, -v) for k, v in totals.items() if v < 0 and not isclose(v, 0, abs_tol=1e-4)),
+        outputs=dict((k, v) for k, v in totals.items() if v > 0 and not isclose(v, 0, abs_tol=1e-4)),
+    )
+
+
+def sum_by_item(lhs: dict[Item, float], rhs: dict[Item, float]) -> dict[Item, float]:
+    return dict((item, lhs.get(item, 0) + rhs.get(item, 0)) for item in Item if (item in lhs or item in rhs))

--- a/duckbot/cogs/games/satisfy/rate.py
+++ b/duckbot/cogs/games/satisfy/rate.py
@@ -41,6 +41,9 @@ class Rates:
 
     def get(self, key: Item, default: Optional[float]) -> Optional[float]:
         return self.rates.get(key, default)
+    
+    def __bool__(self) -> bool:
+        return bool(self.rates)
 
     def __add__(self, rate: Rate) -> Rates:
         x = self.rates.copy()

--- a/duckbot/cogs/games/satisfy/rate.py
+++ b/duckbot/cogs/games/satisfy/rate.py
@@ -41,7 +41,7 @@ class Rates:
 
     def get(self, key: Item, default: Optional[float]) -> Optional[float]:
         return self.rates.get(key, default)
-    
+
     def __bool__(self) -> bool:
         return bool(self.rates)
 

--- a/duckbot/cogs/games/satisfy/satisfy.py
+++ b/duckbot/cogs/games/satisfy/satisfy.py
@@ -8,7 +8,7 @@ from .factory import Factory
 from .item import Item
 from .pretty import factory_embed, solution_embed
 from .rate import Rates
-from .recipe import Recipe, all
+from .recipe import all
 from .solver import optimize
 
 

--- a/duckbot/cogs/games/satisfy/solver.py
+++ b/duckbot/cogs/games/satisfy/solver.py
@@ -30,7 +30,7 @@ def optimize(factory: Factory) -> dict[Recipe, float]:
     for c in constraints.values():
         model.add_constr(c >= 0)
 
-    model.objective = zero + sum([c for i, c in constraints.items() if i in factory.maximize])
+    model.objective = sum([c for i, c in constraints.items() if i in factory.maximize])
     model.optimize()
 
     return dict((r, float(v.x)) for r, v in zip(factory.recipes, use_recipes) if v.x is not None and v.x > 0)


### PR DESCRIPTION
##### Summary

**NOTE** I think this needs some updates since the prior PR changed some types. Everything compiles because python and no tests. 

Title. I moved all the pretty output related code to a new file as well. Only real new stuff is `solution_summary` and related. Though I snuck in a few random cleanups or whatnot.

![image](https://github.com/user-attachments/assets/b03c82ed-7e05-430a-88cb-bab226a4fa80)


##### Checklist

- [x] this is a source code change
  - [x] run `format` in the repository root
  - [x] run `pytest` in the repository root
  - [ ] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [ ] update the wiki documentation if necessary
- [ ] or, this is **not** a source code change
