### PR TITLE
:bug: ensure `release` job blocks PRs, fix broken markdown format

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -68,7 +68,7 @@ jobs:
     if: ${{ always() }}
     steps:
     - run: exit 1
-      if: ${{ failure() }}
+      if: ${{ contains(needs.*.result, 'failure') }}
     - run: echo all checks passed
 
   deploy:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -65,7 +65,10 @@ jobs:
     - sanity
     - synthesize
     runs-on: ubuntu-latest
+    if: ${{ always() }}
     steps:
+    - run: exit 1
+      if: ${{ failure() }}
     - run: echo all checks passed
 
   deploy:

--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ https://user-images.githubusercontent.com/3149083/135654217-244d7457-9db9-4c30-a
 
 Before running DuckBot, you want to create a virtualenv to develop in. DuckBot runs on `python3.10`, so prefer to use that.
 
+
+
+
 ```sh
 python3.10 -m venv --clear --prompt duckbot venv
 . venv/bin/activate

--- a/README.md
+++ b/README.md
@@ -17,9 +17,6 @@ https://user-images.githubusercontent.com/3149083/135654217-244d7457-9db9-4c30-a
 
 Before running DuckBot, you want to create a virtualenv to develop in. DuckBot runs on `python3.10`, so prefer to use that.
 
-
-
-
 ```sh
 python3.10 -m venv --clear --prompt duckbot venv
 . venv/bin/activate

--- a/wiki/Commands.md
+++ b/wiki/Commands.md
@@ -193,10 +193,10 @@ Make power shards or somersloops available to use in the factory. Note that powe
 
 Changes the recipe bank. For the love of god, use slash commands for this one. Recipe bank names are available in autocomplete. Some recipe banks include,
 
-* Default: only default in game recipes, no raw supply or conversion recipes
-* All: all available recipes, includes raw supply and conversions
-* _RawSupply_ modifier: the set of raw supply recipes
-* _Conversions_ modifier: the set of raw resource conversion recipes, does not include other recipes in the Converter
+- Default: only default in game recipes, no raw supply or conversion recipes
+- All: all available recipes, includes raw supply and conversions
+- _RawSupply_ modifier: the set of raw supply recipes
+- _Conversions_ modifier: the set of raw resource conversion recipes, does not include other recipes in the Converter
 
 ```
 /satisfy recipe include   name


### PR DESCRIPTION
##### Summary

#1001 for some reason auto-merged despite the `test` check failing. `release` is the only check that is required for branch protections, and it was skipped because `test` failed, which apparently counts as succeeding. [Docs](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks#handling-skipped-but-required-checks) say _use the always() conditional expression in addition to needsuse the always() conditional expression in addition to needs_, but that isn't exactly useful either since we want `release` to just be a marker. ~~Chaining `always()` with `failure()` should work? Draft for testing it out.~~ [contains](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/evaluate-expressions-in-workflows-and-actions#example-using-an-object-filter) works better, [actions link to failure](https://github.com/duck-dynasty/duckbot/actions/runs/11799879898/job/32869663411?pr=1002).

This also fixes the broken format.

##### Checklist

- [ ] this is a source code change
  - [x] run `format` in the repository root
  - [ ] run `pytest` in the repository root
  - [ ] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [ ] update the wiki documentation if necessary
- [ ] or, this is **not** a source code change
