### PR TITLE
reduce edif diff message lifetime to 2min from 5min

### DIFF
--- a/duckbot/cogs/messages/edit_diff.py
+++ b/duckbot/cogs/messages/edit_diff.py
@@ -23,7 +23,7 @@ class EditDiff(commands.Cog):
                 msg += d[2:]  # append the letter
                 prev = change
         msg += self.try_leave_diff_chunk(" ", prev)  # close the final diff chunk if necessary
-        await after.channel.send(f":eyes: {after.author.mention}.\n{msg}", delete_after=300)
+        await after.channel.send(f":eyes: {after.author.mention}.\n{msg}", delete_after=120)
 
     def split_words(self, content):
         return re.split(r"(\s+)", content)

--- a/tests/cogs/messages/edit_diff_test.py
+++ b/tests/cogs/messages/edit_diff_test.py
@@ -27,7 +27,7 @@ async def test_show_edit_diff_typical_case(before, after, before_text, after_tex
     after.clean_content = after_text
     clazz = EditDiff(bot)
     await clazz.show_edit_diff(before, after)
-    after.channel.send.assert_called_once_with(f":eyes: {after.author.mention}.\n{diff}", delete_after=300)
+    after.channel.send.assert_called_once_with(f":eyes: {after.author.mention}.\n{diff}", delete_after=120)
 
 
 @mock.patch("discord.Message")


### PR DESCRIPTION
##### Summary

I mean. Title.

##### Checklist

- [x] this is a source code change
  - [ ] run `format` in the repository root
  - [ ] run `pytest` in the repository root
  - [ ] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [ ] update the wiki documentation if necessary
- [ ] or, this is **not** a source code change
