### PR TITLE
✨ allow maniulation of power shards and sloopers

### DIFF
--- a/duckbot/cogs/games/satisfy/item.py
+++ b/duckbot/cogs/games/satisfy/item.py
@@ -31,6 +31,9 @@ class Item(Enum):
     AwesomeTicketPoints = (auto(), Form.Aux, 0)
     MwPower = (auto(), Form.Aux, 0)
 
+    PowerShard = (auto(), Form.Solid, 0)
+    Somersloop = (auto(), Form.Solid, 0)
+
     def _generate_next_value_(name, start, count, last_values):  # noqa: N805
         return name
 

--- a/duckbot/cogs/games/satisfy/pretty.py
+++ b/duckbot/cogs/games/satisfy/pretty.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from functools import reduce
-from math import ceil, isclose
+from math import ceil
 
 from discord import Embed
 
@@ -10,12 +10,8 @@ from .rates import Rates
 from .recipe import ModifiedRecipe
 
 
-def num_str(x: float) -> str:
-    return round(x, 4)
-
-
 def rate_str(rate: tuple[Item, float]) -> str:
-    return f"{num_str(rate[1])} {rate[0]}"
+    return f"{rate[1]} {rate[0]}"
 
 
 def rates_str(rates: Rates) -> str:
@@ -61,7 +57,7 @@ def solution_embed(solution: dict[ModifiedRecipe, float]) -> Embed:
             name = f"{name} {'+' if ' @ ' in name else '@'} {recipe.sloop_scale}x"
             building = f"{building} {'+' if ' with ' in building else 'with'} {recipe.sloops} Somersloop{plrl(recipe.sloops)}"
 
-        embed.add_field(name=name, value=f"{num_str(num)} {building}\n{inout_str(recipe.inputs, recipe.outputs, num)}", inline=False)
+        embed.add_field(name=name, value=f"{num} {building}\n{inout_str(recipe.inputs, recipe.outputs, num)}", inline=False)
 
     summary = solution_summary(solution)
     footer = inout_str(summary.inputs, summary.outputs)
@@ -93,8 +89,8 @@ def solution_summary(solution: dict[ModifiedRecipe, float]) -> SolutionSummary:
     outputs = reduce(sum_by_item, [r.outputs * v for r, v in solution.items()], dict())
     totals = sum_by_item(inputs, outputs)
     return SolutionSummary(
-        inputs=Rates(dict((k, -v) for k, v in totals.items() if v < 0 and not isclose(v, 0, abs_tol=1e-4))),
-        outputs=Rates(dict((k, v) for k, v in totals.items() if v > 0 and not isclose(v, 0, abs_tol=1e-4))),
+        inputs=Rates(dict((k, -v) for k, v in totals.items() if v < 0)),
+        outputs=Rates(dict((k, v) for k, v in totals.items() if v > 0)),
         total_shards=sum([ceil(n * r.power_shards) for r, n in solution.items()]),
         total_sloops=sum([ceil(n * r.sloops) for r, n in solution.items()]),
     )

--- a/duckbot/cogs/games/satisfy/pretty.py
+++ b/duckbot/cogs/games/satisfy/pretty.py
@@ -1,13 +1,13 @@
 from dataclasses import dataclass
 from functools import reduce
-from math import isclose
+from math import ceil, isclose
 
 from discord import Embed
 
 from .factory import Factory
 from .item import Item
 from .rates import Rates
-from .recipe import ModifiedRecipe, Recipe
+from .recipe import ModifiedRecipe
 
 
 def num_str(x: float) -> str:
@@ -25,8 +25,8 @@ def rates_str(rates: Rates) -> str:
 def factory_embed(factory: Factory) -> Embed:
     embed = Embed()
 
-    power_shards = [] if factory.power_shards <= 0 else [f"{factory.power_shards} **Power Shard**"]
-    sloops = [] if factory.sloops <= 0 else [f"{factory.sloops} **Somersloop**"]
+    power_shards = [] if factory.power_shards <= 0 else [f"{factory.power_shards} **{Item.PowerShard}**"]
+    sloops = [] if factory.sloops <= 0 else [f"{factory.sloops} **{Item.Somersloop}**"]
     inputs = "\n".join([rate_str(rate) for rate in factory.inputs.items()] + power_shards + sloops)
     embed.add_field(name="Inputs", value=inputs if inputs else "N/A")
 
@@ -46,39 +46,59 @@ def factory_embed(factory: Factory) -> Embed:
 def solution_embed(solution: dict[ModifiedRecipe, float]) -> Embed:
     embed = Embed()
 
