### PR TITLE
:rocket: try ack deprecated cdk to avoid synthesize error

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -58,6 +58,8 @@ jobs:
       working-directory: .aws
       run: |
         . ../${{ steps.cdk.outputs.venv-path }}/bin/activate
+        # https://aws.amazon.com/blogs/devops/cdk-v1-end-of-support/ https://github.com/aws/aws-cdk/issues/19836
+        cdk acknowledge 19836
         cdk synth
 
   deploy:


### PR DESCRIPTION
##### Summary

Synth started to fail with
> Cannot read properties of undefined (reading 'endsWith')

not sure why. It seems to finish the synth no problem, but it fails before displaying the "warnings" section. Trying to ack them ahead of time to see if that helps it out.

##### Checklist

- [ ] this is a source code change
  - [ ] run `format` in the repository root
  - [ ] run `pytest` in the repository root
  - [ ] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [ ] update the wiki documentation if necessary
- [x] or, this is **not** a source code change
