### PR TITLE
:art: rejig operators for cleaner recipe definitions

### DIFF
--- a/duckbot/cogs/games/satisfy/factory.py
+++ b/duckbot/cogs/games/satisfy/factory.py
@@ -2,12 +2,13 @@ from dataclasses import dataclass
 from typing import List, Set
 
 from .item import Item
+from .rate import Rates
 from .recipe import Recipe
 
 
 @dataclass
 class Factory:
-    inputs: dict[Item, float]
+    inputs: Rates
     recipes: List[Recipe]
-    targets: dict[Item, float]
+    targets: Rates
     maximize: Set[Item]

--- a/duckbot/cogs/games/satisfy/item.py
+++ b/duckbot/cogs/games/satisfy/item.py
@@ -7,6 +7,7 @@ from enum import Enum, auto, unique
 class Form(Enum):
     Solid = auto()
     Fluid = auto()
+    Aux = auto()
 
 
 @unique
@@ -27,7 +28,8 @@ class Item(Enum):
     Plastic = (auto(), Form.Solid, 75)
     Rubber = (auto(), Form.Solid, 60)
 
-    AwesomeTicketPoints = (auto(), Form.Fluid, 0)
+    AwesomeTicketPoints = (auto(), Form.Aux, 0)
+    MwPower = (auto(), Form.Aux, 0)
 
     def _generate_next_value_(name, start, count, last_values):  # noqa: N805
         return name
@@ -36,11 +38,13 @@ class Item(Enum):
         self.form = form
         self.points = points
 
-    def __mul__(self, rhs: float) -> tuple[Item, float]:
-        return (self, rhs)
+    def __mul__(self, rhs: float):
+        from .rate import Rate
 
-    def __repr__(self):
-        return self.name
+        return Rate(self, rhs)
 
     def __str__(self):
         return self.name
+
+    def __repr__(self):
+        return str(self)

--- a/duckbot/cogs/games/satisfy/rate.py
+++ b/duckbot/cogs/games/satisfy/rate.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from typing import List, Optional
+
+from .item import Item
+
+
+class Rate:
+    def __init__(self, item: Item, rate: float):
+        self.item = item
+        self.rate = rate
+
+    def tuple(self) -> tuple[Item, float]:
+        return (self.item, self.rate)
+
+    def __add__(self, rhs: Rate | tuple[Item, float]) -> Rates:
+        return Rates([self.tuple(), rhs.tuple() if isinstance(rhs, Rate) else rhs])
+
+    def __rshift__(self, output: Rate | tuple[Item, float] | Rates) -> tuple[Rates, Rates]:
+        if isinstance(output, Rates):
+            return (Rates([self.tuple()]), output)
+        else:
+            return (Rates([self.tuple()]), Rates([output.tuple() if isinstance(output, Rate) else output]))
+
+    def __str__(self) -> str:
+        return str(self.tuple())
+
+    def __repr__(self) -> str:
+        return str(self)
+
+
+class Rates:
+    def __init__(self, rates: List[tuple[Item, float]] | dict[Item, float] = []):
+        self.rates = dict(rates)
+
+    def items(self):
+        return self.rates.items()
+
+    def __iter__(self):
+        return self.rates.__iter__()
+
+    def get(self, key: Item, default: Optional[float]) -> Optional[float]:
+        return self.rates.get(key, default)
+
+    def __add__(self, rate: Rate) -> Rates:
+        x = self.rates.copy()
+        x[rate.item] = rate.rate
+        return Rates(x)
+
+    def __rshift__(self, output: Rate | tuple[Item, float] | Rates) -> tuple[Rates, Rates]:
+        if isinstance(output, Rates):
+            return (self, output)
+        else:
+            return (self, Rates([output.tuple() if isinstance(output, Rate) else output]))
+
+    def __str__(self) -> str:
+        return str(self.rates)
+
+    def __repr__(self) -> str:
+        return str(self)

--- a/duckbot/cogs/games/satisfy/recipe.py
+++ b/duckbot/cogs/games/satisfy/recipe.py
@@ -1,18 +1,17 @@
 from dataclasses import dataclass
-from typing import List, Optional
+from typing import List
 
 from .building import Building
-from .item import Item
-
-Rate = tuple[Item, float]
+from .item import Form, Item
+from .rate import Rate, Rates
 
 
 @dataclass
 class Recipe:
     name: str
     building: Building
-    inputs: dict[Item, float]
-    outputs: dict[Item, float]
+    inputs: Rates
+    outputs: Rates
 
     def __hash__(self):
         return hash(self.name)
@@ -20,56 +19,72 @@ class Recipe:
 
 def default() -> List[Recipe]:
     return [
-        smelt("IronIngot", Item.IronOre * 30, Item.IronIngot * 30),
-        ctor("IronPlate", Item.IronIngot * 30, Item.IronPlate * 20),
-        ctor("IronRod", Item.IronIngot * 30, Item.IronRod * 30),
+        smelt("IronIngot", Item.IronOre * 30 >> Item.IronIngot * 30),
+        ctor("IronPlate", Item.IronIngot * 30 >> Item.IronPlate * 20),
+        ctor("IronRod", Item.IronIngot * 30 >> Item.IronRod * 30),
     ]
 
 
