### PR TITLE
🐛 update `/weather` to use openweather api 3.0

### DIFF
--- a/tests/cogs/weather/weather_test.py
+++ b/tests/cogs/weather/weather_test.py
@@ -33,6 +33,7 @@ def owm(o, city_id, weather_manager):
 def weather(bot, owm, db):
     clazz = Weather(bot, db)
     clazz._owm = owm
+    clazz.one_call = mock.MagicMock()
     return clazz
 
 
@@ -52,7 +53,7 @@ def test_owm_returns_cached_instance(weather, owm):
 
 
 async def test_weather_get_failure(weather, owm, context):
-    owm.weather_manager.side_effect = Exception("ded")
+    weather.one_call.side_effect = Exception("ded")
     with pytest.raises(Exception):
         await weather.weather(context, "city", None, None)
     context.send.assert_called_once_with("Iunno. Figure it out.\nded")


### PR DESCRIPTION
##### Summary

The library we use for this doesn't support the new openweather api version yet, and it seems development on their side is very slow (link to issue in comments). Here I just call the new API directly and use the library to parse the result, which is backward compatible. The new API version is more related to how openweather is charging, but for us it's still free (1000 calls per day are free).

##### Checklist

- [x] this is a source code change
  - [x] run `format` in the repository root
  - [x] run `pytest` in the repository root
  - [ ] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [ ] update the wiki documentation if necessary
- [ ] or, this is **not** a source code change
