### PR TITLE
✨ add function to calculate item weights by cheapest possible cost

### DIFF
--- a/duckbot/cogs/games/satisfy/item.py
+++ b/duckbot/cogs/games/satisfy/item.py
@@ -202,6 +202,9 @@ class Item(Enum):
 
         return Rates({self: rhs})
 
+    def __lt__(self, rhs):
+        return self.name < rhs.name
+
     def __str__(self):
         return self.name
 

--- a/duckbot/cogs/games/satisfy/rates.py
+++ b/duckbot/cogs/games/satisfy/rates.py
@@ -13,6 +13,9 @@ class Rates:
     def items(self):
         return self.rates.items()
 
+    def keys(self):
+        return self.rates.keys()
+
     def __iter__(self):
         return self.rates.__iter__()
 

--- a/duckbot/cogs/games/satisfy/weights.py
+++ b/duckbot/cogs/games/satisfy/weights.py
@@ -1,0 +1,111 @@
+import sys
+from itertools import groupby
+from math import isclose
+from typing import List
+
+from .item import Item
+from .rates import Rates
+from .recipe import Recipe
+from .recipe import all as all_recipes
+from .recipe import default
+
+map_limits = {
+    Item.Bauxite: 12_300,
+    Item.CateriumOre: 15_000,
+    Item.Coal: 42_300,
+    Item.CopperOre: 36_900,
+    Item.CrudeOil: 12_600,
+    Item.IronOre: 92_100,
+    Item.Limestone: 69_900,
+    Item.NitrogenGas: 12_000,
+    Item.RawQuartz: 13_500,
+    Item.Sam: 10_200,
+    Item.Sulfur: 10_800,
+    Item.Uranium: 2_100,
+    Item.Water: sys.maxsize,
+    Item.Somersloop: 106,
+    Item.Leaves: sys.maxsize,
+    Item.Wood: sys.maxsize,
+    Item.Mycelia: sys.maxsize,
+    Item.HogRemains: sys.maxsize,
+    Item.HatcherRemains: sys.maxsize,
+    Item.SpitterRemains: sys.maxsize,
+    Item.StingerRemains: sys.maxsize,
+    Item.ExcitedPhotonicMatter: sys.maxsize,
+}
+
+
+def unit_inputs(item: Item, recipe: Recipe) -> Rates:
+    """Returns the input Rates for the recipe when the item output from the recipe is 1/min."""
+    return recipe.inputs * (1.0 / recipe.outputs.get(item, 1.0))
+
+
+def default_weights() -> dict[Item, float]:
+    """Determines item weights (costs) based on default recipes only, and raw resource availability."""
+    inputs_by_item = {i: next((unit_inputs(i, r) for r in default() if r.name == str(i)), Rates()) for i in Item}
+    # manually add items which would have no recipe otherwise
+    inputs_by_item[Item.FicsiteIngot] = next(unit_inputs(Item.FicsiteIngot, r) for r in default() if r.name == "FicsiteIngot#Iron")
+    inputs_by_item[Item.PowerShard] = next(unit_inputs(Item.PowerShard, r) for r in default() if r.name == "SyntheticPowerShard")
+    inputs_by_item[Item.TurboRifleAmmo] = next(unit_inputs(Item.TurboRifleAmmo, r) for r in default() if r.name == f"{Item.TurboRifleAmmo}#Blender")
+    inputs_by_item[Item.UraniumWaste] = next(unit_inputs(Item.UraniumWaste, r) for r in default() if r.name == f"NuclearPowerPlant#{Item.UraniumFuelRod}")
+    inputs_by_item[Item.PlutoniumWaste] = next(unit_inputs(Item.PlutoniumWaste, r) for r in default() if r.name == f"NuclearPowerPlant#{Item.PlutoniumFuelRod}")
+    inputs_by_item[Item.HeavyOilResidue] = next(unit_inputs(Item.HeavyOilResidue, r) for r in all_recipes() if r.name == str(Item.HeavyOilResidue))
+    inputs_by_item[Item.PolymerResin] = next(unit_inputs(Item.PolymerResin, r) for r in all_recipes() if r.name == str(Item.PolymerResin))
+    inputs_by_item[Item.Fabric] = next(unit_inputs(Item.Fabric, r) for r in all_recipes() if r.name == "PolyesterFabric")
+    inputs_by_item[Item.PortableMiner] = next(unit_inputs(Item.PortableMiner, r) for r in all_recipes() if r.name == "AutomatedMiner")
+
+    weights = {i: 1.0 / total for i, total in map_limits.items()}
+    adjusted = True
+    while adjusted:
+        adjusted = False
+        for item in Item:
+            if item not in weights:
+                if all(i in weights for i, _ in inputs_by_item[item].items()):
+                    weights[item] = sum(r * weights[i] for i, r in inputs_by_item[item].items())
+                    adjusted = True
+
+    return weights
+
+
+def alternate_weights() -> dict[Item, float]:
+    """Determines item weights (costs) based on the cheapest possible cost given all alternates."""
+    recipes_by_input = _recipes_by_input_item()
+    weights = {item: 1.0 / limit for item, limit in map_limits.items()}
+    # manually add recycling chain, since it is an iterative process which won't resolve with this approach
+    weights[Item.Plastic] = (1 / 3 * weights[Item.CrudeOil]) + (10 / 9 * weights[Item.Water])
+    weights[Item.Rubber] = (1 / 3 * weights[Item.CrudeOil]) + (10 / 9 * weights[Item.Water])
+
+    def propagate(item: Item):
+        """For each recipe where item is an input, calculate the new weight of that recipe's output."""
+        for recipe in recipes_by_input.get(item, []):
+            if all(i in weights for i in recipe.inputs.keys()):
+                for out in recipe.outputs.keys():
+                    rates = unit_inputs(out, recipe)
+                    new_weight = sum(weights[i] * rate for i, rate in rates.items())
+                    if out not in weights or new_weight < weights[out]:
+                        weights[out] = new_weight
+                        propagate(out)
+
+    for item in Item:
+        propagate(item)
+    return weights
+
+
+def _recipes_by_input_item() -> dict[Item, List[Recipe]]:
+    recipe_inputs = sorted(((recipe, item) for recipe in all_recipes() for item, _ in recipe.inputs.items()), key=lambda r: r[1])
+    return {item: [r[0] for r in recipes] for item, recipes in groupby(recipe_inputs, lambda r: r[1])}
+
+
+def minmax_weights():
+    item_weights = default_weights()
+    max_weight = max(item_weights.values())
+    min_weight = min(v for v in item_weights.values() if not isclose(v, 0, abs_tol=1e-6))
+
+    # fudge auxiliary items to avoid them unless asked
+    item_weights[Item.MwPower] = max_weight
+    item_weights[Item.AwesomeTicketPoints] = max_weight
+
+    scale_factor = 1.0 / max_weight * 10
+    scaled = {i: scale_factor * v for i, v in item_weights.items()}
+    all_items = {i: scale_factor * max_weight * 100 for i in Item}
+    return all_items | scaled, scale_factor * max_weight, scale_factor * min_weight

