### PR TITLE
🐛 fix state error in embed grouping calculation

### DIFF
--- a/duckbot/util/embeds/__init__.py
+++ b/duckbot/util/embeds/__init__.py
@@ -19,7 +19,7 @@ def group_by_max_length(embeds: List[Embed]) -> List[List[Embed]]:
     total, group, groups = 0, [], []
     for embed in embeds:
         length = len(embed)
-        if total + length < MAX_EMBED_LENGTH:
+        if total + length < MAX_EMBED_LENGTH * 9 / 10:  # give some breather room; length calc seems to be off
             total += length
             group.append(embed)
         else:

--- a/duckbot/util/embeds/__init__.py
+++ b/duckbot/util/embeds/__init__.py
@@ -19,10 +19,10 @@ def group_by_max_length(embeds: List[Embed]) -> List[List[Embed]]:
     total, group, groups = 0, [], []
     for embed in embeds:
         length = len(embed)
-        if total + length < MAX_EMBED_LENGTH * 9 / 10:  # give some breather room; length calc seems to be off
+        if total + length < MAX_EMBED_LENGTH:
             total += length
             group.append(embed)
         else:
-            total = 0
             groups.append(group)
+            total, group = 0, [embed]
     return groups + [group] if group else groups

--- a/tests/util/embeds/group_by_max_length_test.py
+++ b/tests/util/embeds/group_by_max_length_test.py
@@ -5,36 +5,28 @@ from duckbot.util.embeds import group_by_max_length
 
 
 def embed(length: int) -> Embed:
-    return Embed(title="a" * length)
+    return Embed(title=f"{length}" + "_" * (length - len(f"{length}")))
 
 
-@pytest.mark.parametrize("length", [0, 1, 3000, 6001])
+@pytest.mark.parametrize("length", [1, 2, 3, 3000, 6001])
 def test_embed_length(length):
     assert len(embed(length)) == length
 
 
-def test_empty_returns_empty():
-    assert group_by_max_length([]) == []
-
-
-def test_singleton_returns_singleton():
-    e = embed(1)
-    assert group_by_max_length([e]) == [[e]]
-
-
-def test_multiple_fits_in_single_message_returns_single_group():
-    e1 = embed(1)
-    e2 = embed(2)
-    assert group_by_max_length([e1, e2]) == [[e1, e2]]
-
-
-def test_multiple_does_not_fit_in_single_message_returns_groups():
-    e1 = embed(4000)
-    e2 = embed(4000)
-    assert group_by_max_length([e1, e2]) == [[e1], [e2]]
-
-
-def test_multiple_just_fits_in_single_message_returns_smaller_groups():
-    e1 = embed(2999)
-    e2 = embed(2999)
-    assert group_by_max_length([e1, e2]) == [[e1], [e2]]
+@pytest.mark.parametrize(
+    "lengths, expected_indexes",
+    [
+        ([], []),
+        ([1], [[0]]),
+        ([2000, 2000], [[0, 1]]),  # fits in single message
+        ([3000, 2999], [[0, 1]]),  # just fits in single message
+        ([3000, 3000], [[0], [1]]),  # equal to max; separates
+        ([4000, 4000], [[0], [1]]),  # each gets put into own message
+        ([2500, 2500, 2500], [[0, 1], [2]]),  # single embed leftover in new message
+        ([4000, 2500, 2500], [[0], [1, 2]]),  # multiple leftover in new message
+    ],
+)
+def test_group_by_max_length_all_cases(lengths, expected_indexes):
+    embeds = [embed(length) for length in lengths]
+    expected = [[embeds[i] for i in group] for group in expected_indexes]
+    assert group_by_max_length(embeds) == expected

--- a/tests/util/embeds/group_by_max_length_test.py
+++ b/tests/util/embeds/group_by_max_length_test.py
@@ -16,8 +16,8 @@ def test_embed_length(length):
 @pytest.mark.parametrize(
     "lengths, expected_indexes",
     [
-        ([], []),
-        ([1], [[0]]),
+        ([], []),  # empty
+        ([1], [[0]]),  # trivial singleton
         ([2000, 2000], [[0, 1]]),  # fits in single message
         ([3000, 2999], [[0, 1]]),  # just fits in single message
         ([3000, 3000], [[0], [1]]),  # equal to max; separates

--- a/tests/util/embeds/group_by_max_length_test.py
+++ b/tests/util/embeds/group_by_max_length_test.py
@@ -32,3 +32,9 @@ def test_multiple_does_not_fit_in_single_message_returns_groups():
     e1 = embed(4000)
     e2 = embed(4000)
     assert group_by_max_length([e1, e2]) == [[e1], [e2]]
+
+
+def test_multiple_just_fits_in_single_message_returns_smaller_groups():
+    e1 = embed(2999)
+    e2 = embed(2999)
+    assert group_by_max_length([e1, e2]) == [[e1], [e2]]


### PR DESCRIPTION
##### Summary

Related to #1006. Logic there missed reseting the `group` variable. Dang ol' state.

Refactored the tests a bit when adding the new one. Changed the `embed` creation function to include the size so errors were easier to read, but it means there is no 0 length embed any more. /shrug.

##### Checklist

- [x] this is a source code change
  - [x] run `format` in the repository root
  - [x] run `pytest` in the repository root
  - [ ] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [ ] update the wiki documentation if necessary
- [ ] or, this is **not** a source code change
