### PR TITLE
:art: move `_generate_next_value_` function to comply with python3.11

### DIFF
--- a/duckbot/cogs/games/satisfy/building.py
+++ b/duckbot/cogs/games/satisfy/building.py
@@ -3,6 +3,9 @@ from enum import Enum, auto, unique
 
 @unique
 class Building(Enum):
+    def _generate_next_value_(name, start, count, last_values):  # noqa: N805
+        return name
+
     AlienPowerAugmenter = (auto(), 0, 0)
     Assembler = (auto(), 3, 2)
     AwesomeSink = (auto(), 0, 0)
@@ -27,9 +30,6 @@ class Building(Enum):
     ResourceWell = (auto(), 3, 0)
     Smelter = (auto(), 3, 1)
     WaterExtractor = (auto(), 3, 0)
-
-    def _generate_next_value_(name, start, count, last_values):  # noqa: N805
-        return name
 
     def __init__(self, value, max_shards, max_sloop: int):
         self.max_shards = max_shards

--- a/duckbot/cogs/games/satisfy/item.py
+++ b/duckbot/cogs/games/satisfy/item.py
@@ -12,6 +12,9 @@ class Form(Enum):
 
 @unique
 class Item(Enum):
+    def _generate_next_value_(name, start, count, last_values):  # noqa: N805
+        return name
+
     AdaptiveControlUnit = (auto(), Form.Solid, 76_368)
     AiExpensionServer = (auto(), Form.Solid, 597_652)
     AiLimiter = (auto(), Form.Solid, 920)
@@ -189,9 +192,6 @@ class Item(Enum):
 
     AwesomeTicketPoints = (auto(), Form.Aux, 0)
     MwPower = (auto(), Form.Aux, 0)
-
-    def _generate_next_value_(name, start, count, last_values):  # noqa: N805
-        return name
 
     def __init__(self, value, form: Form, points: int):
         self.form = form


### PR DESCRIPTION
##### Summary

Setting up new Chromebook, I can't seem to get python3.10 on it. Running tests with 3.11, I get, 
> E   TypeError: _generate_next_value_ must be defined before members

so moving those around to comply.

##### Checklist

- [x] this is a source code change
  - [x] run `format` in the repository root
  - [x] run `pytest` in the repository root
  - [ ] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [ ] update the wiki documentation if necessary
- [ ] or, this is **not** a source code change
