### PR TITLE
🐛 fix raw resource creation not working with intermediary item inputs

### DIFF
--- a/duckbot/cogs/games/satisfy/rates.py
+++ b/duckbot/cogs/games/satisfy/rates.py
@@ -22,6 +22,11 @@ class Rates:
     def get(self, key: Item, default: Optional[float]) -> Optional[float]:
         return self.rates.get(key, default)
 
+    def singleton_rate(self) -> float:
+        if len(self.rates) != 1:
+            raise AssertionError(f"{self} is not a singleton")
+        return next(x for x in self.items())[1]
+
     def __bool__(self) -> bool:
         return bool(self.rates)
 

--- a/duckbot/cogs/games/satisfy/satisfy.py
+++ b/duckbot/cogs/games/satisfy/satisfy.py
@@ -200,9 +200,7 @@ class Satisfy(Cog):
 
     def factory(self, context: Context) -> Factory:
         factory = Factory(inputs=Rates(), targets=Rates(), maximize=set(), recipes=all(), power_shards=0, sloops=0)
-        # factory = Factory(inputs=Item.CrudeOil * 300 + Item.Water * 10000, targets=Rates(), maximize=set([Item.Plastic]), recipes=all(), power_shards=0, sloops=10)
-        # factory = Factory(inputs=Item.CrudeOil * 30, targets=Item.Plastic * 20, maximize=set(), recipes=all(), power_shards=0, sloops=0)
-        # factory = Factory(inputs=Item.IronOre * 30, targets=Rates(), maximize=set([Item.IronPlate]), recipes=all(), power_shards=0, sloops=10)
+        factory = Factory(inputs=Item.Coal * 120 + Item.IronOre * 120 + Item.Limestone * 270, targets=Rates(), maximize=set([Item.EncasedIndustrialBeam]), recipes=all(), power_shards=0, sloops=0)
         # monkeypatch fields for recipe manipulations
         factory.recipe_bank = "Default"
         factory.include_recipes = set()

--- a/duckbot/cogs/games/satisfy/satisfy.py
+++ b/duckbot/cogs/games/satisfy/satisfy.py
@@ -200,7 +200,6 @@ class Satisfy(Cog):
 
     def factory(self, context: Context) -> Factory:
         factory = Factory(inputs=Rates(), targets=Rates(), maximize=set(), recipes=all(), power_shards=0, sloops=0)
-        factory = Factory(inputs=Item.Coal * 120 + Item.IronOre * 120 + Item.Limestone * 270, targets=Rates(), maximize=set([Item.EncasedIndustrialBeam]), recipes=all(), power_shards=0, sloops=0)
         # monkeypatch fields for recipe manipulations
         factory.recipe_bank = "Default"
         factory.include_recipes = set()

--- a/duckbot/cogs/games/satisfy/solver.py
+++ b/duckbot/cogs/games/satisfy/solver.py
@@ -100,10 +100,19 @@ def optimize(factory: Factory) -> Optional[dict[ModifiedRecipe, float]]:
     used_power_shards = item_weights[Item.Somersloop] / 100 * power_shards_used(model, factory, recipes, use_recipe)
     used_sloops = item_weights[Item.Somersloop] * sloops_used(model, factory, recipes, use_recipe)
     recipes_used = xsum(use_recipe)
+
+    input_used = xsum([
+        amount * item_weights[i]
+        for i, amount in amount_by_item.items()
+        if i in factory.inputs or i in can_generate])
+    
+    print(input_used)
+
     model.objective = maximize(
         100 * maximize_items  # prioritize maximizing requested items above all
         + 10 * input_remaining  # maximize the amount of remaining factory inputs
         - 10 * raw_usage  # minimize raw material usage, weighted by map availability
+        # - 10 * input_used  # minimize item usage, weighted by map availability
         - 3 * unsinkable_excess  # get rid of fluid products if possible
         - 0.5 * used_power_shards  # minimize power shard usage; they are only eventually cheap
         - 10 * used_sloops  # minimize sloop usage; they ain't cheap

--- a/duckbot/cogs/games/satisfy/solver.py
+++ b/duckbot/cogs/games/satisfy/solver.py
@@ -113,7 +113,6 @@ def optimize(factory: Factory) -> Optional[dict[ModifiedRecipe, float]]:
     used_power_shards = item_weights[Item.Somersloop] / 100 * power_shards_used(model, factory, recipes, use_recipe)
     used_sloops = item_weights[Item.Somersloop] * sloops_used(model, factory, recipes, use_recipe)
     recipes_used = xsum(use_recipe)
-
     model.objective = maximize(
         100 * maximize_items  # prioritize maximizing requested items above all
         + 10 * input_remaining  # maximize the amount of remaining factory inputs

--- a/tests/cogs/games/satisfy/rates_test.py
+++ b/tests/cogs/games/satisfy/rates_test.py
@@ -39,6 +39,20 @@ def test_contains_is_dict_contains(item, rate):
     assert (item in rates) == (item in rates.rates)
 
 
+def test_singleton_rate_empty_throws_error():
+    with pytest.raises(AssertionError):
+        Rates({}).singleton_rate()
+
+
+def test_singleton_rate_singleton_returns_rate(rate):
+    assert to_rates(rate).singleton_rate() == rate[1]
+
+
+def test_singleton_rate_not_singleton_throws_error():
+    with pytest.raises(AssertionError):
+        Rates({Item.AdaptiveControlUnit: 1, Item.AiExpensionServer: 1}).singleton_rate()
+
+
 def test_bool_empty_is_false():
     assert bool(Rates()) is False
 

--- a/tests/cogs/games/satisfy/solver_test.py
+++ b/tests/cogs/games/satisfy/solver_test.py
@@ -84,6 +84,20 @@ def test_optimize_create_resources_minimal_inputs_used():
     )
 
 
+def test_optimize_create_resources_with_inputs_minimizes_inputs_used():
+    f = factory(input=Item.IronIngot * 30, target=Item.IronPlate * 40, recipes=default_with_raw)
+    ore = recipe_by_name(Item.IronOre)
+    ingot = recipe_by_name(Item.IronIngot)
+    plate = recipe_by_name(Item.IronPlate)
+    assert optimize(f) == dict(
+        [
+            (ore, approx(30.0 / 60.0)),
+            (ingot, approx(1.0)),
+            (plate, approx(2.0)),
+        ]
+    )
+
+
 def test_optimize_maximize_oversupplied_minimizes_inputs_used():
     f = factory(input=Item.Coal * 120 + Item.IronOre * 120 + Item.Limestone * 270, maximize=set([Item.EncasedIndustrialBeam]), recipes=all_no_raw)
     ingot = recipe_by_name("IronIngot")
@@ -159,8 +173,8 @@ def test_optimize_recycled_bois_returns_chain():
     )
 
 
