### PR TITLE
make `sanity` build image instead of pulling it

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -40,7 +40,7 @@ jobs:
     - uses: actions/checkout@v4
     - name: Test Connection to Discord
       run: |
-        docker compose run --rm \
+        docker compose run --build --rm \
           -e 'DUCKBOT_ARGS=connection-test' \
           -e "DISCORD_TOKEN=$(cat .github/workflows/test-token.txt | base64 --decode)" \
           duckbot


### PR DESCRIPTION
##### Summary

Related #1140 #1141

Looks like this was pulling the existing image from dockerhub instead of building locally ><

##### Checklist

- [ ] this is a source code change
  - [ ] run `format` in the repository root
  - [ ] run `pytest` in the repository root
  - [ ] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [ ] update the wiki documentation if necessary
- [x] or, this is **not** a source code change
