### PR TITLE
✅ add solver tests for sloopy

### DIFF
--- a/duckbot/cogs/games/satisfy/solver.py
+++ b/duckbot/cogs/games/satisfy/solver.py
@@ -1,5 +1,6 @@
 import itertools
 from functools import reduce
+from math import isclose
 from typing import Callable, List
 
 from mip import INF, INTEGER, LinExpr, Model, Var, maximize, xsum
@@ -35,7 +36,7 @@ def optimize(factory: Factory) -> dict[ModifiedRecipe, float]:
     )
     model.optimize()
 
-    return dict((r, float(v.x)) for r, v in zip(recipes, use_recipe) if v.x is not None and v.x > 0)
+    return dict((r, round(float(v.x), 4)) for r, v in zip(recipes, use_recipe) if v.x is not None and v.x > 0 and not isclose(float(v), 0, abs_tol=1e-4))
 
 
 def modify_recipes(recipes: List[Recipe], max_shards: int, max_sloops: int) -> List[ModifiedRecipe]:

--- a/tests/cogs/games/satisfy/solver_test.py
+++ b/tests/cogs/games/satisfy/solver_test.py
@@ -47,7 +47,7 @@ def test_optimize_simple_sloop_target_returns_recipe():
     assert optimize(factory) == dict([(recipe, approx(1))])
 
 
-def test_optimize_simple_factory_maximize_returns_recipe():
+def test_optimize_simple_sloop_maximize_returns_recipe():
     factory = Factory(Item.IronOre * 30, all(), Rates(), set([Item.IronIngot]), sloops=1)
     recipe = recipe_by_name("IronIngot", sloops=1)
     assert optimize(factory) == dict([(recipe, approx(1))])

--- a/tests/cogs/games/satisfy/solver_test.py
+++ b/tests/cogs/games/satisfy/solver_test.py
@@ -32,7 +32,7 @@ def test_optimize_infeasible_returns_empty():
 def test_optimize_simple_factory_target_returns_recipe():
     factory = Factory(Item.IronOre * 30, all(), Item.IronIngot * 30, set())
     recipe = recipe_by_name("IronIngot")
-    assert optimize(factory) == dict([(recipe, 1)])
+    assert optimize(factory) == dict([(recipe, approx(1))])
 
 
 def test_optimize_simple_factory_maximize_returns_recipe():
@@ -41,10 +41,43 @@ def test_optimize_simple_factory_maximize_returns_recipe():
     assert optimize(factory) == dict([(recipe, approx(1))])
 
 
+def test_optimize_simple_sloop_target_returns_recipe():
+    factory = Factory(Item.IronOre * 30, all(), Item.IronIngot * 60, set(), sloops=1)
+    recipe = recipe_by_name("IronIngot", sloops=1)
+    assert optimize(factory) == dict([(recipe, approx(1))])
+
+
+def test_optimize_simple_factory_maximize_returns_recipe():
+    factory = Factory(Item.IronOre * 30, all(), Rates(), set([Item.IronIngot]), sloops=1)
+    recipe = recipe_by_name("IronIngot", sloops=1)
+    assert optimize(factory) == dict([(recipe, approx(1))])
+
+
 def test_optimize_two_step_returns_chain():
     factory = Factory(Item.IronOre * 30, all(), Rates(), set([Item.IronPlate]))
     ignot = recipe_by_name("IronIngot")
     plate = recipe_by_name("IronPlate")
+    assert optimize(factory) == dict([(ignot, approx(1)), (plate, approx(1))])
+
+
+def test_optimize_two_step_single_sloop_returns_chain():
+    factory = Factory(Item.IronOre * 30, all(), Rates(), set([Item.IronPlate]), sloops=1)
+    ignot = recipe_by_name("IronIngot")
+    plate = recipe_by_name("IronPlate", sloops=1)
+    assert optimize(factory) == dict([(ignot, approx(1)), (plate, approx(1))])
+
+
+def test_optimize_two_step_many_sloop_returns_chain():
+    factory = Factory(Item.IronOre * 30, all(), Rates(), set([Item.IronPlate]), sloops=10)
+    ignot = recipe_by_name("IronIngot", sloops=1)
+    plate = recipe_by_name("IronPlate", sloops=1)
+    assert optimize(factory) == dict([(ignot, approx(1)), (plate, approx(2))])
+
+
+def test_optimize_two_step_many_sloop_and_power_shards_returns_chain():
+    factory = Factory(Item.IronOre * 30, all(), Rates(), set([Item.IronPlate]), sloops=10, power_shards=10)
+    ignot = recipe_by_name("IronIngot", sloops=1)
+    plate = recipe_by_name("IronPlate", sloops=1, power_shards=2)
     assert optimize(factory) == dict([(ignot, approx(1)), (plate, approx(1))])
 
 


### PR DESCRIPTION
##### Summary

Also pulled in solver changes from https://github.com/duck-dynasty/duckbot/pull/929, which filters out what gets returned from the solver. For some reason it keeps picking like 0.0001 iron rod constructors in the ore=>max(plate) w/ sloops case.

##### Checklist

- [x] this is a source code change
  - [x] run `format` in the repository root
  - [x] run `pytest` in the repository root
  - [ ] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [ ] update the wiki documentation if necessary
- [ ] or, this is **not** a source code change
