### PR TITLE
✨ allow the solver to supply it's own input raw materials

### DIFF
--- a/duckbot/cogs/games/satisfy/pretty.py
+++ b/duckbot/cogs/games/satisfy/pretty.py
@@ -7,7 +7,7 @@ from discord import Embed
 from .factory import Factory
 from .item import Item
 from .rates import Rates
-from .recipe import ModifiedRecipe
+from .recipe import ModifiedRecipe, raw
 
 
 def rnd(num: float) -> float:
@@ -91,7 +91,8 @@ class SolutionSummary:
 def solution_summary(solution: dict[ModifiedRecipe, float]) -> SolutionSummary:
     inputs = reduce(sum_by_item, [r.inputs * -v for r, v in solution.items()], dict())
     outputs = reduce(sum_by_item, [r.outputs * v for r, v in solution.items()], dict())
-    totals = sum_by_item(inputs, outputs)
+    creation = {i: -n for i, n in outputs.items() if i in [Item[x.name] for x in raw()]}
+    totals = sum_by_item(sum_by_item(inputs, creation), outputs)
     return SolutionSummary(
         inputs=Rates(dict((k, -v) for k, v in totals.items() if v < 0)),
         outputs=Rates(dict((k, v) for k, v in totals.items() if v > 0)),

--- a/duckbot/cogs/games/satisfy/recipe.py
+++ b/duckbot/cogs/games/satisfy/recipe.py
@@ -395,6 +395,22 @@ def alternates() -> List[Recipe]:
 def awesome_sink() -> List[Recipe]:
     return [sink(item) for item in Item if sinkable(item)]
 
+def raw() -> List[Recipe]:
+    return [
+        recipe(Item.Bauxite, Building.Miner, Rates() >> Item.Bauxite * 1),
+        recipe(Item.CateriumOre, Building.Miner, Rates() >> Item.CateriumOre * 1),
+        recipe(Item.Coal, Building.Miner, Rates() >> Item.Coal * 1),
+        recipe(Item.CopperOre, Building.Miner, Rates() >> Item.CopperOre * 1),
+        recipe(Item.CrudeOil, Building.OilExtractor, Rates() >> Item.CrudeOil * 1),
+        recipe(Item.IronOre, Building.Miner, Rates() >> Item.IronOre * 1),
+        recipe(Item.Limestone, Building.Miner, Rates() >> Item.Limestone * 1),
+        recipe(Item.NitrogenGas, Building.ResourceWell, Rates() >> Item.NitrogenGas * 1),
+        recipe(Item.RawQuartz, Building.Miner, Rates() >> Item.RawQuartz * 1),
+        recipe(Item.Sam, Building.Miner, Rates() >> Item.Sam * 1),
+        recipe(Item.Sulfur, Building.Miner, Rates() >> Item.Sulfur * 1),
+        recipe(Item.Uranium, Building.Miner, Rates() >> Item.Uranium * 1),
+        recipe(Item.Water, Building.WaterExtractor, Rates() >> Item.Water * 1),
+    ]
 
 def recipe(name: str | Item, building: Building, inout: tuple[Rates, Rates]) -> Recipe:
     return Recipe(str(name), building, inputs=inout[0], outputs=inout[1])

--- a/duckbot/cogs/games/satisfy/recipe.py
+++ b/duckbot/cogs/games/satisfy/recipe.py
@@ -52,7 +52,7 @@ class ModifiedRecipe:
 
 
 def default() -> List[Recipe]:
-    return regular() + packager() + power() + awesome_sink()
+    return regular() + packager() + power() + awesome_sink() + raw()
 
 
 def all() -> List[Recipe]:
@@ -395,6 +395,7 @@ def alternates() -> List[Recipe]:
 def awesome_sink() -> List[Recipe]:
     return [sink(item) for item in Item if sinkable(item)]
 
+
 def raw() -> List[Recipe]:
     return [
         recipe(Item.Bauxite, Building.Miner, Rates() >> Item.Bauxite * 1),
@@ -411,6 +412,7 @@ def raw() -> List[Recipe]:
         recipe(Item.Uranium, Building.Miner, Rates() >> Item.Uranium * 1),
         recipe(Item.Water, Building.WaterExtractor, Rates() >> Item.Water * 1),
     ]
+
 
 def recipe(name: str | Item, building: Building, inout: tuple[Rates, Rates]) -> Recipe:
     return Recipe(str(name), building, inputs=inout[0], outputs=inout[1])

--- a/duckbot/cogs/games/satisfy/recipe.py
+++ b/duckbot/cogs/games/satisfy/recipe.py
@@ -398,19 +398,19 @@ def awesome_sink() -> List[Recipe]:
 
 def raw() -> List[Recipe]:
     return [
-        recipe(Item.Bauxite, Building.Miner, Rates() >> Item.Bauxite * 1),
-        recipe(Item.CateriumOre, Building.Miner, Rates() >> Item.CateriumOre * 1),
-        recipe(Item.Coal, Building.Miner, Rates() >> Item.Coal * 1),
-        recipe(Item.CopperOre, Building.Miner, Rates() >> Item.CopperOre * 1),
-        recipe(Item.CrudeOil, Building.OilExtractor, Rates() >> Item.CrudeOil * 1),
-        recipe(Item.IronOre, Building.Miner, Rates() >> Item.IronOre * 1),
-        recipe(Item.Limestone, Building.Miner, Rates() >> Item.Limestone * 1),
-        recipe(Item.NitrogenGas, Building.ResourceWell, Rates() >> Item.NitrogenGas * 1),
-        recipe(Item.RawQuartz, Building.Miner, Rates() >> Item.RawQuartz * 1),
-        recipe(Item.Sam, Building.Miner, Rates() >> Item.Sam * 1),
-        recipe(Item.Sulfur, Building.Miner, Rates() >> Item.Sulfur * 1),
-        recipe(Item.Uranium, Building.Miner, Rates() >> Item.Uranium * 1),
-        recipe(Item.Water, Building.WaterExtractor, Rates() >> Item.Water * 1),
+        recipe(Item.Bauxite, Building.Miner, Rates() >> Item.Bauxite * 60),
+        recipe(Item.CateriumOre, Building.Miner, Rates() >> Item.CateriumOre * 60),
+        recipe(Item.Coal, Building.Miner, Rates() >> Item.Coal * 60),
+        recipe(Item.CopperOre, Building.Miner, Rates() >> Item.CopperOre * 60),
+        recipe(Item.CrudeOil, Building.OilExtractor, Rates() >> Item.CrudeOil * 120),
+        recipe(Item.IronOre, Building.Miner, Rates() >> Item.IronOre * 60),
+        recipe(Item.Limestone, Building.Miner, Rates() >> Item.Limestone * 60),
+        recipe(Item.NitrogenGas, Building.ResourceWell, Rates() >> Item.NitrogenGas * 60),
+        recipe(Item.RawQuartz, Building.Miner, Rates() >> Item.RawQuartz * 60),
+        recipe(Item.Sam, Building.Miner, Rates() >> Item.Sam * 60),
+        recipe(Item.Sulfur, Building.Miner, Rates() >> Item.Sulfur * 60),
+        recipe(Item.Uranium, Building.Miner, Rates() >> Item.Uranium * 60),
+        recipe(Item.Water, Building.WaterExtractor, Rates() >> Item.Water * 120),
     ]
 
 

--- a/duckbot/cogs/games/satisfy/satisfy.py
+++ b/duckbot/cogs/games/satisfy/satisfy.py
@@ -8,7 +8,7 @@ from .factory import Factory
 from .item import Item
 from .pretty import factory_embed, solution_embed
 from .rates import Rates
-from .recipe import all, converter, default
+from .recipe import all, converter, default, raw
 from .solver import optimize
 
 
@@ -23,9 +23,13 @@ item_names = [i.name for i in Item]
 boost_item_names = [Item.PowerShard.name, Item.Somersloop.name]
 recipe_banks = {
     "All": all(),
-    "All without Conversions": [r for r in all() if r.name not in [x.name for x in converter()]],
+    "All - Conversions": [r for r in all() if r.name not in [x.name for x in converter()]],
+    "All - RawSupply": [r for r in all() if r.name not in [x.name for x in raw()]],
+    "All - Conversions - RawSupply": [r for r in all() if r.name not in [x.name for x in converter() + raw()]],
     "Default": default(),
-    "Default with Conversions": default() + converter(),
+    "Default + Conversions": default() + converter(),
+    "Default + Conversions - RawSupply": [r for r in default() + converter() if r.name not in [x.name for x in raw()]],
+    "Default - RawSupply": [r for r in default() if r.name not in [x.name for x in raw()]],
     "Multiplayer": default() + [r for r in all() if r.name in []],
     "Clandestine": default()
     + [

--- a/duckbot/cogs/games/satisfy/satisfy.py
+++ b/duckbot/cogs/games/satisfy/satisfy.py
@@ -145,7 +145,7 @@ class Satisfy(Cog):
     @check(allowed)
     async def solve(self, context: Context):
         factory = self.factory(context)
-        if not factory.inputs or (not factory.targets and not factory.maximize):
+        if not factory.targets and not factory.maximize:
             await context.send("No.", delete_after=10)
         else:
             async with context.typing():

--- a/duckbot/cogs/games/satisfy/satisfy.py
+++ b/duckbot/cogs/games/satisfy/satisfy.py
@@ -149,9 +149,7 @@ class Satisfy(Cog):
     @check(allowed)
     async def solve(self, context: Context):
         factory = self.factory(context)
-        if not factory.targets and not factory.maximize:
-            await context.send("No.", delete_after=10)
-        else:
+        if factory.targets or (factory.inputs and factory.maximize):
             async with context.typing():
                 recipes = [r for r in recipe_banks[factory.recipe_bank] if r.name not in factory.exclude_recipes]
                 names = [r.name for r in recipes]
@@ -161,6 +159,8 @@ class Satisfy(Cog):
                     await context.send("Why do you hate possible?", delete_after=10)
                 else:
                     await context.send(embeds=[factory_embed(factory), solution_embed(solution)])
+        else:
+            await context.send("No.", delete_after=10)
 
     @add_input.autocomplete("item")
     @add_target.autocomplete("item")

--- a/tests/cogs/games/satisfy/solver_test.py
+++ b/tests/cogs/games/satisfy/solver_test.py
@@ -1,5 +1,7 @@
 from typing import Set
 
+import pytest
+
 from duckbot.cogs.games.satisfy.factory import Factory
 from duckbot.cogs.games.satisfy.item import Item
 from duckbot.cogs.games.satisfy.rates import Rates
@@ -11,9 +13,7 @@ default_no_raw = [r for r in default() if r.name not in [x.name for x in raw()]]
 
 
 def approx(x):
-    from pytest import approx as pyapprox
-
-    return pyapprox(x, abs=1e-4)
+    return pytest.approx(x, abs=1e-4)
 
 
 def factory(*, input: Rates, target: Rates = Rates(), maximize: Set[Item] = set(), recipes=all_no_raw, power_shards: int = 0, sloops: int = 0):

--- a/tests/cogs/games/satisfy/solver_test.py
+++ b/tests/cogs/games/satisfy/solver_test.py
@@ -62,7 +62,7 @@ def test_optimize_create_resources_returns_target():
     f = factory(input=Rates(), target=Item.IronIngot * 30, recipes=default())
     ore = recipe_by_name("IronOre")
     ingot = recipe_by_name("IronIngot")
-    assert optimize(f) == dict([(ore, approx(30)), (ingot, approx(1))])
+    assert optimize(f) == dict([(ore, approx(0.5)), (ingot, approx(1))])
 
 
 def test_optimize_two_step_returns_chain():
@@ -101,7 +101,7 @@ def test_optimize_fluid_excess_is_made_sinkable():
 
 
 def test_optimize_recycled_bois_returns_chain():
-    f = factory(input=Item.Water * 90 + Item.CrudeOil * 27, target=Item.Plastic * 81, recipes=[r for r in all() if r.name != "DilutedFuel"])
+    f = factory(input=Item.Water * 90 + Item.CrudeOil * 27, target=Item.Plastic * 81, recipes=[r for r in all_no_raw if r.name != "DilutedFuel"])
     goo = recipe_by_name("HeavyOilResidue")
     dilute = recipe_by_name("DilutedPackagedFuel")
     wudder = recipe_by_name("PackagedWater")

--- a/tests/cogs/games/satisfy/solver_test.py
+++ b/tests/cogs/games/satisfy/solver_test.py
@@ -16,12 +16,12 @@ def approx(x):
     return pyapprox(x, abs=1e-4)
 
 
-def factory(input: Rates, target: Rates = Rates(), maximize: Set[Item] = set(), power_shards: int = 0, sloops: int = 0):
-    return Factory(inputs=input, targets=target, maximize=maximize, power_shards=power_shards, sloops=sloops, recipes=all_no_raw)
+def factory(*, input: Rates, target: Rates = Rates(), maximize: Set[Item] = set(), recipes=all_no_raw, power_shards: int = 0, sloops: int = 0):
+    return Factory(inputs=input, targets=target, maximize=maximize, power_shards=power_shards, sloops=sloops, recipes=recipes)
 
 
 def test_optimize_empty_factory_returns_empty():
-    assert optimize(factory(Rates())) == dict()
+    assert optimize(factory(input=Rates())) == dict()
 
 
 def test_optimize_trivial_factory_returns_empty():
@@ -30,71 +30,78 @@ def test_optimize_trivial_factory_returns_empty():
 
 
 def test_optimize_infeasible_returns_none():
-    factory = Factory(Item.IronOre * 30, all_no_raw, Item.IronIngot * 31, set())
-    assert optimize(factory) is None
+    f = factory(input=Item.IronOre * 30, target=Item.IronIngot * 31, recipes=all_no_raw)
+    assert optimize(f) is None
 
 
 def test_optimize_simple_factory_target_returns_recipe():
-    factory = Factory(Item.IronOre * 30, default(), Item.IronIngot * 30, set())
+    f = factory(input=Item.IronOre * 30, target=Item.IronIngot * 30, recipes=default())
     recipe = recipe_by_name("IronIngot")
-    assert optimize(factory) == dict([(recipe, approx(1))])
+    assert optimize(f) == dict([(recipe, approx(1))])
 
 
 def test_optimize_simple_factory_maximize_returns_recipe():
-    factory = Factory(Item.IronOre * 30, default_no_raw, Rates(), set([Item.IronIngot]))
+    f = factory(input=Item.IronOre * 30, maximize=set([Item.IronIngot]), recipes=default_no_raw)
     recipe = recipe_by_name("IronIngot")
-    assert optimize(factory) == dict([(recipe, approx(1))])
+    assert optimize(f) == dict([(recipe, approx(1))])
 
 
 def test_optimize_simple_sloop_target_returns_recipe():
-    factory = Factory(Item.IronOre * 30, default_no_raw, Item.IronIngot * 60, set(), sloops=1)
+    f = factory(input=Item.IronOre * 30, target=Item.IronIngot * 60, sloops=1, recipes=default_no_raw)
     recipe = recipe_by_name("IronIngot", sloops=1)
-    assert optimize(factory) == dict([(recipe, approx(1))])
+    assert optimize(f) == dict([(recipe, approx(1))])
 
 
 def test_optimize_simple_sloop_maximize_returns_recipe():
-    factory = Factory(Item.IronOre * 30, default_no_raw, Rates(), set([Item.IronIngot]), sloops=1)
+    f = factory(input=Item.IronOre * 30, maximize=set([Item.IronIngot]), sloops=1, recipes=default_no_raw)
     recipe = recipe_by_name("IronIngot", sloops=1)
-    assert optimize(factory) == dict([(recipe, approx(1))])
+    assert optimize(f) == dict([(recipe, approx(1))])
+
+
+def test_optimize_create_resources_returns_target():
+    f = factory(input=Rates(), target=Item.IronIngot * 30, recipes=default())
+    ore = recipe_by_name("IronOre")
+    ingot = recipe_by_name("IronIngot")
+    assert optimize(f) == dict([(ore, approx(30)), (ingot, approx(1))])
 
 
 def test_optimize_two_step_returns_chain():
-    factory = Factory(Item.IronOre * 30, default_no_raw, Rates(), set([Item.IronPlate]))
+    f = factory(input=Item.IronOre * 30, maximize=set([Item.IronPlate]), recipes=default_no_raw)
     ignot = recipe_by_name("IronIngot")
     plate = recipe_by_name("IronPlate")
-    assert optimize(factory) == dict([(ignot, approx(1)), (plate, approx(1))])
+    assert optimize(f) == dict([(ignot, approx(1)), (plate, approx(1))])
 
 
 def test_optimize_two_step_single_sloop_returns_chain():
-    factory = Factory(Item.IronOre * 30, default_no_raw, Rates(), set([Item.IronPlate]), sloops=1)
+    f = factory(input=Item.IronOre * 30, maximize=set([Item.IronPlate]), sloops=1, recipes=default_no_raw)
     ignot = recipe_by_name("IronIngot")
     plate = recipe_by_name("IronPlate", sloops=1)
-    assert optimize(factory) == dict([(ignot, approx(1)), (plate, approx(1))])
+    assert optimize(f) == dict([(ignot, approx(1)), (plate, approx(1))])
 
 
 def test_optimize_two_step_many_sloop_returns_chain():
-    factory = Factory(Item.IronOre * 30, default_no_raw, Rates(), set([Item.IronPlate]), sloops=10)
+    f = factory(input=Item.IronOre * 30, maximize=set([Item.IronPlate]), sloops=10, recipes=default_no_raw)
     ignot = recipe_by_name("IronIngot", sloops=1)
     plate = recipe_by_name("IronPlate", sloops=1)
-    assert optimize(factory) == dict([(ignot, approx(1)), (plate, approx(2))])
+    assert optimize(f) == dict([(ignot, approx(1)), (plate, approx(2))])
 
 
 def test_optimize_two_step_many_sloop_and_power_shards_returns_chain():
-    factory = Factory(Item.IronOre * 30, default_no_raw, Rates(), set([Item.IronPlate]), sloops=10, power_shards=10)
+    f = factory(input=Item.IronOre * 30, maximize=set([Item.IronPlate]), sloops=10, power_shards=10, recipes=default_no_raw)
     ignot = recipe_by_name("IronIngot", sloops=1)
     plate = recipe_by_name("IronPlate", sloops=1, power_shards=2)
-    assert optimize(factory) == dict([(ignot, approx(1)), (plate, approx(1))])
+    assert optimize(f) == dict([(ignot, approx(1)), (plate, approx(1))])
 
 
 def test_optimize_fluid_excess_is_made_sinkable():
-    factory = Factory(Item.CrudeOil * 30, default(), Item.Plastic * 20, set())
+    f = factory(input=Item.CrudeOil * 30, target=Item.Plastic * 20, recipes=default())
     plastic = recipe_by_name("Plastic")
     coke = recipe_by_name("PetroleumCoke")
-    assert optimize(factory) == dict([(plastic, approx(1)), (coke, approx(0.25))])
+    assert optimize(f) == dict([(plastic, approx(1)), (coke, approx(0.25))])
 
 
 def test_optimize_recycled_bois_returns_chain():
-    factory = Factory(inputs=Item.Water * 90 + Item.CrudeOil * 27, targets=Item.Plastic * 81, recipes=[r for r in all() if r.name != "DilutedFuel"], maximize=set())
+    f = factory(input=Item.Water * 90 + Item.CrudeOil * 27, target=Item.Plastic * 81, recipes=[r for r in all() if r.name != "DilutedFuel"])
     goo = recipe_by_name("HeavyOilResidue")
     dilute = recipe_by_name("DilutedPackagedFuel")
     wudder = recipe_by_name("PackagedWater")
@@ -102,7 +109,7 @@ def test_optimize_recycled_bois_returns_chain():
     residual = recipe_by_name("ResidualRubber")
     plastic = recipe_by_name("RecycledPlastic")
     rubber = recipe_by_name("RecycledRubber")
-    assert optimize(factory) == dict(
+    assert optimize(f) == dict(
         [
             (goo, approx(0.9)),
             (dilute, approx(1.2)),
@@ -116,4 +123,4 @@ def test_optimize_recycled_bois_returns_chain():
 
 
 def recipe_by_name(name: str, power_shards: int = 0, sloops: int = 0) -> ModifiedRecipe:
-    return ModifiedRecipe(next(r for r in all_no_raw if r.name == name), power_shards, sloops)
+    return ModifiedRecipe(next(r for r in all() if r.name == name), power_shards, sloops)


### PR DESCRIPTION
##### Summary

Fixes https://github.com/duck-dynasty/duckbot/issues/944. Basically if you only specify `output` it'll supply it's own inputs, so long as the recipe bank has those creation recipes in it. The default bank does.

I'm not sure if automatically supplying raw resources should be the default recipe bank, as it makes `maximize` harder to use. What will be used more, `output` or `maximize` ?

How it currently looks:

![{D350EB95-6CC2-49A4-B31F-6D81E6D87958}](https://github.com/user-attachments/assets/db26e093-0aa8-45c9-8efe-03ea1cc38512)

exmaple 2 with some input, but not enough to meet target
![{DAC4C260-2BDC-47A3-B8CC-8236C6C0232D}](https://github.com/user-attachments/assets/38b8043d-b479-44fc-87f6-16e4ae314ec4)


##### Checklist

- [x] this is a source code change
  - [x] run `format` in the repository root
  - [x] run `pytest` in the repository root
  - [x] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [ ] update the wiki documentation if necessary
- [ ] or, this is **not** a source code change
