### PR TITLE
✨ allow limiting the number of times a recipe is used

### DIFF
--- a/duckbot/cogs/games/satisfy/factory.py
+++ b/duckbot/cogs/games/satisfy/factory.py
@@ -1,5 +1,5 @@
-from dataclasses import dataclass
-from typing import Set
+from dataclasses import dataclass, field
+from typing import Dict, Set
 
 from .item import Item
 from .rates import Rates
@@ -8,9 +8,10 @@ from .recipe import ModifiedRecipe
 
 @dataclass
 class Factory:
-    inputs: Rates
-    recipes: Set[ModifiedRecipe]
-    targets: Rates
-    maximize: Set[Item]
+    inputs: Rates = Rates()
+    targets: Rates = Rates()
+    maximize: Set[Item] = field(default_factory=set)
+    recipes: Set[ModifiedRecipe] = field(default_factory=set)
+    limits: Dict[ModifiedRecipe, float] = field(default_factory=dict)
     power_shards: int = 0
     sloops: int = 0

--- a/duckbot/cogs/games/satisfy/pretty.py
+++ b/duckbot/cogs/games/satisfy/pretty.py
@@ -39,12 +39,15 @@ def factory_embed(factory: Factory) -> Embed:
     maxify = "\n".join([str(item) for item in factory.maximize]) if factory.maximize else "N/A"
     embed.add_field(name="Maximize", value=maxify)
 
-    def group_recipes(names):
-        return sorted(list({n.split("#")[0] for n in names}))
+    def group_recipes(names, limits={}):
+        limits = {r.name: v for r, v in limits.items()}
+        names = names | {n for n in limits.keys()}
+        print(limits)
+        return sorted(list({n.split("#")[0] + (f" <= {rnd(limits.get(n))}" if n in limits else "") for n in names}))
 
     embed.add_field(name="Recipe Bank", value=factory.recipe_bank)
     embed.add_field(name="Recipe Includes", value="\n".join(group_recipes(factory.include_recipes)) if factory.include_recipes else "N/A")
-    embed.add_field(name="Recipe Excludes", value="\n".join(group_recipes(factory.exclude_recipes)) if factory.exclude_recipes else "N/A")
+    embed.add_field(name="Recipe Excludes", value="\n".join(group_recipes(factory.exclude_recipes, factory.limits)) if factory.exclude_recipes or factory.limits else "N/A")
 
     return embed
 
@@ -104,8 +107,8 @@ def solution_summary(solution: dict[ModifiedRecipe, float]) -> SolutionSummary:
     return SolutionSummary(
         inputs=Rates(dict((k, -v) for k, v in totals.items() if v < 0)),
         outputs=Rates(dict((k, v) for k, v in totals.items() if v > 0)),
-        total_shards=sum([ceil(n * r.power_shards) for r, n in solution.items()]),
-        total_sloops=sum([ceil(n * r.sloops) for r, n in solution.items()]),
+        total_shards=sum([ceil(n) * r.power_shards for r, n in solution.items()]),
+        total_sloops=sum([ceil(n) * r.sloops for r, n in solution.items()]),
     )
 
 

--- a/tests/cogs/games/satisfy/satisfy_test.py
+++ b/tests/cogs/games/satisfy/satisfy_test.py
@@ -128,6 +128,18 @@ async def test_exclude_recipe_adds_exclude_no_boost(clazz, context):
     assert clazz.factory(context).exclude_recipes == {r.name for r in sloop([r for r in all() if r.name in ["IronOre", "IronIngot"]])}
 
 
+async def test_exclude_recipe_adds_include_with_boost(clazz, context):
+    await clazz.exclude_recipe.callback(clazz, context, str(Item.IronIngot), 3, 1)
+    assert clazz.factory(context).exclude_recipes == {r.name for r in sloop(all()) if r.original_recipe.name == "IronIngot" and r.sloops == 1 and r.power_shards == 3}
+
+    await clazz.exclude_recipe.callback(clazz, context, str(Item.CopperIngot), 2, 0)
+    assert clazz.factory(context).exclude_recipes == {
+        r.name
+        for r in sloop(all())
+        if (r.original_recipe.name == "IronIngot" and r.sloops == 1 and r.power_shards == 3) or (r.original_recipe.name == "CopperIngot" and r.sloops == 0 and r.power_shards == 2)
+    }
+
+
 async def test_exclude_recipe_removes_inclusion(clazz, context):
     await clazz.include_recipe.callback(clazz, context, str(Item.IronOre))
     await clazz.exclude_recipe.callback(clazz, context, str(Item.IronOre))