-    for recipe, num in solution.items():
-        embed.add_field(name=recipe.original_recipe.name, value=f"{num_str(num)} {recipe.building}\n{inout_str(recipe.inputs, recipe.outputs, num)}", inline=False)
+    def plrl(val: float) -> str:
+        return "s" if val > 1 else ""
+
+    for recipe, num in sorted(solution.items(), key=lambda kv: (kv[0].name, kv[0].sloops, kv[0].power_shards)):
+        name = recipe.original_recipe.name
+        building = recipe.building.name
+
+        if recipe.power_shards > 0:
+            name = f"{name} @ {int(recipe.shard_scale * 100)}%"
+            building = f"{building} with {recipe.power_shards} Power Shard{plrl(recipe.power_shards)}"
+
+        if recipe.sloops > 0:
+            name = f"{name} {'+' if ' @ ' in name else '@'} {recipe.sloop_scale}x"
+            building = f"{building} {'+' if ' with ' in building else 'with'} {recipe.sloops} Somersloop{plrl(recipe.sloops)}"
+
+        embed.add_field(name=name, value=f"{num_str(num)} {building}\n{inout_str(recipe.inputs, recipe.outputs, num)}", inline=False)
 
     summary = solution_summary(solution)
-    embed.set_footer(text=f"{inout_str(summary.inputs, summary.outputs)}")
+    footer = inout_str(summary.inputs, summary.outputs)
+    if summary.total_shards > 0 or summary.total_sloops > 0:
+        shards = f"{summary.total_shards} Power Shard{plrl(summary.total_shards)}"
+        sloops = f"{summary.total_sloops} Somersloop{plrl(summary.total_sloops)}"
+        joiner = " + " if summary.total_shards > 0 and summary.total_sloops > 0 else ""
+        footer = f"{footer}\n{shards if summary.total_shards > 0 else ''}{joiner}{sloops if summary.total_sloops > 0 else ''}"
+    embed.set_footer(text=footer)
     return embed
 
 
-def inout_str(inputs: dict[Item, float] | Rates, outputs: dict[Item, float] | Rates, scale_factor: float = 1.0) -> str:
-    inputs = rates_str(scale_rates(inputs, scale_factor))
-    output = rates_str(scale_rates(outputs, scale_factor))
+def inout_str(inputs: Rates, outputs: Rates, scale_factor: float = 1.0) -> str:
+    inputs = rates_str(inputs * scale_factor)
+    output = rates_str(outputs * scale_factor)
     return f"{inputs} -> {output}"
-
-
-def scale_rates(rates: dict[Item, float] | Rates, scale_factor: float) -> dict[Item, float]:
-    return dict((k, scale_factor * v) for k, v in rates.items())
 
 
 @dataclass
 class SolutionSummary:
-    inputs: dict[Item, float]
-    outputs: dict[Item, float]
+    inputs: Rates
+    outputs: Rates
+    total_shards: int
+    total_sloops: int
 
 
-def solution_summary(solution: dict[Recipe, float]) -> SolutionSummary:
-    inputs = reduce(sum_by_item, [scale_rates(r.inputs, -v) for r, v in solution.items()], dict())
-    outputs = reduce(sum_by_item, [scale_rates(r.outputs, v) for r, v in solution.items()], dict())
+def solution_summary(solution: dict[ModifiedRecipe, float]) -> SolutionSummary:
+    inputs = reduce(sum_by_item, [r.inputs * -v for r, v in solution.items()], dict())
+    outputs = reduce(sum_by_item, [r.outputs * v for r, v in solution.items()], dict())
     totals = sum_by_item(inputs, outputs)
     return SolutionSummary(
-        inputs=dict((k, -v) for k, v in totals.items() if v < 0 and not isclose(v, 0, abs_tol=1e-4)),
-        outputs=dict((k, v) for k, v in totals.items() if v > 0 and not isclose(v, 0, abs_tol=1e-4)),
+        inputs=Rates(dict((k, -v) for k, v in totals.items() if v < 0 and not isclose(v, 0, abs_tol=1e-4))),
+        outputs=Rates(dict((k, v) for k, v in totals.items() if v > 0 and not isclose(v, 0, abs_tol=1e-4))),
+        total_shards=sum([ceil(n * r.power_shards) for r, n in solution.items()]),
+        total_sloops=sum([ceil(n * r.sloops) for r, n in solution.items()]),
     )
 
 
-def sum_by_item(lhs: dict[Item, float], rhs: dict[Item, float]) -> dict[Item, float]:
+def sum_by_item(lhs: Rates | dict[Item, float], rhs: Rates | dict[Item, float]) -> dict[Item, float]:
     return dict((item, lhs.get(item, 0) + rhs.get(item, 0)) for item in Item if (item in lhs or item in rhs))

