### PR TITLE
🚨 fix some test warnings

### DIFF
--- a/tests/fixtures/discord/bot.py
+++ b/tests/fixtures/discord/bot.py
@@ -24,9 +24,13 @@ async def bot(autospec, monkeypatch) -> DuckBot:
     """Returns a mock DuckBot instance. The default event loops are replaced by mocks."""
     b = autospec.of(DuckBot)
     b.command_prefix = "!"
+
+    # stub the bot being started already
+    b.wait_until_ready = mock.Mock(spec=b.wait_until_ready)
+
     b.loop = mock.Mock(spec=asyncio.get_event_loop())
     # mock out loop, it uses `asyncio.get_event_loop()` by default
     monkeypatch.setattr(discord.ext.tasks, "Loop", mock.Mock(spec=discord.ext.tasks.Loop))
     monkeypatch.setattr(discord.ext.tasks, "loop", mock.Mock(spec=discord.ext.tasks.loop))
-    b.wait_until_ready = mock.AsyncMock(spec=discord.Client.wait_until_ready(b))
+
     return b


### PR DESCRIPTION
##### Summary

Trying to fix warnings like,

```
Task exception was never retrieved
future: <Task finished name='discord-ext-tasks: Insights.check_should_respond_loop' coro=<Loop._loop() done, defined at /home/lemon/git/duckbot/venv/lib/python3.10/site-packages/discord/ext/tasks/__init__.py:207> exception=RuntimeError('Client has not been properly initialised. Please use the login method or asynchronous context manager before calling this method')>
Traceback (most recent call last):
  File "/home/lemon/git/duckbot/venv/lib/python3.10/site-packages/discord/ext/tasks/__init__.py", line 209, in _loop
    await self._call_loop_function('before_loop')
  File "/home/lemon/git/duckbot/venv/lib/python3.10/site-packages/discord/ext/tasks/__init__.py", line 193, in _call_loop_function
    await coro(self._injected, *args, **kwargs)
  File "/home/lemon/git/duckbot/duckbot/cogs/insights/insights.py", line 43, in before_loop
    await self.bot.wait_until_ready()
  File "/home/lemon/git/duckbot/venv/lib/python3.10/site-packages/discord/client.py", line 1203, in wait_until_ready
    raise RuntimeError(
RuntimeError: Client has not been properly initialised. Please use the login method or asynchronous context manager before calling this method
```

They arise from `bot.wait_until_ready`. I got rid of a lot of the warnings, but the rest stick around no matter what I do. I stubbed the function out completely and they still crop up. /shrug

##### Checklist

- [x] this is a source code change
  - [x] run `format` in the repository root
  - [x] run `pytest` in the repository root
  - [ ] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [ ] update the wiki documentation if necessary
- [ ] or, this is **not** a source code change