@@ -149,6 +161,26 @@ async def test_exclude_recipe_invalid_args(clazz, context, shards, sloops):
 
 
 async def test_limit_recipe_adds_limit_no_boost(clazz, context, default_factory):
+    await clazz.limit_recipe.callback(clazz, context, str(Item.IronOre), 30)
+    assert clazz.factory(context).limits == {x: 30 for x in sloop([r for r in all() if r.name in ["IronOre"]])}
+
+    await clazz.limit_recipe.callback(clazz, context, str(Item.IronIngot), 30)
+    assert clazz.factory(context).limits == {x: 30 for x in sloop([r for r in all() if r.name in ["IronOre", "IronIngot"]])}
+
+
+async def test_limit_recipe_adds_include_with_boost(clazz, context):
+    await clazz.limit_recipe.callback(clazz, context, str(Item.IronIngot), 30, 3, 1)
+    assert clazz.factory(context).limits == {r: 30 for r in sloop(all()) if r.original_recipe.name == "IronIngot" and r.sloops == 1 and r.power_shards == 3}
+
+    await clazz.limit_recipe.callback(clazz, context, str(Item.CopperIngot), 30, 2, 0)
+    assert clazz.factory(context).limits == {
+        r: 30
+        for r in sloop(all())
+        if (r.original_recipe.name == "IronIngot" and r.sloops == 1 and r.power_shards == 3) or (r.original_recipe.name == "CopperIngot" and r.sloops == 0 and r.power_shards == 2)
+    }
+
+
+async def test_limit_recipe_adds_limit_with_boost(clazz, context, default_factory):
     await clazz.limit_recipe.callback(clazz, context, str(Item.IronOre), 30)
     assert clazz.factory(context).limits == {x: 30 for x in sloop([r for r in all() if r.name in ["IronOre"]])}
 

--- a/tests/cogs/games/satisfy/satisfy_test.py
+++ b/tests/cogs/games/satisfy/satisfy_test.py
@@ -114,6 +114,12 @@ async def test_include_recipe_removes_boosted_exclusion(clazz, context):
     assert clazz.factory(context).exclude_recipes == set()
 
 
+@pytest.mark.parametrize("shards,sloops", [(None, 0), (0, None)])
+async def test_include_recipe_invalid_args(clazz, context, shards, sloops):
+    with pytest.raises(ValueError):
+        await clazz.include_recipe.callback(clazz, context, str(Item.IronIngot), shards, sloops)
+
+
 async def test_exclude_recipe_adds_exclude_no_boost(clazz, context):
     await clazz.exclude_recipe.callback(clazz, context, str(Item.IronOre))
     assert clazz.factory(context).exclude_recipes == {r.name for r in sloop([r for r in all() if r.name in ["IronOre"]])}
@@ -134,6 +140,26 @@ async def test_exclude_recipe_removes_boosted_inclusion(clazz, context):
     await clazz.exclude_recipe.callback(clazz, context, str(Item.IronIngot))
     assert clazz.factory(context).exclude_recipes == set()
     assert clazz.factory(context).include_recipes == set()
+
+
+@pytest.mark.parametrize("shards,sloops", [(None, 0), (0, None)])
+async def test_exclude_recipe_invalid_args(clazz, context, shards, sloops):
+    with pytest.raises(ValueError):
+        await clazz.exclude_recipe.callback(clazz, context, str(Item.IronIngot), shards, sloops)
+
+
+async def test_limit_recipe_adds_limit_no_boost(clazz, context, default_factory):
+    await clazz.limit_recipe.callback(clazz, context, str(Item.IronOre), 30)
+    assert clazz.factory(context).limits == {x: 30 for x in sloop([r for r in all() if r.name in ["IronOre"]])}
+
+    await clazz.limit_recipe.callback(clazz, context, str(Item.IronIngot), 30)
+    assert clazz.factory(context).limits == {x: 30 for x in sloop([r for r in all() if r.name in ["IronOre", "IronIngot"]])}
+
+
+@pytest.mark.parametrize("shards,sloops", [(None, 0), (0, None)])
+async def test_limit_recipe_invalid_args(clazz, context, shards, sloops):
+    with pytest.raises(ValueError):
+        await clazz.limit_recipe.callback(clazz, context, str(Item.IronIngot), 30, shards, sloops)
 
 
 async def test_solve_no_factory_rejects(clazz, context):

