### PR TITLE
✨ add `/satisfy state` to display the factory

### DIFF
--- a/duckbot/cogs/games/satisfy/satisfy.py
+++ b/duckbot/cogs/games/satisfy/satisfy.py
@@ -60,6 +60,11 @@ class Satisfy(Cog):
         self.clear(context)
         await context.send(f":factory: :fire: Factory for {context.author.display_name} cleared. Bitch. :fire: :factory:", delete_after=10)
 
+    @satisfy.command(name="state", description="Displays the current factory.")
+    @check(allowed)
+    async def factory_state(self, context: Context):
+        await context.send(embed=factory_embed(self.factory(context)), delete_after=60)
+
     @satisfy.command(name="input", description="Adds an input to the factory.")
     @check(allowed)
     async def add_input(self, context: Context, item: str, rate_per_minute: float):

--- a/tests/cogs/games/satisfy/satisfy_test.py
+++ b/tests/cogs/games/satisfy/satisfy_test.py
@@ -28,6 +28,11 @@ async def test_reset_destroys_factory(clazz, context):
     context.send.assert_called_once_with(f":factory: :fire: Factory for {context.author.display_name} cleared. Bitch. :fire: :factory:", delete_after=10)
 
 
+async def test_factory_state_sends_something_i_guess(clazz, context):
+    await clazz.factory_state.callback(clazz, context)
+    context.send.assert_called_once()
+
+
 async def test_add_input_stores_input_rate(clazz, context, default_factory):
     await clazz.add_input.callback(clazz, context, str(Item.IronOre), 30)
     default_factory.inputs = Item.IronOre * 30


### PR DESCRIPTION
##### Summary

Title. Other commands only display the factory for 10s before deleting the message, this just displays it for more time.

##### Checklist

- [x] this is a source code change
  - [x] run `format` in the repository root
  - [x] run `pytest` in the repository root
  - [ ] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [ ] update the wiki documentation if necessary
- [ ] or, this is **not** a source code change
