### PR TITLE
🐛 fix double counting of raw resources in factory summary

### DIFF
--- a/duckbot/cogs/games/satisfy/pretty.py
+++ b/duckbot/cogs/games/satisfy/pretty.py
@@ -92,10 +92,10 @@ class SolutionSummary:
 
 
 def solution_summary(solution: dict[ModifiedRecipe, float]) -> SolutionSummary:
+    raw_creation = [r.name for r in raw()]
     inputs = reduce(sum_by_item, [r.inputs * -v for r, v in solution.items()], dict())
-    outputs = reduce(sum_by_item, [r.outputs * v for r, v in solution.items()], dict())
-    creation = {i: -n for i, n in outputs.items() if i in [Item[x.name] for x in raw()]}
-    totals = sum_by_item(sum_by_item(inputs, creation), outputs)
+    outputs = reduce(sum_by_item, [r.outputs * v for r, v in solution.items() if r.original_recipe.name not in raw_creation], dict())
+    totals = sum_by_item(inputs, outputs)
     return SolutionSummary(
         inputs=Rates(dict((k, -v) for k, v in totals.items() if v < 0)),
         outputs=Rates(dict((k, v) for k, v in totals.items() if v > 0)),


### PR DESCRIPTION
##### Summary

Currently the factory output "double counts" raw resources when they are also produced by non-raw-resource-recipes, most notably water, but also with conversion recipes since they produce raw resources.

Tested with a factory producing 10 aluminium ingots using `All` recipe bank. Solution includes,
```
Bauxite#Copper
0.0833 Converter
0.8333 ReanimatedSam + 15.0 CopperOre -> 10.0 Bauxite
CopperOre
0.25 Miner
-> 15.0 CopperOre
CrudeOil
0.0083 OilExtractor
-> 1.0 CrudeOil
ElectrodeAluminumScrap
0.0667 Refinery
12.0 AluminaSolution + 4.0 PetroleumCoke -> 20.0 AluminumScrap + 7.0 Water
Sam
0.0556 Miner
-> 3.3333 Sam
Water
0.025 WaterExtractor
-> 3.0 Water
```

old, note only 3 water is actually produced, and bauxite is created by combining copper+sam
```
10.0 Bauxite + 15.0 CopperOre + 1.0 CrudeOil + 3.3333 Sam + 10.0 Water -> 10.0 AluminumIngot + 0.6667 PolymerResin
```

new:
```
15.0 CopperOre + 1.0 CrudeOil + 3.3333 Sam + 3.0 Water -> 10.0 AluminumIngot + 0.6667 PolymerResin
```

There's no tests for things in `pretty`, just manual testing.

##### Checklist

- [x] this is a source code change
  - [x] run `format` in the repository root
  - [x] run `pytest` in the repository root
  - [ ] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [ ] update the wiki documentation if necessary
- [ ] or, this is **not** a source code change
