### PR TITLE
✨ minimize inputs used

### DIFF
--- a/duckbot/cogs/games/satisfy/rates.py
+++ b/duckbot/cogs/games/satisfy/rates.py
@@ -16,6 +16,9 @@ class Rates:
     def __iter__(self):
         return self.rates.__iter__()
 
+    def __contains__(self, key):
+        return key in self.rates
+
     def get(self, key: Item, default: Optional[float]) -> Optional[float]:
         return self.rates.get(key, default)
 

--- a/duckbot/cogs/games/satisfy/recipe.py
+++ b/duckbot/cogs/games/satisfy/recipe.py
@@ -363,7 +363,7 @@ def alternates() -> List[Recipe]:
         manu("RadioControlSystem", Item.CrystalOscillator * 1.5 + Item.CircuitBoard * 15 + Item.AluminumCasing * 90 + Item.Rubber * 45 >> Item.RadioControlUnit * 4.5),
         manu("RadioConnectionUnit", Item.HeatSink * 15 + Item.HighSpeedConnector * 7.5 + Item.QuartzCrystal * 45 >> Item.RadioControlUnit * 3.75),
         assy("AdheredIronPlate", Item.IronPlate * 11.25 + Item.Rubber * 3.75 >> Item.ReinforcedIronPlate * 3.75),
-        assy("StitchedIronPlate", Item.IronPlate * 18.75 + Item.Wire * 37.6 >> Item.ReinforcedIronPlate * 5.625),
+        assy("StitchedIronPlate", Item.IronPlate * 18.75 + Item.Wire * 37.5 >> Item.ReinforcedIronPlate * 5.625),
         assy("BoltedIronPlate", Item.IronPlate * 90 + Item.Screw * 250 >> Item.ReinforcedIronPlate * 15),
         blend("NitroRocketFuel", Item.Fuel * 120 + Item.NitrogenGas * 90 + Item.Sulfur * 120 + Item.Coal * 60 >> Item.RocketFuel * 180 + Item.CompactedCoal * 30),
         assy("CopperRotor", Item.CopperSheet * 22.5 + Item.Screw * 195 >> Item.Rotor * 11.25),

--- a/tests/cogs/games/satisfy/rates_test.py
+++ b/tests/cogs/games/satisfy/rates_test.py
@@ -33,6 +33,12 @@ def test_get_is_dict_get(item, rate):
     assert rates.get(item, None) == rates.rates.get(item, None)
 
 
+@pytest.mark.parametrize("item", items)
+def test_contains_is_dict_contains(item, rate):
+    rates = to_rates(rate)
+    assert (item in rates) == (item in rates.rates)
+
+
 def test_bool_empty_is_false():
     assert bool(Rates()) is False
 

--- a/tests/cogs/games/satisfy/solver_test.py
+++ b/tests/cogs/games/satisfy/solver_test.py
@@ -65,6 +65,42 @@ def test_optimize_create_resources_returns_target():
     assert optimize(f) == dict([(ore, approx(0.5)), (ingot, approx(1))])
 
 
+def test_optimize_create_resources_minimal_inputs_used():
+    f = factory(input=Rates(), target=Item.ReinforcedIronPlate * 5.625, recipes=default_no_raw + [r for r in all() if r.name in ["IronOre", "IronWire", "StitchedIronPlate"]])
+    ore = recipe_by_name("IronOre")
+    ingot = recipe_by_name("IronIngot")
+    wire = recipe_by_name("IronWire")
+    plate = recipe_by_name("IronPlate")
+    super_plate = recipe_by_name("StitchedIronPlate")
+    assert optimize(f) == dict(
+        [
+            (ore, approx(48.958 / 60.0)),
+            (ingot, approx(48.958 / 30.0)),
+            (wire, approx(1.0 + 2.0 / 3.0)),
+            (plate, approx(18.75 / 20.0)),
+            (super_plate, approx(1)),
+        ]
+    )
+
+
+def test_optimize_maximize_oversupplied_minimizes_inputs_used():
+    f = factory(input=Item.Coal * 120 + Item.IronOre * 120 + Item.Limestone * 270, maximize=set([Item.EncasedIndustrialBeam]), recipes=all_no_raw)
+    ingot = recipe_by_name("IronIngot")
+    steel = recipe_by_name("SolidSteelIngot")
+    concrete = recipe_by_name("Concrete")
+    pipe = recipe_by_name("SteelPipe")
+    butter = recipe_by_name("EncasedIndustrialPipe")
+    assert optimize(f) == dict(
+        [
+            (concrete, approx(6)),
+            (ingot, approx(3.6)),
+            (pipe, approx(5.4)),
+            (butter, approx(4.5)),
+            (steel, approx(2.7)),
+        ]
+    )
+
+
 def test_optimize_two_step_returns_chain():
     f = factory(input=Item.IronOre * 30, maximize=set([Item.IronPlate]), recipes=default_no_raw)
     ignot = recipe_by_name("IronIngot")


### PR DESCRIPTION
##### Summary

Trying to avoid solves like this,

![image](https://github.com/user-attachments/assets/48fbc87f-fc10-4a70-bc15-c0e5d3fe3046)


where it does two different steel ingot recipes, wasting the extra coal. Changed the objective function to reward not using up all the inputs. The weighting will likely have to be adjusted later, but the specific factory above looks better now at least.

Also fixed a typo in the stitched iron plate recipe.

##### Checklist

- [x] this is a source code change
  - [x] run `format` in the repository root
  - [x] run `pytest` in the repository root
  - [ ] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [ ] update the wiki documentation if necessary
- [ ] or, this is **not** a source code change
