### PR TITLE
✨ make autocomplete check for letters in same order instead of substring

### DIFF
--- a/duckbot/cogs/games/satisfy/satisfy.py
+++ b/duckbot/cogs/games/satisfy/satisfy.py
@@ -191,7 +191,13 @@ class Satisfy(Cog):
 
 
 def choices(pool: List[str], needle: str, threshold: int = 3) -> List[Choice[str]]:
+    def match(needle: str, haystack: str) -> bool:
+        import builtins
+
+        it = iter(haystack)
+        return builtins.all(any(next_letter == ch for next_letter in it) for ch in needle)
+
     if len(needle) < threshold:
         return []
     else:
-        return [Choice(name=i, value=i) for i in pool if needle.lower() in i.lower()]
+        return [Choice(name=i, value=i) for i in pool if match(needle.lower(), i.lower())]

--- a/tests/cogs/games/satisfy/choices_test.py
+++ b/tests/cogs/games/satisfy/choices_test.py
@@ -1,0 +1,31 @@
+import pytest
+from discord.app_commands import Choice
+
+from duckbot.cogs.games.satisfy.satisfy import choices
+
+
+def choice(value: str) -> Choice:
+    return Choice(name=value, value=value)
+
+
+@pytest.mark.parametrize("threshold", range(1, 10))
+def test_choices_below_threshold_returns_empty(threshold):
+    assert choices([], "x" * (threshold - 1), threshold=threshold) == []
+
+
+@pytest.mark.parametrize("substr", ["substr"[i:j] for i in range(6) for j in range(i + 1, 6 + 1)])
+def test_choices_substring_returns_matches(substr):
+    pool = ["substr", "nope"]
+    assert choices(pool, substr, threshold=0) == [choice("substr")]
+
+
+@pytest.mark.parametrize("substr", ["SUBSTR"[i:j] for i in range(6) for j in range(i + 1, 6 + 1)])
+def test_choices_substring_case_different_returns_matches(substr):
+    pool = ["substr", "nope"]
+    assert choices(pool, substr, threshold=0) == [choice("substr")]
+
+
+@pytest.mark.parametrize("substr", ["sub", "SUB", "sbt", "sBT"])
+def test_choices_same_characters_in_same_order_returns_matches(substr):
+    pool = ["substr", "nope"]
+    assert choices(pool, substr, threshold=0) == [choice("substr")]


### PR DESCRIPTION
##### Summary

Full substring is kinda annoying to search for. Changed so autocomplete searches for the same letters in the same order. So like `repl -> REinforcedironPLate`; capitals are the match. Example here as well:

![{781878DE-58C5-4B81-96FA-6612F781BB1E}](https://github.com/user-attachments/assets/7176153b-fea5-4a38-918a-0e6a2be48325)

##### Checklist

- [x] this is a source code change
  - [x] run `format` in the repository root
  - [x] run `pytest` in the repository root
  - [ ] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [ ] update the wiki documentation if necessary
- [ ] or, this is **not** a source code change