+def awesome_sink() -> List[Recipe]:
+    return [sink(item) for item in Item if item.form == Form.Solid and item.points > 0]
+
+
 def all() -> List[Recipe]:
-    return default() + recycled()
+    return default() + recycled() + awesome_sink()
 
 
-def recipe(name: str, building: Building, inputs: List[Optional[Rate]], outputs: List[Optional[Rate]]) -> Recipe:
-    return Recipe(name, building, inputs=dict([x for x in inputs if x is not None]), outputs=dict([x for x in outputs if x is not None]))
+def recipe(name: str, building: Building, inout: tuple[Rates, Rates]) -> Recipe:
+    return Recipe(name, building, inputs=inout[0].rates, outputs=inout[1].rates)
 
 
-def smelt(name: str, input: Rate, output: Rate) -> Recipe:
-    return recipe(name, Building.Smelter, [input], [output])
+def smelt(name: str, inout: tuple[Rates, Rates]) -> Recipe:
+    return recipe(name, Building.Smelter, inout)
 
 
-def ctor(name: str, input: Rate, output: Rate) -> Recipe:
-    return recipe(name, Building.Constructor, [input], [output])
+def ctor(name: str, inout: tuple[Rates, Rates]) -> Recipe:
+    return recipe(name, Building.Constructor, inout)
 
 
-def assy(name: str, input1: Rate, input2: Rate, output: Rate) -> Recipe:
-    return recipe(name, Building.Assembler, [input1, input2], [output])
+def assy(name: str, inout: tuple[Rates, Rates]) -> Recipe:
+    return recipe(name, Building.Assembler, inout)
 
 
-def manu(name: str, input1: Rate, input2: Rate, input3: Rate, input4: Optional[Rate], output: Rate) -> Recipe:
-    return recipe(name, Building.Manufacturer, [input1, input2, input3, input4], [output])
+def manu(name: str, inout: tuple[Rates, Rates]) -> Recipe:
+    return recipe(name, Building.Manufacturer, inout)
 
 
-def refinery(name: str, input1: Rate, input2: Optional[Rate], output1: Rate, output2: Optional[Rate] = None) -> Recipe:
-    return recipe(name, Building.Refinery, [input1, input2], [output1, output2])
+def refine(name: str, inout: tuple[Rates, Rates]) -> Recipe:
+    return recipe(name, Building.Refinery, inout)
 
 
-def pack(name: str, rate: int, input: Item, output: Item) -> Recipe:
-    return recipe(name, Building.Packager, [input * rate, Item.EmptyCanister * rate], [output * rate])
+def pack(name: str, inout: tuple[Rates, Rates]) -> Recipe:
+    return recipe(name, Building.Packager, inout[0] + Item.EmptyCanister * list(inout[0].rates.values())[0] >> inout[1])
 
 
-def unpack(name: str, rate: int, input: Item, output: Item) -> Recipe:
-    return recipe(name, Building.Packager, [input * rate], [output * rate, Item.EmptyCanister * rate])
+def unpack(name: str, inout: tuple[Rates, Rates]) -> Recipe:
+    return recipe(name, Building.Packager, inout[0] >> inout[1] + Item.EmptyCanister * list(inout[1].rates.values())[0])
+
+
+def blend(name: str, inout: tuple[Rates, Rates]) -> Recipe:
+    return recipe(name, Building.Blender, inout)
+
+
+def sink(item: Item) -> Recipe:
+    return recipe(f"Sink{item}", Building.AwesomeSink, item * 1 >> Item.AwesomeTicketPoints * item.points)
+
+
+def bioburn(name: str, input: Rate) -> Recipe:
+    return recipe(name, Building.BiomassBurner, input >> Item.MwPower * 30)
 
 
 def recycled() -> List[Recipe]:
     return [
-        refinery("HeavyOilResidue", Item.CrudeOil * 30, None, Item.HeavyOilResidue * 40, Item.PolymerResin * 20),
-        refinery("RecycledPlastic", Item.Rubber * 30, Item.Fuel * 30, Item.Plastic * 60),
-        refinery("RecycledRubber", Item.Plastic * 30, Item.Fuel * 30, Item.Rubber * 60),
-        refinery("ResidualPlastic", Item.PolymerResin * 60, Item.Water * 20, Item.Plastic * 20),
-        refinery("ResidualRubber", Item.PolymerResin * 40, Item.Water * 40, Item.Rubber * 20),
-        refinery("DilutedPackagedFuel", Item.HeavyOilResidue * 30, Item.PackagedWater * 60, Item.PackagedFuel * 60),
-        pack("PackagedWater", 60, Item.Water, Item.PackagedWater),
-        unpack("UnpackageFuel", 60, Item.PackagedFuel, Item.Fuel),
+        refine("HeavyOilResidue", Item.CrudeOil * 30 >> Item.HeavyOilResidue * 40 + Item.PolymerResin * 20),
+        refine("RecycledPlastic", Item.Rubber * 30 + Item.Fuel * 30 >> Item.Plastic * 60),
+        refine("RecycledRubber", Item.Plastic * 30 + Item.Fuel * 30 >> Item.Rubber * 60),
+        refine("ResidualPlastic", Item.PolymerResin * 60 + Item.Water * 20 >> Item.Plastic * 20),
+        refine("ResidualRubber", Item.PolymerResin * 40 + Item.Water * 40 >> Item.Rubber * 20),
+        refine("DilutedPackagedFuel", Item.HeavyOilResidue * 30 + Item.PackagedWater * 60 >> Item.PackagedFuel * 60),
+        pack("PackagedWater", Item.Water * 60 >> Item.PackagedWater * 60),
+        unpack("UnpackageFuel", Item.PackagedFuel * 60 >> Item.Fuel * 60),
     ]

