### PR TITLE
✅ add basic /satisfy command tests

### DIFF
--- a/tests/cogs/games/satisfy/satisfy_test.py
+++ b/tests/cogs/games/satisfy/satisfy_test.py
@@ -85,7 +85,6 @@ async def test_solve_no_factory_rejects(clazz, context):
 
 
 async def test_solve_no_in_or_out(clazz, context, default_factory):
-    clazz.save(context, default_factory)
     await clazz.solve.callback(clazz, context)
     context.send.assert_called_once_with("No.", delete_after=10)
 

--- a/tests/cogs/games/satisfy/satisfy_test.py
+++ b/tests/cogs/games/satisfy/satisfy_test.py
@@ -16,16 +16,12 @@ def clazz(bot) -> Satisfy:
 
 
 @pytest.fixture
-def empty_factory() -> Factory:
-    return Factory(Rates(), [], Rates(), set())
-
-
-@pytest.fixture
 def default_factory(clazz, context) -> Factory:
     return clazz.factory(context)
 
 
-async def test_reset_destroys_factory(clazz, context, empty_factory):
+async def test_reset_destroys_factory(clazz, context):
+    empty_factory = Factory(Rates(), [], Rates(), set())
     clazz.save(context, empty_factory)
     await clazz.reset.callback(clazz, context)
     assert clazz.factory_cache == {}

--- a/tests/cogs/games/satisfy/satisfy_test.py
+++ b/tests/cogs/games/satisfy/satisfy_test.py
@@ -1,0 +1,91 @@
+import pytest
+
+from duckbot.cogs.games.satisfy import Satisfy
+from duckbot.cogs.games.satisfy.factory import Factory
+from duckbot.cogs.games.satisfy.item import Item
+from duckbot.cogs.games.satisfy.rate import Rates
+from duckbot.cogs.games.satisfy.recipe import all
+
+
+@pytest.fixture
+def clazz(bot) -> Satisfy:
+    return Satisfy(bot)
+
+
+@pytest.fixture
+def empty_factory() -> Factory:
+    return Factory(Rates(), [], Rates(), set())
+
+
+@pytest.fixture
+def default_factory() -> Factory:
+    return Factory(Rates(), all(), Rates(), set())
+
+
+async def test_reset_destroys_factory(clazz, context, empty_factory):
+    clazz.save(context, empty_factory)
+    await clazz.reset.callback(clazz, context)
+    assert clazz.factory_cache == {}
+    context.send.assert_called_once_with(f":factory: :fire: Factory for {context.author.display_name} cleared. Bitch. :fire: :factory:", delete_after=10)
+
+
+async def test_add_input_stores_input_rate(clazz, context, default_factory):
+    await clazz.add_input.callback(clazz, context, str(Item.IronOre), 30)
+    default_factory.inputs = Rates([Item.IronOre * 30])
+    assert clazz.factory(context) == default_factory
+
+    await clazz.add_input.callback(clazz, context, str(Item.IronIngot), 30)
+    default_factory.inputs = Item.IronOre * 30 + Item.IronIngot * 30
+    assert clazz.factory(context) == default_factory
+
+
+async def test_add_target_stores_output_rate(clazz, context, default_factory):
+    await clazz.add_target.callback(clazz, context, str(Item.IronOre), 30)
+    default_factory.targets = Rates([Item.IronOre * 30])
+    assert clazz.factory(context) == default_factory
+
+    await clazz.add_target.callback(clazz, context, str(Item.IronIngot), 30)
+    default_factory.targets = Item.IronOre * 30 + Item.IronIngot * 30
+    assert clazz.factory(context) == default_factory
+
+
+async def test_add_maximize_stores_maximizer(clazz, context, default_factory):
+    await clazz.add_maximize.callback(clazz, context, str(Item.IronOre))
+    default_factory.maximize = set([Item.IronOre])
+    assert clazz.factory(context) == default_factory
+
+    await clazz.add_maximize.callback(clazz, context, str(Item.IronIngot))
+    default_factory.maximize = set([Item.IronOre, Item.IronIngot])
+    assert clazz.factory(context) == default_factory
+
+
+async def test_recipe_bank_stores_bank(clazz, context):
+    await clazz.recipe_bank.callback(clazz, context, "Default")
+    assert clazz.factory(context).recipe_bank == "Default"
+
+
+async def test_include_recipe_adds_include(clazz, context):
+    await clazz.include_recipe.callback(clazz, context, str(Item.IronOre))
+    assert clazz.factory(context).include_recipes == set(["IronOre"])
+
+    await clazz.include_recipe.callback(clazz, context, str(Item.IronIngot))
+    assert clazz.factory(context).include_recipes == set(["IronOre", "IronIngot"])
+
+
+async def test_exclude_recipe_adds_include(clazz, context):
+    await clazz.exclude_recipe.callback(clazz, context, str(Item.IronOre))
+    assert clazz.factory(context).exclude_recipes == set(["IronOre"])
+
+    await clazz.exclude_recipe.callback(clazz, context, str(Item.IronIngot))
+    assert clazz.factory(context).exclude_recipes == set(["IronOre", "IronIngot"])
+
+
+async def test_solve_no_factory_rejects(clazz, context):
+    await clazz.solve.callback(clazz, context)
+    context.send.assert_called_once_with("No.", delete_after=10)
+
+
+async def test_solve_no_target_or_max_rejects(clazz, context, default_factory):
+    clazz.save(context, default_factory)
+    await clazz.solve.callback(clazz, context)
+    context.send.assert_called_once_with("No.", delete_after=10)


### PR DESCRIPTION
##### Summary

I don't assert the actual outputs, but rather the internal state manipulation. There's no tests for the solve yet either. I figure that function can/should be tested directly.

##### Checklist

- [x] this is a source code change
  - [x] run `format` in the repository root
  - [x] run `pytest` in the repository root
  - [ ] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [ ] update the wiki documentation if necessary
- [ ] or, this is **not** a source code change