--- a/tests/cogs/games/satisfy/item_test.py
+++ b/tests/cogs/games/satisfy/item_test.py
@@ -22,6 +22,12 @@ def test_mul_returns_rates(item: Item):
     assert item * n == Rates(dict([(item, n)]))
 
 
+@pytest.mark.parametrize("item", Item)
+def test_lt_alphabetical_order_by_name(item: Item):
+    rhs = random.choice([x for x in Item])
+    assert (item < rhs) == (item.name < rhs.name)
+
+
 @pytest.mark.parametrize("item", [i for i in Item if i.form != Form.Solid])
 def test_sinkable_nonsolid_returns_false(item: Item):
     assert sinkable(item) is False

--- a/tests/cogs/games/satisfy/rates_test.py
+++ b/tests/cogs/games/satisfy/rates_test.py
@@ -27,6 +27,11 @@ def test_items_is_dict_items(rate):
     assert dict(rates.items()) == dict(rates.rates.items())
 
 
+def test_keys_is_dict_keys(rate):
+    rates = to_rates(rate)
+    assert set(rates.keys()) == set(rates.rates.keys())
+
+
 @pytest.mark.parametrize("item", items)
 def test_get_is_dict_get(item, rate):
     rates = to_rates(rate)

--- a/tests/cogs/games/satisfy/solver_test.py
+++ b/tests/cogs/games/satisfy/solver_test.py
@@ -104,6 +104,21 @@ def test_optimize_create_resources_with_inputs_issue_995():
     assert optimize(f)[crystal] == approx(0.2667)  # makes 0.5 extra only
 
 
