### PR TITLE
🔧 change default recipe banks to exclude raw resource generation

### DIFF
--- a/duckbot/cogs/games/satisfy/recipe.py
+++ b/duckbot/cogs/games/satisfy/recipe.py
@@ -52,11 +52,11 @@ class ModifiedRecipe:
 
 
 def default() -> List[Recipe]:
-    return regular() + packager() + power() + awesome_sink() + raw()
+    return regular() + packager() + power() + awesome_sink()
 
 
 def all() -> List[Recipe]:
-    return default() + converter() + alternates()
+    return default() + converter() + alternates() + raw()
 
 
 def regular() -> List[Recipe]:

--- a/duckbot/cogs/games/satisfy/satisfy.py
+++ b/duckbot/cogs/games/satisfy/satisfy.py
@@ -20,10 +20,10 @@ recipe_banks = {
     "All - Conversions - RawSupply": [r for r in all() if r.name not in [x.name for x in converter() + raw()]],
     "Default": default(),
     "Default + Conversions": default() + converter(),
-    "Default + Conversions - RawSupply": [r for r in default() + converter() if r.name not in [x.name for x in raw()]],
-    "Default - RawSupply": [r for r in default() if r.name not in [x.name for x in raw()]],
+    "Default + RawSupply": default() + raw(),
+    "Default + Conversions + RawSupply": default() + converter() + raw(),
     "Multiplayer": default() + [r for r in all() if r.name in []],
-    "Clandestine": [r for r in default() if r.name not in [x.name for x in raw()]]
+    "Clandestine": default()
     + [
         r
         for r in all()

--- a/tests/cogs/games/satisfy/solver_test.py
+++ b/tests/cogs/games/satisfy/solver_test.py
@@ -10,6 +10,7 @@ from duckbot.cogs.games.satisfy.solver import optimize
 
 all_no_raw = [r for r in all() if r.name not in [x.name for x in raw()]]
 default_no_raw = [r for r in default() if r.name not in [x.name for x in raw()]]
+default_with_raw = default() + raw()
 
 
 def approx(x):
@@ -35,7 +36,7 @@ def test_optimize_infeasible_returns_none():
 
 
 def test_optimize_simple_factory_target_returns_recipe():
-    f = factory(input=Item.IronOre * 30, target=Item.IronIngot * 30, recipes=default())
+    f = factory(input=Item.IronOre * 30, target=Item.IronIngot * 30, recipes=default_with_raw)
     recipe = recipe_by_name("IronIngot")
     assert optimize(f) == dict([(recipe, approx(1))])
 
@@ -59,7 +60,7 @@ def test_optimize_simple_sloop_maximize_returns_recipe():
 
 
 def test_optimize_create_resources_returns_target():
-    f = factory(input=Rates(), target=Item.IronIngot * 30, recipes=default())
+    f = factory(input=Rates(), target=Item.IronIngot * 30, recipes=default_with_raw)
     ore = recipe_by_name("IronOre")
     ingot = recipe_by_name("IronIngot")
     assert optimize(f) == dict([(ore, approx(0.5)), (ingot, approx(1))])
@@ -130,7 +131,7 @@ def test_optimize_two_step_many_sloop_and_power_shards_returns_chain():
 
 
 def test_optimize_fluid_excess_is_made_sinkable():
-    f = factory(input=Item.CrudeOil * 30, target=Item.Plastic * 20, recipes=default())
+    f = factory(input=Item.CrudeOil * 30, target=Item.Plastic * 20, recipes=default_with_raw)
     plastic = recipe_by_name("Plastic")
     coke = recipe_by_name("PetroleumCoke")
     assert optimize(f) == dict([(plastic, approx(1)), (coke, approx(0.25))])


### PR DESCRIPTION
##### Summary

I find myself using `maximize` more often than a targetted output, and the objective function is set up so it should return good results for either flavour. But, maximizing fails when you can create resources, so making that no longer the default option should make everything a little easier to use.

##### Checklist

- [x] this is a source code change
  - [x] run `format` in the repository root
  - [x] run `pytest` in the repository root
  - [ ] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [ ] update the wiki documentation if necessary
- [ ] or, this is **not** a source code change
