### PR TITLE
🚀 update ec2 ami to address AL2 end of life

### DIFF
--- a/.aws/duckdeploy/stack.py
+++ b/.aws/duckdeploy/stack.py
@@ -87,7 +87,7 @@ class DuckBotStack(core.Stack):
             instance_type=ec2.InstanceType.of(instance_class=ec2.InstanceClass.T3, instance_size=ec2.InstanceSize.MICRO),
             cpu_credits=ec2.CpuCredits.STANDARD,
             key_name="duckbot",  # needs to be created manually
-            machine_image=ec2.MachineImage.generic_linux(ami_map={"us-east-1": "ami-0c90bcaed0062d19b"}),  # custom ECS AMI created manually via https://github.com/aws/amazon-ecs-ami
+            machine_image=ec2.MachineImage.generic_linux(ami_map={"us-east-1": "ami-0cdf40f78318eeff6"}),  # custom ECS AMI created manually via https://github.com/aws/amazon-ecs-ami
             security_group=ec2.SecurityGroup(self, "HostSecurityGroup", vpc=vpc),
             role=iam.Role(self, "HostRole", assumed_by=iam.ServicePrincipal("ec2.amazonaws.com")),
             user_data=ec2.UserData.for_linux(),


### PR DESCRIPTION
##### Summary

**NOTE** I'll merge in the morning. If we deploy when the host is shut down overnight, it just gets stuck and requires some manual intervention.

AL2 is going end of life in June. This new ami uses the recommended AL2023, which says it's supported until 2028 some time. Should be no affect otherwise; we did this same when I was still working at Amazon and it always sent smooth there. The only thing for us is that an 8gb drive might not be enough any more, we'll see.

##### Checklist

- [ ] this is a source code change
  - [ ] run `format` in the repository root
  - [ ] run `pytest` in the repository root
  - [ ] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [ ] update the wiki documentation if necessary
- [x] or, this is **not** a source code change
