### PR TITLE
🐛 address pygithub deprecations

### DIFF
--- a/duckbot/cogs/github/yolo_merge.py
+++ b/duckbot/cogs/github/yolo_merge.py
@@ -53,7 +53,7 @@ class YoloMerge(commands.Cog):
     async def list(self, context: commands.Context, repo: Repository):
         pulls = repo.get_pulls()
         if pulls.totalCount > 0:
-            prs = list(repo.get_pulls()[:6])
+            prs = list(pulls[:6])
             embed = self.as_embed(prs)
             await context.send(embed=embed)
         else:

--- a/duckbot/cogs/github/yolo_merge.py
+++ b/duckbot/cogs/github/yolo_merge.py
@@ -4,6 +4,7 @@ from typing import Dict, List, Optional
 
 import discord
 import github
+import github.Auth
 from discord.ext import commands
 from discord.utils import utcnow
 from github.PullRequest import PullRequest
@@ -33,7 +34,7 @@ class YoloMerge(commands.Cog):
     @property
     def github(self) -> github.Github:
         if self._github is None:
-            self._github = github.Github(os.getenv("BOT_GITHUB_TOKEN"))
+            self._github = github.Github(auth=github.Auth.Token(os.getenv("BOT_GITHUB_TOKEN")))
         return self._github
 
     @commands.command(name="yolo")
@@ -50,9 +51,10 @@ class YoloMerge(commands.Cog):
             await self.merge(context, repo, pr_id)
 
     async def list(self, context: commands.Context, repo: Repository):
-        pulls = list(repo.get_pulls()[:6])
-        if pulls:
-            embed = self.as_embed(pulls)
+        pulls = repo.get_pulls()
+        if pulls.totalCount > 0:
+            prs = list(repo.get_pulls()[:6])
+            embed = self.as_embed(prs)
             await context.send(embed=embed)
         else:
             await context.send("There's no open pull requests, brother. Never forget to wumbo.")

--- a/tests/cogs/github/yolo_merge_test.py
+++ b/tests/cogs/github/yolo_merge_test.py
@@ -203,5 +203,5 @@ class MockPaginatedList(list):
         return copy
 
     @property
-    def totalCount(self):
+    def totalCount(self):  # noqa: N802
         return len(self)

--- a/tests/cogs/github/yolo_merge_test.py
+++ b/tests/cogs/github/yolo_merge_test.py
@@ -46,7 +46,7 @@ def test_github_returns_cached_instance(yolo, gh):
 
 async def test_yolo_list_no_pulls(yolo, context, gh, repo, skip_if_private_channel):
     gh.get_repo.return_value = repo
-    repo.get_pulls.return_value = []
+    repo.get_pulls.return_value = MockPaginatedList([])
     await yolo.yolo(context, None)
     context.send.assert_called_once_with("There's no open pull requests, brother. Never forget to wumbo.")
 
@@ -54,7 +54,7 @@ async def test_yolo_list_no_pulls(yolo, context, gh, repo, skip_if_private_chann
 async def test_yolo_list_send_pull_status(yolo, context, gh, repo, skip_if_private_channel):
     gh.get_repo.return_value = repo
     pull, embed_value = make_pull_request(1)
-    repo.get_pulls.return_value = [pull]
+    repo.get_pulls.return_value = MockPaginatedList([pull])
     await yolo.yolo(context, None)
     context.send.assert_called_once_with(embed=discord.Embed().add_field(name="#1", value=embed_value))
 
@@ -63,7 +63,7 @@ async def test_yolo_list_max_six_pulls(yolo, context, gh, repo, skip_if_private_
     gh.get_repo.return_value = repo
     all_pulls = [make_pull_request(i, i % 2 == 0) for i in range(15)]
     kept_pulls = all_pulls[:6]
-    repo.get_pulls.return_value = [p[0] for p in all_pulls]
+    repo.get_pulls.return_value = MockPaginatedList([p[0] for p in all_pulls])
     await yolo.yolo(context, None)
     embed = discord.Embed()
     for pull, embed_value in kept_pulls:
@@ -201,3 +201,7 @@ class MockPaginatedList(list):
         copy = [x for x in self]
         copy.reverse()
         return copy
+    
+    @property
+    def totalCount(self):
+        return len(self)

--- a/tests/cogs/github/yolo_merge_test.py
+++ b/tests/cogs/github/yolo_merge_test.py
@@ -201,7 +201,7 @@ class MockPaginatedList(list):
         copy = [x for x in self]
         copy.reverse()
         return copy
-    
+
     @property
     def totalCount(self):
         return len(self)


### PR DESCRIPTION
##### Summary

Warnings are:
```
DeprecationWarning: Argument login_or_token is deprecated, please use auth=github.Auth.Token(...) instead
```
and
```
  File "/home/lemon/git/duckbot/duckbot/cogs/github/yolo_merge.py", line 54, in list
    pulls = list(repo.get_pulls()[:6])
  File "/home/lemon/git/duckbot/venv/lib/python3.10/site-packages/github/PaginatedList.py", line 110, in __iter__
    yield self.__list[index]
  File "/home/lemon/git/duckbot/venv/lib/python3.10/site-packages/github/PaginatedList.py", line 77, in __getitem__
    return self.__elements[index]
IndexError: list index out of range
```


##### Checklist

- [x] this is a source code change
  - [x] run `format` in the repository root
  - [x] run `pytest` in the repository root
  - [ ] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [ ] update the wiki documentation if necessary
- [ ] or, this is **not** a source code change
