### PR TITLE
formula one  --- "SANDIEGO" reaction

### DIFF
--- a/duckbot/cogs/formula_one/phrases.py
+++ b/duckbot/cogs/formula_one/phrases.py
@@ -54,5 +54,14 @@ def phrases(supermax):
             regional_indicator("d"),
         ],
         # San Diego
-        [regional_indicator("s"), regional_indicator("a"), regional_indicator("n"), regional_indicator("d"), regional_indicator("i"), regional_indicator("e"), regional_indicator("g"), regional_indicator("o")],
+        [
+            regional_indicator("s"),
+            regional_indicator("a"),
+            regional_indicator("n"),
+            regional_indicator("d"),
+            regional_indicator("i"),
+            regional_indicator("e"),
+            regional_indicator("g"),
+            regional_indicator("o"),
+        ],
     ]

--- a/duckbot/cogs/formula_one/phrases.py
+++ b/duckbot/cogs/formula_one/phrases.py
@@ -53,4 +53,6 @@ def phrases(supermax):
             regional_indicator("e"),
             regional_indicator("d"),
         ],
+        # San Diego
+        [regional_indicator("s"), regional_indicator("a"), regional_indicator("n"), regional_indicator("d"), regional_indicator("i"), regional_indicator("e"), regional_indicator("g"), regional_indicator("o")],
     ]


### PR DESCRIPTION
##### Summary

Add "S" "A" "N" "D" "I" "E" "G" "O" reaction --- regional indicators were used, but I suppose a `red_a` could be used for more pop. 

[Why? Idk really, but apparently it means Pole to Lewis?](https://www.youtube.com/shorts/uYEgO4-V_Bw)


##### Checklist

- [x] this is a source code change
  - [x] run `format` in the repository root
  - [x] run `pytest` in the repository root
  - [ ] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [ ] update the wiki documentation if necessary
- [ ] or, this is **not** a source code change