+def test_optimize_create_expensive_resources_with_inputs():
+    f = factory(input=Item.CrystalOscillator * 1, target=Item.CrystalOscillator * 2, recipes=all())
+    crystal = recipe_by_name("InsulatedCrystalOscillator")
+    assert optimize(f)[crystal] == approx(0.5333)  # makes 1 extra only
+
+
+@pytest.mark.skip(reason="very cheap resources are still preferred to be made")
+def test_optimize_create_cheap_resources_with_inputs():
+    f = factory(input=Item.Plastic * 9, target=Item.Plastic * 90, recipes=all())
+    plastic = recipe_by_name("RecycledPlastic")
+    for k, v in optimize(f).items():
+        print(k, v)
+    assert optimize(f)[plastic] == approx(1.7)  # makes 81 extra only
+
+
 def test_optimize_maximize_oversupplied_minimizes_inputs_used():
     f = factory(input=Item.Coal * 120 + Item.IronOre * 120 + Item.Limestone * 270, maximize=set([Item.EncasedIndustrialBeam]), recipes=all_no_raw)
     ingot = recipe_by_name("IronIngot")
@@ -199,18 +214,3 @@ def test_optimize_recycled_bois_returns_chain():
 
 def recipe_by_name(name: str | Item, power_shards: int = 0, sloops: int = 0) -> ModifiedRecipe:
     return ModifiedRecipe(next(r for r in all() if r.name == str(name)), power_shards, sloops)
-
-
-def test_weights_by_item():
-    from duckbot.cogs.games.satisfy.solver import weight_by_item
-
-    w = weight_by_item()
-    assert w[Item.AiLimiter] == approx(12 * w[Item.CateriumOre] + 10 * w[Item.CopperOre])
-    assert w[Item.BallisticWarpDrive] == approx(w[Item.ThermalPropulsionRocket] + 5 * w[Item.SingularityCell] + 2 * w[Item.SuperpositionOscillator] + 40 * w[Item.DarkMatterCrystal])
-    assert 2 * w[Item.ThermalPropulsionRocket] == approx(5 * w[Item.ModularEngine] + 2 * w[Item.TurboMotor] + 6 * w[Item.CoolingSystem] + 2 * w[Item.FusedModularFrame])
-    assert w[Item.ModularEngine] == approx(2 * w[Item.Motor] + 15 * w[Item.Rubber] + 2 * w[Item.SmartPlating])
-    assert w[Item.SmartPlating] == approx(w[Item.ReinforcedIronPlate] + w[Item.Rotor])
-    assert w[Item.ReinforcedIronPlate] == approx(6 * w[Item.IronPlate] + 12 * w[Item.Screw])
-    assert 3 * w[Item.IronOre] == approx(2 * w[Item.IronPlate])
-    assert w[Item.IronOre] == w[Item.IronRod]
-    assert w[Item.IronOre] == w[Item.IronIngot]

