### PR TITLE
use `libopenblas` instead of `libatlas`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ FROM python:3.10-slim as prod
 RUN apt-get update && apt-get -y install \
     ffmpeg \
     libpq-dev \
-    libatlas-base-dev \
+    libopenblas-dev \
     fortune-mod fortunes cowsay \
   && apt-get clean && rm -rf /var/lib/apt/lists/*
 ENV PATH "$PATH:/usr/games"


### PR DESCRIPTION
##### Summary

Found [this issue](https://github.com/numpy/numpy/issues/29108) from numpy that indicates we were referencing an outdated package. YOLO.

Related #1140 

##### Checklist

- [ ] this is a source code change
  - [ ] run `format` in the repository root
  - [ ] run `pytest` in the repository root
  - [ ] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [ ] update the wiki documentation if necessary
- [x] or, this is **not** a source code change
