### PR TITLE
🐛 send multiple messages if solution is too big

### DIFF
--- a/duckbot/cogs/games/satisfy/satisfy.py
+++ b/duckbot/cogs/games/satisfy/satisfy.py
@@ -4,6 +4,8 @@ from discord import Interaction
 from discord.app_commands import Choice
 from discord.ext.commands import Cog, Context, hybrid_group
 
+from duckbot.util.embeds import group_by_max_length
+
 from .factory import Factory
 from .item import Item
 from .pretty import factory_embed, solution_embed
@@ -303,13 +305,8 @@ class Satisfy(Cog):
                 if solution is None:
                     await context.send("Why do you hate possible?", delete_after=60)
                 else:
-                    f = factory_embed(factory)
-                    embeds = solution_embed(solution)
-                    try:
-                        await context.send(embeds=[f] + embeds)
-                    except:
-                        for e in ([f] + embeds):
-                            await context.send(embed=e)
+                    for embeds in group_by_max_length([factory_embed(factory)] + solution_embed(solution)):
+                        await context.send(embeds=embeds)
         else:
             await context.send("No.", delete_after=60)
 

--- a/duckbot/cogs/games/satisfy/satisfy.py
+++ b/duckbot/cogs/games/satisfy/satisfy.py
@@ -303,7 +303,13 @@ class Satisfy(Cog):
                 if solution is None:
                     await context.send("Why do you hate possible?", delete_after=60)
                 else:
-                    await context.send(embeds=[factory_embed(factory)] + solution_embed(solution))
+                    f = factory_embed(factory)
+                    embeds = solution_embed(solution)
+                    try:
+                        await context.send(embeds=[f] + embeds)
+                    except:
+                        for e in ([f] + embeds):
+                            await context.send(embed=e)
         else:
             await context.send("No.", delete_after=60)
 

--- a/duckbot/util/embeds/__init__.py
+++ b/duckbot/util/embeds/__init__.py
@@ -1,3 +1,7 @@
+from typing import List
+
+from discord import Embed
+
 # https://discord.com/developers/docs/resources/channel#embed-limits
 MAX_EMBED_LENGTH = 6000
 MAX_TITLE_LENGTH = 256
@@ -7,3 +11,18 @@ MAX_FIELD_NAME_LENGTH = 256
 MAX_FIELD_VALUE_LENGTH = 1024
 MAX_FOOTER_LENGTH = 2048
 MAX_AUTHOR_NAME_LENGTH = 256
+
+
+def group_by_max_length(embeds: List[Embed]) -> List[List[Embed]]:
+    """Returns groups of embeds which will fit into a single discord message.
+    Will still fail if any single embed is itself bigger than the limit."""
+    total, group, groups = 0, [], []
+    for embed in embeds:
+        length = len(embed)
+        if total + length < MAX_EMBED_LENGTH:
+            total += length
+            group.append(embed)
+        else:
+            total = 0
+            groups.append(group)
+    return groups + [group] if group else groups

--- a/tests/util/embeds/group_by_max_length_test.py
+++ b/tests/util/embeds/group_by_max_length_test.py
@@ -1,0 +1,34 @@
+import pytest
+from discord import Embed
+
+from duckbot.util.embeds import group_by_max_length
+
+
+def embed(length: int) -> Embed:
+    return Embed(title="a" * length)
+
+
+@pytest.mark.parametrize("length", [0, 1, 3000, 6001])
+def test_embed_length(length):
+    assert len(embed(length)) == length
+
+
+def test_empty_returns_empty():
+    assert group_by_max_length([]) == []
+
+
+def test_singleton_returns_singleton():
+    e = embed(1)
+    assert group_by_max_length([e]) == [[e]]
+
+
+def test_multiple_fits_in_single_message_returns_single_group():
+    e1 = embed(1)
+    e2 = embed(2)
+    assert group_by_max_length([e1, e2]) == [[e1, e2]]
+
+
+def test_multiple_does_not_fit_in_single_message_returns_groups():
+    e1 = embed(4000)
+    e2 = embed(4000)
+    assert group_by_max_length([e1, e2]) == [[e1], [e2]]


### PR DESCRIPTION
##### Summary

Fixes #959

Discord has a message size limit, which sometimes big solutions will run into. This chunks up the message into the biggest possible components that can fit into a single message, then send multiple messages.

##### Checklist

- [x] this is a source code change
  - [x] run `format` in the repository root
  - [x] run `pytest` in the repository root
  - [x] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [ ] update the wiki documentation if necessary
- [ ] or, this is **not** a source code change
