### PR TITLE
🔧 display satisfy messages for more time

### DIFF
--- a/duckbot/cogs/games/satisfy/satisfy.py
+++ b/duckbot/cogs/games/satisfy/satisfy.py
@@ -76,32 +76,32 @@ class Satisfy(Cog):
     @satisfy.command(name="reset", description="Clears factory inputs built so far.")
     async def reset(self, context: Context):
         self.clear(context)
-        await context.send(f":factory: :fire: Factory for {context.author.display_name} cleared. Bitch. :fire: :factory:", delete_after=10)
+        await context.send(f":factory: :fire: Factory for {context.author.display_name} cleared. Bitch. :fire: :factory:", delete_after=60)
 
     @satisfy.command(name="state", description="Displays the current factory.")
     async def factory_state(self, context: Context):
-        await context.send(embed=factory_embed(self.factory(context)), delete_after=60)
+        await context.send(embed=factory_embed(self.factory(context)), delete_after=1800)
 
     @satisfy.command(name="input", description="Adds an input to the factory.")
     async def add_input(self, context: Context, item: str, rate_per_minute: float):
         factory = self.factory(context)
         factory.inputs = factory.inputs + Item[item] * rate_per_minute
         self.save(context, factory)
-        await context.send(embed=factory_embed(factory), delete_after=10)
+        await context.send(embed=factory_embed(factory), delete_after=60)
 
     @satisfy.command(name="output", description="Specifies a desired output for the factory.")
     async def add_target(self, context: Context, item: str, rate_per_minute: float):
         factory = self.factory(context)
         factory.targets = factory.targets + Item[item] * rate_per_minute
         self.save(context, factory)
-        await context.send(embed=factory_embed(factory), delete_after=10)
+        await context.send(embed=factory_embed(factory), delete_after=60)
 
     @satisfy.command(name="maximize", description="Specify maximize output of desired item.")
     async def add_maximize(self, context: Context, item: str):
         factory = self.factory(context)
         factory.maximize.add(Item[item])
         self.save(context, factory)
-        await context.send(embed=factory_embed(factory), delete_after=10)
+        await context.send(embed=factory_embed(factory), delete_after=60)
 
     @satisfy.command(name="booster", description="Specify how many of a booster item is available to use.")
     async def add_booster(self, context: Context, boost_item: str, amount: int):
@@ -112,7 +112,7 @@ class Satisfy(Cog):
         elif item == Item.Somersloop:
             factory.sloops = amount
         self.save(context, factory)
-        await context.send(embed=factory_embed(factory), delete_after=10)
+        await context.send(embed=factory_embed(factory), delete_after=60)
 
     @satisfy.group(name="recipe", description="Recipe related manipulations.")
     async def recipe(self, context: Context):
@@ -123,21 +123,21 @@ class Satisfy(Cog):
         factory = self.factory(context)
         factory.recipe_bank = recipe_bank
         self.save(context, factory)
-        await context.send(embed=factory_embed(factory), delete_after=10)
+        await context.send(embed=factory_embed(factory), delete_after=60)
 
     @recipe.command(name="include", description="Forces a recipe to be available to the solver. Overrides `exclude`")
     async def include_recipe(self, context: Context, recipe: str):
         factory = self.factory(context)
         factory.include_recipes.add(recipe)
         self.save(context, factory)
-        await context.send(embed=factory_embed(factory), delete_after=10)
+        await context.send(embed=factory_embed(factory), delete_after=60)
 
     @recipe.command(name="exclude", description="Makes a recipe to be unavailable to the solver. Overridden by `include`")
     async def exclude_recipe(self, context: Context, recipe: str):
         factory = self.factory(context)
         factory.exclude_recipes.add(recipe)
         self.save(context, factory)
-        await context.send(embed=factory_embed(factory), delete_after=10)
+        await context.send(embed=factory_embed(factory), delete_after=60)
 
     @satisfy.command(name="solve", description="Runs the solver for the factory.")
     async def solve(self, context: Context):
@@ -149,11 +149,11 @@ class Satisfy(Cog):
                 factory.recipes = recipes + [r for r in all() if r.name in factory.include_recipes and r.name not in names]
                 solution = optimize(factory)
                 if solution is None:
-                    await context.send("Why do you hate possible?", delete_after=10)
+                    await context.send("Why do you hate possible?", delete_after=60)
                 else:
                     await context.send(embeds=[factory_embed(factory), solution_embed(solution)])
         else:
-            await context.send("No.", delete_after=10)
+            await context.send("No.", delete_after=60)
 
     @add_input.autocomplete("item")
     @add_target.autocomplete("item")
@@ -184,7 +184,7 @@ class Satisfy(Cog):
     @exclude_recipe.error
     @solve.error
     async def on_error(self, context: Context, error):
-        await context.send(str(error), delete_after=10)
+        await context.send(str(error), delete_after=60)
 
 
 def choices(pool: List[str], needle: str, threshold: int = 3) -> List[Choice[str]]:

--- a/tests/cogs/games/satisfy/satisfy_test.py
+++ b/tests/cogs/games/satisfy/satisfy_test.py
@@ -25,7 +25,7 @@ async def test_reset_destroys_factory(clazz, context):
     clazz.save(context, empty_factory)
     await clazz.reset.callback(clazz, context)
     assert clazz.factory_cache == {}
-    context.send.assert_called_once_with(f":factory: :fire: Factory for {context.author.display_name} cleared. Bitch. :fire: :factory:", delete_after=10)
+    context.send.assert_called_once_with(f":factory: :fire: Factory for {context.author.display_name} cleared. Bitch. :fire: :factory:", delete_after=60)
 
 
 async def test_factory_state_sends_something_i_guess(clazz, context):
@@ -98,12 +98,12 @@ async def test_exclude_recipe_adds_include(clazz, context):
 
 async def test_solve_no_factory_rejects(clazz, context):
     await clazz.solve.callback(clazz, context)
-    context.send.assert_called_once_with("No.", delete_after=10)
+    context.send.assert_called_once_with("No.", delete_after=60)
 
 
 async def test_solve_no_in_or_out(clazz, context, default_factory):
     await clazz.solve.callback(clazz, context)
-    context.send.assert_called_once_with("No.", delete_after=10)
+    context.send.assert_called_once_with("No.", delete_after=60)
 
 
 @mock.patch("duckbot.cogs.games.satisfy.satisfy.optimize", return_value=dict())


### PR DESCRIPTION
##### Summary

With solver interactions being done in discord threads, they aren't as noisy. So. More time.

##### Checklist

- [x] this is a source code change
  - [x] run `format` in the repository root
  - [x] run `pytest` in the repository root
  - [ ] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [ ] update the wiki documentation if necessary
- [ ] or, this is **not** a source code change