--- a/duckbot/cogs/games/satisfy/recipe.py
+++ b/duckbot/cogs/games/satisfy/recipe.py
@@ -31,15 +31,15 @@ class ModifiedRecipe:
         return f"{self.original_recipe.name}#{self.power_shards}#{self.sloops}"
 
     @property
-    def building(self) -> str:
+    def building(self) -> Building:
         return self.original_recipe.building
 
     @property
-    def inputs(self) -> str:
+    def inputs(self) -> Rates:
         return self.original_recipe.inputs * self.shard_scale
 
     @property
-    def outputs(self) -> str:
+    def outputs(self) -> Rates:
         return self.original_recipe.outputs * self.shard_scale * self.sloop_scale
 
     @property

--- a/duckbot/cogs/games/satisfy/satisfy.py
+++ b/duckbot/cogs/games/satisfy/satisfy.py
@@ -36,6 +36,7 @@ class Satisfy(Cog):
     def factory(self, context: Context) -> Factory:
         factory = Factory(inputs=Rates(), targets=Rates(), maximize=set(), recipes=all(), power_shards=0, sloops=0)
         # factory = Factory(inputs=Item.CrudeOil * 300 + Item.Water * 10000, targets=Rates(), maximize=set([Item.Plastic]), recipes=all(), power_shards=0, sloops=10)
+        # factory = Factory(inputs=Item.IronOre * 30, targets=Rates(), maximize=set([Item.IronPlate]), recipes=all(), power_shards=0, sloops=10)
         # monkeypatch fields for recipe manipulations
         factory.recipe_bank = "All"
         factory.include_recipes = set()

--- a/duckbot/cogs/games/satisfy/satisfy.py
+++ b/duckbot/cogs/games/satisfy/satisfy.py
@@ -19,22 +19,23 @@ async def allowed(context: Context | Interaction):
     return True
 
 
+item_names = [i.name for i in Item]
+boost_item_names = [Item.PowerShard.name, Item.Somersloop.name]
 recipe_banks = {
     "All": all(),
     "Default": default(),
 }
+recipe_names = [r.name for r in all()]
 
 
 class Satisfy(Cog):
     def __init__(self, bot):
         self.bot = bot
         self.factory_cache = {}
-        self.item_names = [i.name for i in Item]
-        self.recipe_names = [r.name for r in all()]
 
     def factory(self, context: Context) -> Factory:
         factory = Factory(inputs=Rates(), targets=Rates(), maximize=set(), recipes=all(), power_shards=0, sloops=0)
-        # factory = Factory(inputs=Item.CrudeOil * 300 + Item.Water * 1000, targets=Rates(), maximize=set([Item.Plastic]), recipes=all(), power_shards=0, sloops=0)
+        # factory = Factory(inputs=Item.CrudeOil * 300 + Item.Water * 10000, targets=Rates(), maximize=set([Item.Plastic]), recipes=all(), power_shards=0, sloops=10)
         # monkeypatch fields for recipe manipulations
         factory.recipe_bank = "All"
         factory.include_recipes = set()
@@ -81,11 +82,24 @@ class Satisfy(Cog):
         self.save(context, factory)
         await context.send(embed=factory_embed(factory), delete_after=10)
 
+    @satisfy.command(name="booster", description="Specify how many of a booster item is available to use.")
+    @check(allowed)
+    async def add_booster(self, context: Context, boost_item: str, amount: int):
+        factory = self.factory(context)
+        item = Item[boost_item]
+        if item == Item.PowerShard:
+            factory.power_shards = amount
+        elif item == Item.Somersloop:
+            factory.sloops = amount
+        self.save(context, factory)
+        await context.send(embed=factory_embed(factory), delete_after=10)
+
     @satisfy.group(name="recipe", description="Recipe related manipulations.")
     async def recipe(self, context: Context):
         pass
 
     @recipe.command(name="bank", description="Select a recipe bank for the factory to use. Default is All.")
+    @check(allowed)
     async def recipe_bank(self, context: Context, recipe_bank: str):
         factory = self.factory(context)
         factory.recipe_bank = recipe_bank
@@ -93,6 +107,7 @@ class Satisfy(Cog):
         await context.send(embed=factory_embed(factory), delete_after=10)
 
     @recipe.command(name="include", description="Forces a recipe to be available to the solver. Overrides `exclude`")
+    @check(allowed)
     async def include_recipe(self, context: Context, recipe: str):
         factory = self.factory(context)
         factory.include_recipes.add(recipe)
@@ -100,6 +115,7 @@ class Satisfy(Cog):
         await context.send(embed=factory_embed(factory), delete_after=10)
 
     @recipe.command(name="exclude", description="Makes a recipe to be unavailable to the solver. Overridden by `include`")