-def recipe_by_name(name: str, power_shards: int = 0, sloops: int = 0) -> ModifiedRecipe:
-    return ModifiedRecipe(next(r for r in all() if r.name == name), power_shards, sloops)
+def recipe_by_name(name: str | Item, power_shards: int = 0, sloops: int = 0) -> ModifiedRecipe:
+    return ModifiedRecipe(next(r for r in all() if r.name == str(name)), power_shards, sloops)
 
 
 def test_weights_by_item():

--- a/tests/cogs/games/satisfy/solver_test.py
+++ b/tests/cogs/games/satisfy/solver_test.py
@@ -151,6 +151,24 @@ def test_optimize_fluid_excess_is_made_sinkable():
     assert optimize(f) == dict([(plastic, approx(1)), (coke, approx(0.25))])
 
 
+def test_optimize_raw_resources_are_bound_by_map_limits():
+    f = factory(input=Rates(), maximize=set([Item.IronOre]), recipes=all())
+    ore = recipe_by_name("IronOre")
+    lime = recipe_by_name("Limestone")
+    sam = recipe_by_name("Sam")
+    reanimate = recipe_by_name("ReanimatedSam")
+    convert = recipe_by_name("IronOre#Limestone")
+    assert optimize(f) == dict(
+        [
+            (ore, approx(92_100.0 / 60.0)),
+            (lime, approx(61_200.0 / 60.0)),
+            (sam, approx(10_200.0 / 60.0)),
+            (reanimate, approx(85)),
+            (convert, approx(255)),
+        ]
+    )
+
+
 def test_optimize_recycled_bois_returns_chain():
     f = factory(input=Item.Water * 90 + Item.CrudeOil * 27, target=Item.Plastic * 81, recipes=[r for r in all_no_raw if r.name != "DilutedFuel"])
     goo = recipe_by_name("HeavyOilResidue")

--- a/tests/cogs/games/satisfy/solver_test.py
+++ b/tests/cogs/games/satisfy/solver_test.py
@@ -98,6 +98,12 @@ def test_optimize_create_resources_with_inputs_minimizes_inputs_used():
     )
 
 
+def test_optimize_create_resources_with_inputs_issue_995():
+    f = factory(input=Item.CrystalOscillator * 1, target=Item.RadioControlUnit * 3, recipes=all())
+    crystal = recipe_by_name("InsulatedCrystalOscillator")
+    assert optimize(f)[crystal] == approx(0.2667)  # makes 0.5 extra only
+
+
 def test_optimize_maximize_oversupplied_minimizes_inputs_used():
     f = factory(input=Item.Coal * 120 + Item.IronOre * 120 + Item.Limestone * 270, maximize=set([Item.EncasedIndustrialBeam]), recipes=all_no_raw)
     ingot = recipe_by_name("IronIngot")


### PR DESCRIPTION
##### Summary

Fixes #995

Root cause ended up being a few layers. The symptom was that the solver would make a crapload of an input item even when it was not requested, since it could create new inputs and be rewarded for it (see link in issue). The original issue was that the weights for raw resource creation was wrong, so creating more of the input ended up blowing up the objective to infinity. My first stab at this was to bound the solution so I could inspect it. That's the `upper_bound` function introduced.   
After fixing the weights, it'd work so long as only default recipes were used (since weights are all based on default recipe resource costs). But, if cheaper alternates were included, the solver would prefer to use resources to create those since it was rewarded (cost N to make resources, but then would earn >N to make the item). I introduced a penalty to creating any items it did not have to. That's the `excess_target` objective change.  
Finally, after that, the solver seemed to really like creating power instead of leaving the factory simpler. I made the auxiliary items have max weight, instead of whatever weight they were calculated to be.

Note, a lot of this is arbitrary. But, tests pass, and we can always change weights, etc, later.

##### Checklist

- [x] this is a source code change
  - [x] run `format` in the repository root
  - [x] run `pytest` in the repository root
  - [x] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [ ] update the wiki documentation if necessary
- [ ] or, this is **not** a source code change
