### PR TITLE
:fire: remove release action

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -59,21 +59,11 @@ jobs:
         . ../${{ steps.cdk.outputs.venv-path }}/bin/activate
         cdk synth
 
-  release:
+  deploy:
     needs:
     - test
     - sanity
     - synthesize
-    runs-on: ubuntu-latest
-    if: ${{ always() }}
-    steps:
-    - run: exit 1
-      if: ${{ contains(needs.*.result, 'failure') }}
-    - run: echo all checks passed
-
-  deploy:
-    needs:
-    - release
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && github.repository == 'duck-dynasty/duckbot'
     concurrency: deploy


### PR DESCRIPTION
##### Summary

After having this for quite some time, it doesn't seem to provide any tangible benefit. Originally I thought we'd only need to say `release` is a required check for the branch, but all actions show up in the UI anyways. That and we need to update dependencies of `release` when a new job was added, which is the same as updating `deploy` with this change. Removing also means we don't run some code in the cloud, so sure, save power or whatever.

I've updated the needed checks on the repo already to be the 3 actions here.

##### Checklist

- [ ] this is a source code change
  - [ ] run `format` in the repository root
  - [ ] run `pytest` in the repository root
  - [ ] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [ ] update the wiki documentation if necessary
- [x] or, this is **not** a source code change
