### PR TITLE
🚀 add prod env to deploy job

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -77,6 +77,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && github.repository == 'duck-dynasty/duckbot'
     concurrency: deploy
+    environment: prod
     steps:
     - uses: actions/checkout@v4
     - name: Build and Push Docker Image


### PR DESCRIPTION
##### Summary

For some reason, doing lots of deployments back to back causes the ec2 instance to fall out of sync with the ecs service that is using the instance as a deployment target. The instance is there and running, but ecs loses track of it and just stalls forever. I had to manually replace the ec2 instance twice now, then ecs is fine. It seems to happen when using the merge queue for these dependabot updates.

I created the prod GitHub environment and slapped on a 15min wait timer. That means this actions job will wait for 15 minutes before starting, which hopefully should give everything in aws to settle before deploying again.

##### Checklist

- [ ] this is a source code change
  - [ ] run `format` in the repository root
  - [ ] run `pytest` in the repository root
  - [ ] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [ ] update the wiki documentation if necessary
- [x] or, this is **not** a source code change
