### PR TITLE
✨ add recipe manipulation

### DIFF
--- a/duckbot/cogs/games/satisfy/pretty.py
+++ b/duckbot/cogs/games/satisfy/pretty.py
@@ -33,6 +33,10 @@ def factory_embed(factory: Factory) -> Embed:
     maxify = "\n".join([str(item) for item in factory.maximize]) if factory.maximize else "N/A"
     embed.add_field(name="Maximize", value=maxify)
 
+    embed.add_field(name="Recipe Bank", value=factory.recipe_bank)
+    embed.add_field(name="Recipe Includes", value="\n".join(factory.include_recipes) if factory.include_recipes else "N/A")
+    embed.add_field(name="Recipe Excludes", value="\n".join(factory.exclude_recipes) if factory.exclude_recipes else "N/A")
+
     return embed
 
 

--- a/duckbot/cogs/games/satisfy/recipe.py
+++ b/duckbot/cogs/games/satisfy/recipe.py
@@ -22,6 +22,8 @@ def default() -> List[Recipe]:
         smelt("IronIngot", Item.IronOre * 30 >> Item.IronIngot * 30),
         ctor("IronPlate", Item.IronIngot * 30 >> Item.IronPlate * 20),
         ctor("IronRod", Item.IronIngot * 30 >> Item.IronRod * 30),
+        refine("Plastic", Item.CrudeOil * 30 >> Item.Plastic * 20 + Item.HeavyOilResidue * 10),
+        refine("Rubber", Item.CrudeOil * 30 >> Item.Rubber * 20 + Item.HeavyOilResidue * 20),
     ]
 
 

--- a/duckbot/cogs/games/satisfy/satisfy.py
+++ b/duckbot/cogs/games/satisfy/satisfy.py
@@ -135,7 +135,7 @@ class Satisfy(Cog):
 
     @recipe_bank.autocomplete("recipe_bank")
     async def recipe_banks(self, interaction: Interaction, current: str) -> List[Choice[str]]:
-        return choices(recipe_banks.keys(), current)
+        return choices(recipe_banks.keys(), current, threshold=0)
 
     @include_recipe.autocomplete("recipe")
     @exclude_recipe.autocomplete("recipe")
@@ -154,8 +154,8 @@ class Satisfy(Cog):
         await context.send(str(error), delete_after=10)
 
 
-def choices(list: List[str], needle: str) -> List[Choice[str]]:
-    if len(needle) < 3:
+def choices(list: List[str], needle: str, threshold: int = 3) -> List[Choice[str]]:
+    if len(needle) < threshold:
         return []
     else:
         return [Choice(name=i, value=i) for i in list if needle.lower() in i.lower()]

--- a/duckbot/cogs/games/satisfy/satisfy.py
+++ b/duckbot/cogs/games/satisfy/satisfy.py
@@ -146,6 +146,10 @@ class Satisfy(Cog):
     @add_input.error
     @add_target.error
     @add_maximize.error
+    @recipe_bank.error
+    @include_recipe.error
+    @exclude_recipe.error
+    @solve.error
     async def on_error(self, context: Context, error):
         await context.send(str(error), delete_after=10)
 


### PR DESCRIPTION
##### Summary

Adding `recipe bank`, `recipe include`, and `recipe exclude` commands to add/remove recipes. `bank` is a template that can be used as a starting point, like "default recipes" or "all recipes."

Added plastic/rubber recipes to defaults so I could test out the default recipe bank actually worked.

##### Checklist

- [x] this is a source code change
  - [x] run `format` in the repository root
  - [ ] run `pytest` in the repository root
  - [ ] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [ ] update the wiki documentation if necessary
- [ ] or, this is **not** a source code change
