### PR TITLE
🐛 split solution into multiple embeds if they're big

### DIFF
--- a/duckbot/cogs/games/satisfy/satisfy.py
+++ b/duckbot/cogs/games/satisfy/satisfy.py
@@ -177,7 +177,7 @@ class Satisfy(Cog):
                 if solution is None:
                     await context.send("Why do you hate possible?", delete_after=60)
                 else:
-                    await context.send(embeds=[factory_embed(factory), solution_embed(solution)])
+                    await context.send(embeds=[factory_embed(factory)] + solution_embed(solution))
         else:
             await context.send("No.", delete_after=60)
 


### PR DESCRIPTION
##### Summary

Part of https://github.com/duck-dynasty/duckbot/issues/959

Discord embeds can only have 25 "fields," and a field is used for every recipe in the solution. Splitting into many embeds overcomes that limitation. [Example in beta](https://discord.com/channels/845352633702809621/845353256153907210/1289324175730671648).

But the command can still fail for HUGE factories. Discord still has a 6000 character limit, [example](https://discord.com/channels/845352633702809621/845353256153907210/1289323996348940349).

##### Checklist

- [x] this is a source code change
  - [x] run `format` in the repository root
  - [x] run `pytest` in the repository root
  - [x] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [ ] update the wiki documentation if necessary
- [ ] or, this is **not** a source code change
