### PR TITLE
:bug: allow code scanning actions to run on forked PRs

### DIFF
--- a/.github/workflows/code-analysis.yml
+++ b/.github/workflows/code-analysis.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
     - main
+  pull_request:
+    branches:
+    - main
   pull_request_target:
     branches:
     - main

--- a/.github/workflows/code-analysis.yml
+++ b/.github/workflows/code-analysis.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
     - main
-  pull_request:
+  pull_request_target:
     branches:
     - main
   merge_group:


### PR DESCRIPTION
##### Summary

https://github.com/duck-dynasty/duckbot/pull/1229 pooped out because `SONAR_TOKEN` is not accessible by forked repo actions runs. Changing to `pull_request_target` effectively grants that access.

##### Checklist

- [ ] this is a source code change
  - [ ] run `format` in the repository root
  - [ ] run `pytest` in the repository root
  - [ ] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [ ] update the wiki documentation if necessary
- [x] or, this is **not** a source code change
