### PR TITLE
🐛 improve rounding for output

### DIFF
--- a/duckbot/cogs/games/satisfy/pretty.py
+++ b/duckbot/cogs/games/satisfy/pretty.py
@@ -9,6 +9,7 @@ from .item import Item
 from .rates import Rates
 from .recipe import ModifiedRecipe
 
+
 def rnd(num: float) -> float:
     return round(num, 4)
 

--- a/duckbot/cogs/games/satisfy/pretty.py
+++ b/duckbot/cogs/games/satisfy/pretty.py
@@ -9,9 +9,12 @@ from .item import Item
 from .rates import Rates
 from .recipe import ModifiedRecipe
 
+def rnd(num: float) -> float:
+    return round(num, 4)
+
 
 def rate_str(rate: tuple[Item, float]) -> str:
-    return f"{round(rate[1], 4)} {rate[0]}"
+    return f"{rnd(rate[1])} {rate[0]}"
 
 
 def rates_str(rates: Rates) -> str:
@@ -57,7 +60,7 @@ def solution_embed(solution: dict[ModifiedRecipe, float]) -> Embed:
             name = f"{name} {'+' if ' @ ' in name else '@'} {recipe.sloop_scale}x"
             building = f"{building} {'+' if ' with ' in building else 'with'} {recipe.sloops} Somersloop{plrl(recipe.sloops)}"
 
-        embed.add_field(name=name, value=f"{num} {building}\n{inout_str(recipe.inputs, recipe.outputs, num)}", inline=False)
+        embed.add_field(name=name, value=f"{rnd(num)} {building}\n{inout_str(recipe.inputs, recipe.outputs, num)}", inline=False)
 
     summary = solution_summary(solution)
     footer = inout_str(summary.inputs, summary.outputs)

--- a/duckbot/cogs/games/satisfy/solver.py
+++ b/duckbot/cogs/games/satisfy/solver.py
@@ -44,7 +44,7 @@ def optimize(factory: Factory) -> Optional[dict[ModifiedRecipe, float]]:
     )
     result = model.optimize()
 
-    return dict((r, round(float(v.x), 4)) for r, v in zip(recipes, use_recipe) if v.x is not None and v.x > 0 and not isclose(float(v), 0, abs_tol=1e-4)) if result in good_enough else None
+    return dict((r, float(v.x)) for r, v in zip(recipes, use_recipe) if v.x is not None and v.x > 0 and not isclose(float(v), 0, abs_tol=1e-4)) if result in good_enough else None
 
 
 def modify_recipes(recipes: List[Recipe], max_shards: int, max_sloops: int) -> List[ModifiedRecipe]:


### PR DESCRIPTION
##### Summary

Moving the rounding to display instead of the solver return. Chopping off digits early makes the math wonky.

##### Checklist

- [x] this is a source code change
  - [x] run `format` in the repository root
  - [x] run `pytest` in the repository root
  - [ ] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [ ] update the wiki documentation if necessary
- [ ] or, this is **not** a source code change
