### PR TITLE
✨ randomize insights timer on boot

### DIFF
--- a/duckbot/cogs/insights/insights.py
+++ b/duckbot/cogs/insights/insights.py
@@ -16,7 +16,7 @@ class Insights(commands.Cog):
     def cog_unload(self):
         self.check_should_respond_loop.cancel()
 
-    @tasks.loop(minutes=139.0)
+    @tasks.loop(minutes=random.choice([101, 113, 131, 139, 151]))
     async def check_should_respond_loop(self):
         await self.check_should_respond()
 


### PR DESCRIPTION
##### Summary

With duckbot rebooting daily, the timer for replying to insightful messages is more predictable. This changes the loop to pick a random interval instead of only 139 minutes. It's set only on startup once, but it's still less predictable this way.

##### Checklist

- [x] this is a source code change
  - [x] run `format` in the repository root
  - [x] run `pytest` in the repository root
  - [ ] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [ ] update the wiki documentation if necessary
- [ ] or, this is **not** a source code change