--- a/duckbot/cogs/games/satisfy/satisfy.py
+++ b/duckbot/cogs/games/satisfy/satisfy.py
@@ -1,4 +1,4 @@
-from typing import List, Union
+from typing import List
 
 from discord import Embed, Interaction
 from discord.app_commands import Choice, MissingPermissions, check
@@ -6,11 +6,12 @@ from discord.ext.commands import Cog, Context, hybrid_group
 
 from .factory import Factory
 from .item import Item
+from .rate import Rates
 from .recipe import Recipe, all
 from .solver import optimize
 
 
-async def allowed(context: Union[Context, Interaction]):
+async def allowed(context: Context | Interaction):
     id = context.author.id if hasattr(context, "author") else context.user.id
     if id not in [368038054558171141, 776607982472921088, 375024417358479380]:
         raise MissingPermissions(["lul"])
@@ -23,8 +24,8 @@ class Satisfy(Cog):
         self.factory_cache = {}
 
     def factory(self, context: Context) -> Factory:
-        return self.factory_cache.get(context.author.id, Factory(inputs={}, targets={}, maximize=set(), recipes=all()))
-        # return self.factory_cache.get(context.author.id, Factory(inputs={Item.CrudeOil: 300, Item.Water: 1000}, targets={}, maximize=set([Item.Plastic]), recipes=all()))
+        return self.factory_cache.get(context.author.id, Factory(inputs=Rates(), targets=Rates(), maximize=set(), recipes=all()))
+        # return self.factory_cache.get(context.author.id, Factory(inputs=Item.CrudeOil * 300 + Item.Water * 1000, targets=Rates(), maximize=set([Item.Plastic]), recipes=all()))
 
     def save(self, context: Context, factory: Factory):
         self.factory_cache[context.author.id] = factory
@@ -54,7 +55,7 @@ class Satisfy(Cog):
     @check(allowed)
     async def add_input(self, context: Context, item: str, rate_per_minute: float):
         factory = self.factory(context)
-        factory.inputs = factory.inputs | dict([Item[item] * rate_per_minute])
+        factory.inputs = factory.inputs + Item[item] * rate_per_minute
         self.save(context, factory)
         await context.send(embed=factory_embed(factory), delete_after=10)
 
@@ -62,7 +63,7 @@ class Satisfy(Cog):
     @check(allowed)
     async def add_target(self, context: Context, item: str, rate_per_minute: float):
         factory = self.factory(context)
-        factory.targets = factory.targets | dict([Item[item] * rate_per_minute])
+        factory.targets = factory.targets + Item[item] * rate_per_minute
         self.save(context, factory)
         await context.send(embed=factory_embed(factory), delete_after=10)
 

--- a/duckbot/cogs/games/satisfy/solver.py
+++ b/duckbot/cogs/games/satisfy/solver.py
@@ -1,5 +1,4 @@
 from functools import reduce
-from typing import Union
 
 from mip import INF, MAXIMIZE, LinExpr, Model, Var
 
@@ -16,7 +15,7 @@ def optimize(factory: Factory) -> dict[Recipe, float]:
 
     use_recipes = [model.add_var(f"Recipe_{r.name}", lb=0, ub=INF) for r in factory.recipes]
 
-    def cost(recipe: Recipe, use: Union[Var, LinExpr]) -> dict[Item, LinExpr]:
+    def cost(recipe: Recipe, use: Var | LinExpr) -> dict[Item, LinExpr]:
         costs = dict((item, -use * rate) for item, rate in recipe.inputs.items())
         income = dict((item, use * rate) for item, rate in recipe.outputs.items())
         return costs, income


### PR DESCRIPTION
##### Summary

Making the recipes easier to read and write. Ideally I'd want `N * item -> N * item`, but python doesn't let you define arbitrary operators, you can only define operators for new classes you add (so I can't change `*` for ints). And for some reason, `=>` didn't work, so I ended up using `>>`. Still reads a lot better.

Also snuck in some new recipe helper functions to test it all out.

##### Checklist

- [x] this is a source code change
  - [x] run `format` in the repository root
  - [x] run `pytest` in the repository root
  - [ ] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [ ] update the wiki documentation if necessary
- [ ] or, this is **not** a source code change