--- a/tests/cogs/games/satisfy/weights_test.py
+++ b/tests/cogs/games/satisfy/weights_test.py
@@ -1,0 +1,40 @@
+from pytest import approx
+
+from duckbot.cogs.games.satisfy.item import Item
+from duckbot.cogs.games.satisfy.weights import (
+    alternate_weights,
+    default_weights,
+    map_limits,
+)
+
+
+def test_default_weights():
+    w = default_weights()
+    assert w[Item.AiLimiter] == approx(12 * w[Item.CateriumOre] + 10 * w[Item.CopperOre])
+    assert w[Item.BallisticWarpDrive] == approx(w[Item.ThermalPropulsionRocket] + 5 * w[Item.SingularityCell] + 2 * w[Item.SuperpositionOscillator] + 40 * w[Item.DarkMatterCrystal])
+    assert 2 * w[Item.ThermalPropulsionRocket] == approx(5 * w[Item.ModularEngine] + 2 * w[Item.TurboMotor] + 6 * w[Item.CoolingSystem] + 2 * w[Item.FusedModularFrame])
+    assert w[Item.ModularEngine] == approx(2 * w[Item.Motor] + 15 * w[Item.Rubber] + 2 * w[Item.SmartPlating])
+    assert w[Item.SmartPlating] == approx(w[Item.ReinforcedIronPlate] + w[Item.Rotor])
+    assert w[Item.ReinforcedIronPlate] == approx(6 * w[Item.IronPlate] + 12 * w[Item.Screw])
+    assert 3 * w[Item.IronOre] == approx(2 * w[Item.IronPlate])
+    assert w[Item.IronOre] == w[Item.IronRod]
+    assert w[Item.IronOre] == w[Item.IronIngot]
+
+
+def test_alternate_weights():
+    w = alternate_weights()
+
+    assert w[Item.IronOre] == approx(1 / map_limits[Item.IronOre])
+    assert 65 * w[Item.IronIngot] == approx(35 * w[Item.IronOre] + 20 * w[Item.Water])
+    assert 50 * w[Item.CopperPowder] == approx(300 * w[Item.CopperIngot])
+    assert 3 * w[Item.Plastic] == approx(w[Item.CrudeOil] + (3 + 1 / 3) * w[Item.Water])  # recycling chain is 3:1 plastic:oil
+    assert w[Item.Fuel] == approx(50 / 100 * w[Item.HeavyOilResidue] + w[Item.Water])
+    assert w[Item.HeavyOilResidue] == approx(30 / 40 * w[Item.CrudeOil])
+
+    assert w[Item.BallisticWarpDrive] == approx(w[Item.ThermalPropulsionRocket] + 5 * w[Item.SingularityCell] + 2 * w[Item.SuperpositionOscillator] + 40 * w[Item.DarkMatterCrystal])
+    assert 2 * w[Item.ThermalPropulsionRocket] == approx(5 * w[Item.ModularEngine] + 2 * w[Item.TurboMotor] + 6 * w[Item.CoolingSystem] + 2 * w[Item.FusedModularFrame])
+    assert w[Item.ModularEngine] == approx(2 * w[Item.Motor] + 15 * w[Item.Rubber] + 2 * w[Item.SmartPlating])
+    assert w[Item.SmartPlating] == approx(w[Item.ReinforcedIronPlate] + w[Item.Rotor])
+    assert w[Item.ReinforcedIronPlate] == approx(6 * w[Item.IronPlate] + 12 * w[Item.Screw])
+    assert 3 * w[Item.IronPlate] == approx(w[Item.IronIngot] + w[Item.SteelIngot])
+    assert 3 * w[Item.SteelIngot] == approx(2 * w[Item.IronIngot] + 2 * w[Item.Coal])


### PR DESCRIPTION
##### Summary

It's not used yet in the solver, I couldn't get it to work as I wanted. It also seems to be a little wrong still, since `StitchedIronPlate`, for example, should probably be cheaper than the default recipe for super plates. It may be an `approx` thing, but I haven't looked that deeply into it yet. The alternate weights also ended up producing some wonky solutions in only ways optimizers can; it'd find extremely convoluted solutions that use many different recipes which would end up minimizing the new costs (though, only with non-raw factory inputs, the typical input+maximize still works fine).

I added two solver tests to show the issue that I was trying to resolve here. It is an edge case, at any rate.

Note that the changes to the `solver` file are only moving the declarations to a new file. `alternate_weights` is the only real new code (some minor alterations otherwise, but only cleanup [moving auxiliary item weighing, `all_items` addition in `minmax_weights` function).

##### Checklist

- [x] this is a source code change
  - [x] run `format` in the repository root
  - [x] run `pytest` in the repository root
  - [ ] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [ ] update the wiki documentation if necessary
- [ ] or, this is **not** a source code change