--- a/tests/cogs/games/satisfy/solver_test.py
+++ b/tests/cogs/games/satisfy/solver_test.py
@@ -23,8 +23,8 @@ def approx(x):
     return pytest.approx(x, abs=1e-4)
 
 
-def factory(*, input: Rates, target: Rates = Rates(), maximize: Set[Item] = set(), recipes=all_no_raw, power_shards: int = 0, sloops: int = 0):
-    return Factory(inputs=input, targets=target, maximize=maximize, power_shards=power_shards, sloops=sloops, recipes=[x for r in recipes for x in as_slooped(r)])
+def factory(*, input: Rates, target: Rates = Rates(), maximize: Set[Item] = set(), recipes=all_no_raw, limits={}, power_shards: int = 0, sloops: int = 0):
+    return Factory(inputs=input, targets=target, maximize=maximize, power_shards=power_shards, sloops=sloops, recipes=[x for r in recipes for x in as_slooped(r)], limits=limits)
 
 
 def test_optimize_empty_factory_returns_empty():
@@ -63,6 +63,21 @@ def test_optimize_simple_sloop_maximize_returns_recipe():
     f = factory(input=Item.IronOre * 30, maximize=set([Item.IronIngot]), sloops=1, recipes=default_no_raw)
     recipe = recipe_by_name("IronIngot", sloops=1)
     assert optimize(f) == dict([(recipe, approx(1))])
+
+
+def test_optimize_limit_recipe():
+    f = factory(input=Item.IronOre * 30 + Item.Water * 1000, maximize=set([Item.IronIngot]), recipes=all_no_raw, limits={recipe_by_name("PureIronIngot"): 0.5})
+    pure = recipe_by_name("PureIronIngot")
+    smelt = recipe_by_name("IronIngot")
+    assert optimize(f) == dict([(pure, approx(0.5)), (smelt, approx(0.41666))])
+
+
+def test_optimize_limit_boosted_recipe():
+    f = factory(input=Item.IronOre * 30 + Item.Water * 1000, maximize=set([Item.IronIngot]), recipes=default_no_raw, limits={recipe_by_name("PureIronIngot", 1, 2): 0.5}, power_shards=10, sloops=2)
+    pure = recipe_by_name("PureIronIngot")
+    pure_slooped = recipe_by_name("PureIronIngot", 1, 2)
+    f.recipes = f.recipes + [pure, pure_slooped]  # exclude other pure irons so it's forced to use unslooped
+    assert optimize(f) == dict([(pure_slooped, approx(0.5)), (pure, approx(3.75 / 35))])
 
 
 def test_optimize_create_resources_returns_target():

--- a/wiki/Commands.md
+++ b/wiki/Commands.md
@@ -217,6 +217,14 @@ Note: alternatively, undoes `/satisfy recipe include` for the recipe. In that ca
 Power shards and sloops amount can also be specified to exclude a specific boosted recipe. If neither is provided, all boosted variants of the recipe are excluded. Note that this can lead to some confusing factory states (with a recipe being both included and excluded) since boosted recipes are not distinguished from the base recipe. Basically, deal with it.
 
 ```
+/satisfy recipe limit   name limit [power_shards sloops]
+```
+
+Makes it so the solver cannot use more than `limit` instances of a given recipe. Note that if the recipe is not available (not in the bank, or explicitly excluded), then this limit will have no effect.
+
+Power shards and sloops amount can also be specified to limit usage of a specific boosted recipe. If neither is provided, all boosted variants of the recipe are limited.
+
+```
 /satisfy solve
 ```
 


### PR DESCRIPTION
##### Summary

Fixes #1027

Also:
* fixes an unrelated bug where the factory summary after a solve would display the wrong number of used shards/sloops.
* adds autocompletion for `power_shards` and `sloops` in the commands that can specify them

##### Checklist

- [x] this is a source code change
  - [x] run `format` in the repository root
  - [x] run `pytest` in the repository root
  - [x] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [x] update the wiki documentation if necessary
- [ ] or, this is **not** a source code change
