### PR TITLE
:bug: pyowm --- Update to 3.4 and fix imports

### DIFF
--- a/duckbot/cogs/weather/weather.py
+++ b/duckbot/cogs/weather/weather.py
@@ -36,9 +36,7 @@ class Weather(commands.Cog):
         return self._owm
 
     def one_call(self, **kwargs):
-        # pyowm doesn't support onecall 3.0: https://github.com/csparpa/pyowm/issues/404
-        json = requests.get(url="https://api.openweathermap.org/data/3.0/onecall", params=kwargs | {"appid": os.getenv("OPENWEATHER_TOKEN")}).json()
-        return OneCall.from_dict(json)
+        return self.weather_manager().one_call(**kwargs)
 
     @commands.hybrid_group(name="weather", invoke_without_command=True)
     async def weather_command(self, context: commands.Context, city: Optional[str] = None, country: Optional[str] = None, index: Optional[int] = None):

--- a/duckbot/cogs/weather/weather.py
+++ b/duckbot/cogs/weather/weather.py
@@ -12,8 +12,8 @@ import requests
 import timezonefinder
 from discord.ext import commands
 from pyowm.utils import config
-from pyowm.weatherapi25.location import Location
-from pyowm.weatherapi25.one_call import OneCall
+from pyowm.weatherapi30.location import Location
+from pyowm.weatherapi30.one_call import OneCall
 
 from duckbot.db import Database
 

--- a/duckbot/cogs/weather/weather.py
+++ b/duckbot/cogs/weather/weather.py
@@ -154,10 +154,10 @@ class Weather(commands.Cog):
             messages.append("I might need to take a break today, it hot.")
         return " ".join(messages)
 
-    def __is_rainy(self, weather) -> str:
+    def __is_rainy(self, weather) -> bool:
         return (weather.status and "rain" in weather.status.lower()) or (weather.detailed_status and "rain" in weather.detailed_status.lower())
 
-    def __is_snowy(self, weather) -> str:
+    def __is_snowy(self, weather) -> bool:
         return (weather.status and "snow" in weather.status.lower()) or (weather.detailed_status and "snow" in weather.detailed_status.lower())
 
     def weather_graph(self, city: Location, weather: OneCall):

--- a/duckbot/cogs/weather/weather.py
+++ b/duckbot/cogs/weather/weather.py
@@ -8,7 +8,6 @@ import discord
 import matplotlib.dates as mdates
 import matplotlib.pyplot as plt
 import pyowm
-import requests
 import timezonefinder
 from discord.ext import commands
 from pyowm.utils import config

--- a/duckbot/cogs/weather/weather.py
+++ b/duckbot/cogs/weather/weather.py
@@ -30,8 +30,12 @@ class Weather(commands.Cog):
     @property
     def owm(self) -> pyowm.OWM:
         if self._owm is None:
+            token = os.getenv("OPENWEATHER_TOKEN")
+            print(f"DEBUG: Loaded token prefix: {'...' + token[-4:] if token else 'None/Empty'}")  # Masks most of it for logs
+            if not token:
+                raise ValueError("OPENWEATHER_TOKEN env var is missing!")
             conf = config.get_default_config_for_subscription_type("free")
-            self._owm = pyowm.OWM(os.getenv("OPENWEATHER_TOKEN"), conf)
+            self._owm = pyowm.OWM(token, conf)
         return self._owm
 
     def one_call(self, **kwargs):

--- a/duckbot/cogs/weather/weather.py
+++ b/duckbot/cogs/weather/weather.py
@@ -35,7 +35,7 @@ class Weather(commands.Cog):
         return self._owm
 
     def one_call(self, **kwargs):
-        return self.weather_manager().one_call(**kwargs)
+        return self.owm.weather_manager().one_call(**kwargs)
 
     @commands.hybrid_group(name="weather", invoke_without_command=True)
     async def weather_command(self, context: commands.Context, city: Optional[str] = None, country: Optional[str] = None, index: Optional[int] = None):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "requests==2.32.5",
     "timezonefinder==8.1.0",
     "holidays==0.83",
-    "pyowm==3.3.0",         # openweather
+    "pyowm==3.5.0",         # openweather
     "psycopg2==2.9.11",
     "SQLAlchemy==2.0.44",
     "d20==1.1.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "requests==2.32.5",
     "timezonefinder==8.1.0",
     "holidays==0.83",
-    "pyowm==3.5.0",         # openweather
+    "pyowm==3.4.0",         # openweather
     "psycopg2==2.9.11",
     "SQLAlchemy==2.0.44",
     "d20==1.1.2",

--- a/tests/cogs/weather/weather_test.py
+++ b/tests/cogs/weather/weather_test.py
@@ -1,9 +1,9 @@
 from unittest import mock
 
 import pytest
-from pyowm.weatherapi25.location import Location
-from pyowm.weatherapi25.one_call import OneCall
-from pyowm.weatherapi25.weather import Weather as pyowmWeather
+from pyowm.weatherapi30.location import Location
+from pyowm.weatherapi30.one_call import OneCall
+from pyowm.weatherapi30.weather import Weather as pyowmWeather
 
 from duckbot.cogs.weather import Weather
 from duckbot.cogs.weather.saved_location import SavedLocation
@@ -16,7 +16,7 @@ def city_id(c):
 
 
 @pytest.fixture
-@mock.patch("pyowm.weatherapi25.weather_manager.WeatherManager")
+@mock.patch("pyowm.weatherapi30.weather_manager.WeatherManager")
 def weather_manager(w):
     return w
 


### PR DESCRIPTION
##### Summary

Related to #1152

1. Update to use pyowm 3.4
2. Update the imports that were `weatherapi25` -> `weatherapi30` (2.5 does not work anymore with update to >=3.4)
3. Fixed some type hints
4. Updated the one_call method to work with the update to pyowm 

##### Checklist

- [x] this is a source code change
  - [x] run `format` in the repository root
  - [x] run `pytest` in the repository root
  - [x] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [ ] update the wiki documentation if necessary
- [ ] or, this is **not** a source code change


I ran locally with docker and was able to get it working with version 3.4. Version 3.5 seems to have caused some breaking changes with the city lookup thing. I did not fully look into this 3.5 issue yet and it seems like there could be an issue in a submodule, but whatever, here is a working version with 3.4. 

I think going from 3.3 -> 3.4 is an improvement as the changes here will make it work with versions >=3.4. If a version 3.5.1 comes out where the city lookup works fine, then great. Until then, we are stuck on 3.4. 