### PR TITLE
:rocket: also set `min_capacity` when scaling duckbot out/in for the day

### DIFF
--- a/.aws/duckdeploy/stack.py
+++ b/.aws/duckdeploy/stack.py
@@ -120,8 +120,8 @@ class DuckBotStack(core.Stack):
             instance_monitoring=autoscaling.Monitoring.BASIC,
             vpc=vpc,
         )
-        asg.scale_on_schedule("Night", schedule=autoscaling.Schedule.cron(hour="23", minute="55"), desired_capacity=0, time_zone="America/Toronto")
-        asg.scale_on_schedule("Day", schedule=autoscaling.Schedule.cron(hour="5", minute="57"), desired_capacity=1, time_zone="America/Toronto")
+        asg.scale_on_schedule("Night", schedule=autoscaling.Schedule.cron(hour="23", minute="55"), desired_capacity=0, min_capacity=0, time_zone="America/Toronto")
+        asg.scale_on_schedule("Day", schedule=autoscaling.Schedule.cron(hour="5", minute="57"), desired_capacity=1, min_capacity=1, time_zone="America/Toronto")
 
         cluster = ecs.Cluster(self, "Cluster", cluster_name="duckbot", vpc=vpc)
         cluster.add_asg_capacity_provider(


### PR DESCRIPTION
##### Summary

Duckbot died today due to the autoscaling group decided it didn't want it around any more.

[docs](https://docs.aws.amazon.com/cdk/api/v1/python/aws_cdk.aws_autoscaling/AutoScalingGroup.html#aws_cdk.aws_autoscaling.AutoScalingGroup.scale_on_schedule) for ref

##### Checklist

- [x] this is a source code change
  - [ ] run `format` in the repository root
  - [ ] run `pytest` in the repository root
  - [ ] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [ ] update the wiki documentation if necessary
- [ ] or, this is **not** a source code change