+    @check(allowed)
     async def exclude_recipe(self, context: Context, recipe: str):
         factory = self.factory(context)
         factory.exclude_recipes.add(recipe)
@@ -124,7 +140,11 @@ class Satisfy(Cog):
     @add_target.autocomplete("item")
     @add_maximize.autocomplete("item")
     async def items(self, interaction: Interaction, current: str) -> List[Choice[str]]:
-        return choices(self.item_names, current)
+        return choices(item_names, current)
+
+    @add_booster.autocomplete("boost_item")
+    async def boost_items(self, interaction: Interaction, current: str) -> List[Choice[str]]:
+        return choices(boost_item_names, current, threshold=0)
 
     @recipe_bank.autocomplete("recipe_bank")
     async def recipe_banks(self, interaction: Interaction, current: str) -> List[Choice[str]]:
@@ -133,12 +153,13 @@ class Satisfy(Cog):
     @include_recipe.autocomplete("recipe")
     @exclude_recipe.autocomplete("recipe")
     async def recipes(self, interaction: Interaction, current: str) -> List[Choice[str]]:
-        return choices(self.recipe_names, current)
+        return choices(recipe_names, current)
 
     @reset.error
     @add_input.error
     @add_target.error
     @add_maximize.error
+    @add_booster.error
     @recipe_bank.error
     @include_recipe.error
     @exclude_recipe.error
@@ -147,8 +168,8 @@ class Satisfy(Cog):
         await context.send(str(error), delete_after=10)
 
 
-def choices(list: List[str], needle: str, threshold: int = 3) -> List[Choice[str]]:
+def choices(pool: List[str], needle: str, threshold: int = 3) -> List[Choice[str]]:
     if len(needle) < threshold:
         return []
     else:
-        return [Choice(name=i, value=i) for i in list if needle.lower() in i.lower()]
+        return [Choice(name=i, value=i) for i in pool if needle.lower() in i.lower()]

--- a/duckbot/cogs/games/satisfy/solver.py
+++ b/duckbot/cogs/games/satisfy/solver.py
@@ -1,5 +1,6 @@
 import itertools
 from functools import reduce
+from math import isclose
 from typing import Callable, List
 
 from mip import INF, INTEGER, LinExpr, Model, Var, maximize, xsum
@@ -35,7 +36,7 @@ def optimize(factory: Factory) -> dict[ModifiedRecipe, float]:
     )
     model.optimize()
 
-    return dict((r, float(v.x)) for r, v in zip(recipes, use_recipe) if v.x is not None and v.x > 0)
+    return dict((r, round(float(v.x), 4)) for r, v in zip(recipes, use_recipe) if v.x is not None and v.x > 0 and not isclose(float(v), 0, abs_tol=1e-4))
 
 
 def modify_recipes(recipes: List[Recipe], max_shards: int, max_sloops: int) -> List[ModifiedRecipe]:

--- a/tests/cogs/games/satisfy/satisfy_test.py
+++ b/tests/cogs/games/satisfy/satisfy_test.py
@@ -58,6 +58,18 @@ async def test_add_maximize_stores_maximizer(clazz, context, default_factory):
     assert clazz.factory(context) == default_factory
 
 
+async def test_add_booster_power_shard(clazz, context, default_factory):
+    await clazz.add_booster.callback(clazz, context, str(Item.PowerShard), 10)
+    default_factory.power_shards = 10
+    assert clazz.factory(context) == default_factory
+
+
+async def test_add_booster_sloops(clazz, context, default_factory):
+    await clazz.add_booster.callback(clazz, context, str(Item.Somersloop), 10)
+    default_factory.sloops = 10
+    assert clazz.factory(context) == default_factory
+
+
 async def test_recipe_bank_stores_bank(clazz, context):
     await clazz.recipe_bank.callback(clazz, context, "Default")
     assert clazz.factory(context).recipe_bank == "Default"


### PR DESCRIPTION
##### Summary

Fixes https://github.com/duck-dynasty/duckbot/issues/927, creates `/satisfy booster {item} {amount}`

No sloops
![image](https://github.com/user-attachments/assets/87497dc7-8ad7-45b0-9bd8-9ad8ca5248b1)


Sloops only
![image](https://github.com/user-attachments/assets/4baf0208-9604-47fa-bb9b-d70f28dcb7df)


Sloops + Shards
![image](https://github.com/user-attachments/assets/9f3ac7a0-d5b8-4acc-8c0e-a594e59615e7)


##### Checklist

- [x] this is a source code change
  - [x] run `format` in the repository root
  - [x] run `pytest` in the repository root
  - [x] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [ ] update the wiki documentation if necessary
- [ ] or, this is **not** a source code change
