### PR TITLE
➖ remove unused pytest-lazy-fixture dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,6 @@ if __name__ == "__main__":
                 "pytest-sugar==1.0.0",
                 "pytest-icdiff==0.9",
                 "pytest-cov==6.0.0",
-                "pytest-lazy-fixture==0.6.3",
             ],
             "cdk": [
                 "aws-cdk.core==1.204.0",


### PR DESCRIPTION
##### Summary

Title. Seems to be the root cause for failures in https://github.com/duck-dynasty/duckbot/pull/1036

##### Checklist

- [x] this is a source code change
  - [x] run `format` in the repository root
  - [x] run `pytest` in the repository root
  - [ ] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [ ] update the wiki documentation if necessary
- [ ] or, this is **not** a source code change
