### PR TITLE
:alien: address backward incompatible `setuptools` changes

### DIFF
--- a/.github/actions/setup-python-venv/action.yml
+++ b/.github/actions/setup-python-venv/action.yml
@@ -44,4 +44,4 @@ runs:
       python -m venv --clear ${{ steps.path.outputs.path }}
       . ${{ steps.path.outputs.path }}/bin/activate
       pip install --upgrade pip setuptools wheel
-      SETUPTOOLS_ENABLE_FEATURES="legacy-editable" pip install --editable .[${{ inputs.extras }}]
+      pip install --editable .[${{ inputs.extras }}]

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Before running DuckBot, you want to create a virtualenv to develop in. DuckBot r
 python3.10 -m venv --clear --prompt duckbot venv
 . venv/bin/activate
 pip install --upgrade pip setuptools wheel
-SETUPTOOLS_ENABLE_FEATURES="legacy-editable" pip install --editable .[dev]
+pip install --editable .[dev]
 ```
 
 The `dev` extras will also install development dependencies, like `pytest`. The installation commands should be run whenever you merge from upstream.
@@ -82,7 +82,7 @@ If your work doesn't need a full setup, you can just run `python -m duckbot` for
 Deployment scripts are written using [CDK](https://docs.aws.amazon.com/cdk/latest/guide/home.html), the AWS Cloud Development Kit. The CDK dependencies can be installed alongside DuckBot.
 
 ```sh
-SETUPTOOLS_ENABLE_FEATURES="legacy-editable" pip install --editable .[dev,cdk]  # run from repository root
+pip install --editable .[dev,cdk]  # run from repository root
 ```
 
 You'll then actually need CDK. It's a nodejs package, so you'll need that as well.

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,7 @@
+import subprocess
+
+
+def format():
+    for tool in ["isort .", "black .", "mdformat .", "flake8 duckbot tests *.py", "mdformat --check duckbot tests wiki *.md"]:
+        print(f"running `{tool}`")
+        subprocess.run(tool, shell=True)

--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,8 @@
 import os
-import subprocess
 
 from setuptools import find_packages, setup
-from setuptools.command.develop import develop
+from setuptools.command.editable_wheel import editable_wheel
 from setuptools.command.install import install
-
-
-def run_code_formatters():
-    for tool in ["isort .", "black .", "mdformat .", "flake8 duckbot tests *.py", "mdformat --check duckbot tests wiki *.md"]:
-        print(f"running `{tool}`")
-        subprocess.run(tool, shell=True)
 
 
 def download_nltk_data():
@@ -25,9 +18,9 @@ def download_nltk_data():
     textblob.download_corpora.main()
 
 
-class PostDevelop(develop):
+class PostDevelop(editable_wheel):
     def run(self):
-        develop.run(self)
+        editable_wheel.run(self)
         self.execute(download_nltk_data, [], msg="Download NLTK Data")
 
 
@@ -44,7 +37,7 @@ if __name__ == "__main__":
         url="https://github.com/duck-dynasty/duckbot",
         python_requires=">=3.10",
         packages=find_packages(),
-        cmdclass={"develop": PostDevelop, "install": PostInstall},
+        cmdclass={"editable_wheel": PostDevelop, "install": PostInstall},
         install_requires=[
             "discord.py[voice]==2.5.0",
             "beautifulsoup4==4.13.3",
@@ -100,7 +93,7 @@ if __name__ == "__main__":
         },
         entry_points={
             "console_scripts": [
-                f"format = setup:{run_code_formatters.__name__} [dev]",
+                "format = scripts:format [dev]",
             ]
         },
     )


### PR DESCRIPTION
##### Summary

Fixing issues like this one: https://github.com/duck-dynasty/duckbot/actions/runs/14770581040/job/41469833019?pr=1100#step:4:535

Two things here,
* `develop` is no longer a valid command, it's been replaced by `editable_wheel`
  * we rely on this to install nltk data. `install` still works, but we want editable installs for local work
  * though, this means we don't need the legacy param crap any more, so that's nice
* scripts apparently need to be in a python module now, importing directly from `setup` doesn't work

##### Checklist

- [x] this is a source code change
  - [x] run `format` in the repository root
  - [x] run `pytest` in the repository root
  - [ ] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [ ] update the wiki documentation if necessary
- [ ] or, this is **not** a source code change
