### PR TITLE
✨ prefer not leaving excess non-sinkable items

### DIFF
--- a/duckbot/cogs/games/satisfy/item.py
+++ b/duckbot/cogs/games/satisfy/item.py
@@ -27,6 +27,7 @@ class Item(Enum):
     PackagedWater = (auto(), Form.Solid, 130)
     Plastic = (auto(), Form.Solid, 75)
     Rubber = (auto(), Form.Solid, 60)
+    PetroleumCoke = (auto(), Form.Solid, 20)
 
     AwesomeTicketPoints = (auto(), Form.Aux, 0)
     MwPower = (auto(), Form.Aux, 0)
@@ -51,3 +52,7 @@ class Item(Enum):
 
     def __repr__(self):
         return str(self)
+
+
+def sinkable(item: Item) -> bool:
+    return item.form == Form.Solid and item.points > 0

--- a/duckbot/cogs/games/satisfy/pretty.py
+++ b/duckbot/cogs/games/satisfy/pretty.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from functools import reduce
-from math import ceil
+from math import ceil, isclose
 
 from discord import Embed
 
@@ -11,7 +11,7 @@ from .recipe import ModifiedRecipe
 
 
 def rate_str(rate: tuple[Item, float]) -> str:
-    return f"{rate[1]} {rate[0]}"
+    return f"{round(rate[1], 4)} {rate[0]}"
 
 
 def rates_str(rates: Rates) -> str:
@@ -97,4 +97,5 @@ def solution_summary(solution: dict[ModifiedRecipe, float]) -> SolutionSummary:
 
 
 def sum_by_item(lhs: Rates | dict[Item, float], rhs: Rates | dict[Item, float]) -> dict[Item, float]:
-    return dict((item, lhs.get(item, 0) + rhs.get(item, 0)) for item in Item if (item in lhs or item in rhs))
+    sum = [(item, lhs.get(item, 0) + rhs.get(item, 0)) for item in Item if (item in lhs or item in rhs)]
+    return dict((i, s) for i, s in sum if not isclose(s, 0))

--- a/duckbot/cogs/games/satisfy/recipe.py
+++ b/duckbot/cogs/games/satisfy/recipe.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from typing import List
 
 from .building import Building
-from .item import Form, Item
+from .item import Item, sinkable
 from .rates import Rates
 
 
@@ -58,11 +58,12 @@ def default() -> List[Recipe]:
         ctor("IronRod", Item.IronIngot * 30 >> Item.IronRod * 30),
         refine("Plastic", Item.CrudeOil * 30 >> Item.Plastic * 20 + Item.HeavyOilResidue * 10),
         refine("Rubber", Item.CrudeOil * 30 >> Item.Rubber * 20 + Item.HeavyOilResidue * 20),
+        refine("PetroleumCoke", Item.HeavyOilResidue * 40 >> Item.PetroleumCoke * 120),
     ]
 
 
 def awesome_sink() -> List[Recipe]:
-    return [sink(item) for item in Item if item.form == Form.Solid and item.points > 0]
+    return [sink(item) for item in Item if sinkable(item)]
 
 
 def all() -> List[Recipe]:

--- a/duckbot/cogs/games/satisfy/satisfy.py
+++ b/duckbot/cogs/games/satisfy/satisfy.py
@@ -36,6 +36,7 @@ class Satisfy(Cog):
     def factory(self, context: Context) -> Factory:
         factory = Factory(inputs=Rates(), targets=Rates(), maximize=set(), recipes=all(), power_shards=0, sloops=0)
         # factory = Factory(inputs=Item.CrudeOil * 300 + Item.Water * 10000, targets=Rates(), maximize=set([Item.Plastic]), recipes=all(), power_shards=0, sloops=10)
+        # factory = Factory(inputs=Item.CrudeOil * 30, targets=Item.Plastic * 20, maximize=set(), recipes=all(), power_shards=0, sloops=0)
         # factory = Factory(inputs=Item.IronOre * 30, targets=Rates(), maximize=set([Item.IronPlate]), recipes=all(), power_shards=0, sloops=10)
         # monkeypatch fields for recipe manipulations
         factory.recipe_bank = "All"

--- a/tests/cogs/games/satisfy/item_test.py
+++ b/tests/cogs/games/satisfy/item_test.py
@@ -2,7 +2,7 @@ import random
 
 import pytest
 
-from duckbot.cogs.games.satisfy.item import Item
+from duckbot.cogs.games.satisfy.item import Form, Item, sinkable
 from duckbot.cogs.games.satisfy.rates import Rates
 
 
@@ -20,3 +20,18 @@ def test_repr_returns_enum_name(item: Item):
 def test_mul_returns_rates(item: Item):
     n = random.random()
     assert item * n == Rates(dict([(item, n)]))
+
+
+@pytest.mark.parametrize("item", [i for i in Item if i.form != Form.Solid])
+def test_sinkable_nonsolid_returns_false(item: Item):
+    assert sinkable(item) is False
+
+
+@pytest.mark.parametrize("item", [i for i in Item if i.points == 0])
+def test_sinkable_nonpoints_returns_false(item: Item):
+    assert sinkable(item) is False
+
+
+@pytest.mark.parametrize("item", [i for i in Item if i.form == Form.Solid and i.points != 0])
+def test_sinkable_solid_and_nonzero_points_returns_true(item: Item):
+    assert sinkable(item) is True


### PR DESCRIPTION
##### Summary

Fixes https://github.com/duck-dynasty/duckbot/issues/917

Had to re-jig some of the weightings in the objective function. Not sure why but it started to prefer 0.8 250% clocked constructors for the test `test_optimize_two_step_many_sloop_and_power_shards_returns_chain`. 0.8 @ 250% is literally a single 200% machine, so it should have tried to remove a power shard. Increasing the power shard usage cost made it work again. Optimizers.

##### Checklist

- [x] this is a source code change
  - [x] run `format` in the repository root
  - [x] run `pytest` in the repository root
  - [x] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [ ] update the wiki documentation if necessary
- [ ] or, this is **not** a source code change
