### PR TITLE
remove caching in docker build

### DIFF
--- a/.github/actions/build-push-docker-image/action.yml
+++ b/.github/actions/build-push-docker-image/action.yml
@@ -29,13 +29,6 @@ runs:
   - name: Set up Docker Buildx
     uses: docker/setup-buildx-action@v2
 
-  - name: Set up Docker Build Cache
-    uses: actions/cache@v3
-    with:
-      path: /tmp/.buildx-cache
-      key: ${{ runner.os }}-buildx-${{ github.sha }}
-      restore-keys: ${{ runner.os }}-buildx-
-
   - name: Login to Docker
     uses: docker/login-action@v2
     with:
@@ -49,6 +42,4 @@ runs:
         --tag ${{ steps.image.outputs.latest }} \
         --tag ${{ steps.image.outputs.commit }} \
         --platform=linux/amd64 \
-        --cache-from='type=local,src=/tmp/.buildx-cache' \
-        --cache-to='type=local,dest=/tmp/.buildx-cache' \
         --push


### PR DESCRIPTION
##### Summary

[deploy](https://github.com/duck-dynasty/duckbot/actions/runs/17361657435/job/49328404924) has been failing for a weird reeason. What's odd is that [sanity](https://github.com/duck-dynasty/duckbot/actions/runs/17361657435/job/49328193535) also builds the docker image and that has been fine. The main difference between the builds does seem to be cache, so trying to disable that here.

##### Checklist

- [ ] this is a source code change
  - [ ] run `format` in the repository root
  - [ ] run `pytest` in the repository root
  - [ ] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [ ] update the wiki documentation if necessary
- [x] or, this is **not** a source code change
