### PR TITLE
🚀 bump cdk to v2

### DIFF
--- a/.aws/app.py
+++ b/.aws/app.py
@@ -2,8 +2,8 @@ import json
 import os
 from typing import List
 
+import aws_cdk as cdk
 import boto3
-from aws_cdk import core
 from duckdeploy.secret import Secret
 from duckdeploy.stack import DuckBotStack
 
@@ -32,7 +32,7 @@ def publish_secrets(secrets: List[Secret]):
 
 
 if __name__ == "__main__":
-    app = core.App()
+    app = cdk.App()
 
     write_secrets = app.node.try_get_context("write_secrets")
     if write_secrets and json.loads(write_secrets.lower()):

--- a/.aws/duckdeploy/stack.py
+++ b/.aws/duckdeploy/stack.py
@@ -1,5 +1,6 @@
 from typing import List
 
+import aws_cdk as cdk
 from aws_cdk import aws_autoscaling as autoscaling
 from aws_cdk import aws_ec2 as ec2
 from aws_cdk import aws_ecs as ecs
@@ -7,13 +8,13 @@ from aws_cdk import aws_efs as efs
 from aws_cdk import aws_iam as iam
 from aws_cdk import aws_logs as logs
 from aws_cdk import aws_ssm as ssm
-from aws_cdk import core
+from constructs import Construct
 
 from .secret import Secret
 
 
-class DuckBotStack(core.Stack):
-    def __init__(self, scope: core.Construct, construct_id: str, *, secrets: List[Secret]):
+class DuckBotStack(cdk.Stack):
+    def __init__(self, scope: Construct, construct_id: str, *, secrets: List[Secret]):
         super().__init__(scope, construct_id)
 
         vpc = ec2.Vpc(
@@ -27,7 +28,7 @@ class DuckBotStack(core.Stack):
         )
 
         postgres_volume_name = "duckbot_dbdata"
-        file_system = efs.FileSystem(self, "PostgresFileSystem", vpc=vpc, encrypted=True, file_system_name=postgres_volume_name, removal_policy=core.RemovalPolicy.DESTROY)
+        file_system = efs.FileSystem(self, "PostgresFileSystem", vpc=vpc, encrypted=True, file_system_name=postgres_volume_name, removal_policy=cdk.RemovalPolicy.DESTROY)
         file_system.node.default_child.override_logical_id("FileSystem")  # rename for compatibility with legacy cloudformation template
 
         task_definition = ecs.TaskDefinition(self, "TaskDefinition", compatibility=ecs.Compatibility.EC2, family="duckbot", network_mode=ecs.NetworkMode.BRIDGE)
@@ -45,10 +46,10 @@ class DuckBotStack(core.Stack):
             },
             health_check=ecs.HealthCheck(
                 command=["CMD", "pg_isready", "-U", "duckbot"],
-                interval=core.Duration.seconds(30),
-                timeout=core.Duration.seconds(5),
+                interval=cdk.Duration.seconds(30),
+                timeout=cdk.Duration.seconds(5),
                 retries=3,
-                start_period=core.Duration.seconds(30),
+                start_period=cdk.Duration.seconds(30),
             ),
             logging=ecs.LogDriver.aws_logs(stream_prefix="ecs", log_retention=logs.RetentionDays.ONE_MONTH),
             memory_reservation_mib=64,
@@ -56,11 +57,7 @@ class DuckBotStack(core.Stack):
         task_definition.add_volume(name=postgres_volume_name, efs_volume_configuration=ecs.EfsVolumeConfiguration(file_system_id=file_system.file_system_id, root_directory="/"))
         postgres.add_mount_points(ecs.MountPoint(source_volume=postgres_volume_name, container_path=postgres_data_path, read_only=False))
 
-        secrets_as_parameters = {
-            # note, parameter version is required by cdk, but does not make it into the template; specify version 1 for simplicity
-            x.environment_name: ssm.StringParameter.from_secure_string_parameter_attributes(self, x.environment_name, parameter_name=x.parameter_name, version=1)
-            for x in secrets
-        }
+        secrets_as_parameters = {x.environment_name: ssm.StringParameter.from_secure_string_parameter_attributes(self, x.environment_name, parameter_name=x.parameter_name) for x in secrets}
         duckbot = task_definition.add_container(
             "duckbot",
             container_name="duckbot",
@@ -70,10 +67,10 @@ class DuckBotStack(core.Stack):
             secrets={k: ecs.Secret.from_ssm_parameter(v) for k, v in secrets_as_parameters.items()},
             health_check=ecs.HealthCheck(
                 command=["CMD", "python", "-m", "duckbot.health"],
-                interval=core.Duration.seconds(30),
-                timeout=core.Duration.seconds(10),
+                interval=cdk.Duration.seconds(30),
+                timeout=cdk.Duration.seconds(10),
                 retries=3,
-                start_period=core.Duration.seconds(30),
+                start_period=cdk.Duration.seconds(30),
             ),
             logging=ecs.LogDriver.aws_logs(stream_prefix="ecs", log_retention=logs.RetentionDays.ONE_MONTH),
             memory_reservation_mib=320,
@@ -86,7 +83,7 @@ class DuckBotStack(core.Stack):
             block_devices=[ec2.BlockDevice(device_name="/dev/xvda", volume=ec2.BlockDeviceVolume.ebs(volume_size=8, volume_type=ec2.EbsDeviceVolumeType.GP3))],
             instance_type=ec2.InstanceType.of(instance_class=ec2.InstanceClass.T3, instance_size=ec2.InstanceSize.MICRO),
             cpu_credits=ec2.CpuCredits.STANDARD,
-            key_name="duckbot",  # needs to be created manually
+            key_pair=ec2.KeyPair.from_key_pair_name(self, "KeyPair", "duckbot"),  # needs to be created manually
             machine_image=ec2.MachineImage.generic_linux(ami_map={"us-east-1": "ami-0cdf40f78318eeff6"}),  # custom ECS AMI created manually via https://github.com/aws/amazon-ecs-ami
             security_group=ec2.SecurityGroup(self, "HostSecurityGroup", vpc=vpc),
             role=iam.Role(self, "HostRole", assumed_by=iam.ServicePrincipal("ec2.amazonaws.com")),
@@ -129,11 +126,12 @@ class DuckBotStack(core.Stack):
                 cluster,
                 "AsgCapacityProvider",
                 auto_scaling_group=asg,
+                enable_managed_draining=False,
                 enable_managed_termination_protection=False,
             ),
-            can_containers_access_instance_role=True,
-            task_drain_time=core.Duration.seconds(0),
         )
+        asg.node.try_remove_child("DrainECSHook")  # suppress automatic drain hook, added by cdk v2
+        asg.node.try_remove_child("LifecycleHookDrainHook")
 
         ecs.Ec2Service(
             self,

--- a/.aws/duckdeploy/stack.py
+++ b/.aws/duckdeploy/stack.py
@@ -126,7 +126,6 @@ class DuckBotStack(cdk.Stack):
                 cluster,
                 "AsgCapacityProvider",
                 auto_scaling_group=asg,
-                enable_managed_draining=False,
                 enable_managed_termination_protection=False,
             ),
         )

--- a/.github/actions/setup-aws-cdk/action.yml
+++ b/.github/actions/setup-aws-cdk/action.yml
@@ -27,5 +27,5 @@ runs:
     shell: bash
     run: |
       . ${{ steps.venv.outputs.path }}/bin/activate
-      npm install -g aws-cdk@$(python -c 'from importlib.metadata import version; print(version("aws-cdk.core"))')
+      npm install -g aws-cdk
       cdk --version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,14 +57,8 @@ dev = [
 ]
 
 cdk = [
-    "aws-cdk.core==1.204.0",
-    "aws-cdk.aws-ec2==1.204.0",
-    "aws-cdk.aws-ecs==1.204.0",
-    "aws-cdk.aws-autoscaling==1.204.0",
-    "aws-cdk.aws-efs==1.204.0",
-    "aws-cdk.aws-iam==1.204.0",
-    "aws-cdk.aws-logs==1.204.0",
-    "aws-cdk.aws-ssm==1.204.0",
+    "aws-cdk-lib==2.239.0",
+    "constructs==10.5.1",
     "boto3==1.42.54",
 ]
 


### PR DESCRIPTION
##### Summary

cdk v1 has been deprecated for a long time. Yolo v2.

`cdk diff` locally produces:

```
(duckbot) lemon@lemonware:~/git/duckbot/.aws$ cdk diff
[Warning at /duckbot/HostSecurityGroup] Ignoring Egress rule since 'allowAllOutbound' is set to true; To add customized rules, set allowAllOutbound=false on the SecurityGroup [ack: @aws-cdk/aws-ec2:ipv4IgnoreEgressRule]
[Warning at /duckbot/AutoScalingGroup] desiredCapacity has been configured. Be aware this will reset the size of your AutoScalingGroup on every deployment. See https://github.com/aws/aws-cdk/issues/5215 [ack: @aws-cdk/aws-autoscaling:desiredCapacitySet]
current credentials could not be used to assume 'arn:aws:iam::085851038469:role/cdk-hnb659fds-lookup-role-085851038469-us-east-1', but are for the right account. Proceeding anyway.
Lookup role arn:aws:iam::085851038469:role/cdk-hnb659fds-lookup-role-085851038469-us-east-1 was not assumed. Proceeding with default credentials.
Lookup role arn:aws:iam::085851038469:role/cdk-hnb659fds-lookup-role-085851038469-us-east-1 was not assumed. Proceeding with default credentials.
current credentials could not be used to assume 'arn:aws:iam::085851038469:role/cdk-hnb659fds-deploy-role-085851038469-us-east-1', but are for the right account. Proceeding anyway.
Could not create a change set, will base the diff on template differences (run again with -v to see the reason)

Stack duckbot
IAM Statement Changes
┌───┬─────────────────┬────────┬────────────────┬───────────────────────────────┬───────────┐
│   │ Resource        │ Effect │ Action         │ Principal                     │ Condition │
├───┼─────────────────┼────────┼────────────────┼───────────────────────────────┼───────────┤
│ - │ ${HostRole.Arn} │ Allow  │ sts:AssumeRole │ Service:ec2.${AWS::URLSuffix} │           │
├───┼─────────────────┼────────┼────────────────┼───────────────────────────────┼───────────┤
│ + │ ${HostRole.Arn} │ Allow  │ sts:AssumeRole │ Service:ec2.amazonaws.com     │           │
└───┴─────────────────┴────────┴────────────────┴───────────────────────────────┴───────────┘
(NOTE: There may be security-related changes not in this list. See https://github.com/aws/aws-cdk/issues/1299)

Parameters
[+] Parameter BootstrapVersion BootstrapVersion: {"Type":"AWS::SSM::Parameter::Value<String>","Default":"/cdk-bootstrap/hnb659fds/version","Description":"Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]"}

Conditions
[~] Condition CDKMetadata/Condition CDKMetadataAvailable: {"Fn::Or":[{"Fn::Or":[{"Fn::Equals":[{"Ref":"AWS::Region"},"af-south-1"]},{"Fn::Equals":[{"Ref":"AWS::Region"},"ap-east-1"]},{"Fn::Equals":[{"Ref":"AWS::Region"},"ap-northeast-1"]},{"Fn::Equals":[{"Ref":"AWS::Region"},"ap-northeast-2"]},{"Fn::Equals":[{"Ref":"AWS::Region"},"ap-south-1"]},{"Fn::Equals":[{"Ref":"AWS::Region"},"ap-southeast-1"]},{"Fn::Equals":[{"Ref":"AWS::Region"},"ap-southeast-2"]},{"Fn::Equals":[{"Ref":"AWS::Region"},"ca-central-1"]},{"Fn::Equals":[{"Ref":"AWS::Region"},"cn-north-1"]},{"Fn::Equals":[{"Ref":"AWS::Region"},"cn-northwest-1"]}]},{"Fn::Or":[{"Fn::Equals":[{"Ref":"AWS::Region"},"eu-central-1"]},{"Fn::Equals":[{"Ref":"AWS::Region"},"eu-north-1"]},{"Fn::Equals":[{"Ref":"AWS::Region"},"eu-south-1"]},{"Fn::Equals":[{"Ref":"AWS::Region"},"eu-west-1"]},{"Fn::Equals":[{"Ref":"AWS::Region"},"eu-west-2"]},{"Fn::Equals":[{"Ref":"AWS::Region"},"eu-west-3"]},{"Fn::Equals":[{"Ref":"AWS::Region"},"me-south-1"]},{"Fn::Equals":[{"Ref":"AWS::Region"},"sa-east-1"]},{"Fn::Equals":[{"Ref":"AWS::Region"},"us-east-1"]},{"Fn::Equals":[{"Ref":"AWS::Region"},"us-east-2"]}]},{"Fn::Or":[{"Fn::Equals":[{"Ref":"AWS::Region"},"us-west-1"]},{"Fn::Equals":[{"Ref":"AWS::Region"},"us-west-2"]}]}]} to {"Fn::Or":[{"Fn::Or":[{"Fn::Equals":[{"Ref":"AWS::Region"},"af-south-1"]},{"Fn::Equals":[{"Ref":"AWS::Region"},"ap-east-1"]},{"Fn::Equals":[{"Ref":"AWS::Region"},"ap-northeast-1"]},{"Fn::Equals":[{"Ref":"AWS::Region"},"ap-northeast-2"]},{"Fn::Equals":[{"Ref":"AWS::Region"},"ap-northeast-3"]},{"Fn::Equals":[{"Ref":"AWS::Region"},"ap-south-1"]},{"Fn::Equals":[{"Ref":"AWS::Region"},"ap-south-2"]},{"Fn::Equals":[{"Ref":"AWS::Region"},"ap-southeast-1"]},{"Fn::Equals":[{"Ref":"AWS::Region"},"ap-southeast-2"]},{"Fn::Equals":[{"Ref":"AWS::Region"},"ap-southeast-3"]}]},{"Fn::Or":[{"Fn::Equals":[{"Ref":"AWS::Region"},"ap-southeast-4"]},{"Fn::Equals":[{"Ref":"AWS::Region"},"ca-central-1"]},{"Fn::Equals":[{"Ref":"AWS::Region"},"ca-west-1"]},{"Fn::Equals":[{"Ref":"AWS::Region"},"cn-north-1"]},{"Fn::Equals":[{"Ref":"AWS::Region"},"cn-northwest-1"]},{"Fn::Equals":[{"Ref":"AWS::Region"},"eu-central-1"]},{"Fn::Equals":[{"Ref":"AWS::Region"},"eu-central-2"]},{"Fn::Equals":[{"Ref":"AWS::Region"},"eu-north-1"]},{"Fn::Equals":[{"Ref":"AWS::Region"},"eu-south-1"]},{"Fn::Equals":[{"Ref":"AWS::Region"},"eu-south-2"]}]},{"Fn::Or":[{"Fn::Equals":[{"Ref":"AWS::Region"},"eu-west-1"]},{"Fn::Equals":[{"Ref":"AWS::Region"},"eu-west-2"]},{"Fn::Equals":[{"Ref":"AWS::Region"},"eu-west-3"]},{"Fn::Equals":[{"Ref":"AWS::Region"},"il-central-1"]},{"Fn::Equals":[{"Ref":"AWS::Region"},"me-central-1"]},{"Fn::Equals":[{"Ref":"AWS::Region"},"me-south-1"]},{"Fn::Equals":[{"Ref":"AWS::Region"},"sa-east-1"]},{"Fn::Equals":[{"Ref":"AWS::Region"},"us-east-1"]},{"Fn::Equals":[{"Ref":"AWS::Region"},"us-east-2"]},{"Fn::Equals":[{"Ref":"AWS::Region"},"us-west-1"]}]},{"Fn::Equals":[{"Ref":"AWS::Region"},"us-west-2"]}]}

Resources
[~] AWS::ECS::TaskDefinition TaskDefinition TaskDefinitionB36D86D9 replace
 └─ [~] ContainerDefinitions (requires replacement)
     └─ @@ -70,7 +70,7 @@
        [ ]   "StartPeriod": 30,
        [ ]   "Timeout": 10
        [ ] },
        [-] "Image": "duckdynasty/duckbot:46e72aa",
        [+] "Image": "duckdynasty/duckbot:latest",
        [ ] "Links": [
        [ ]   "postgres"
        [ ] ],
[~] AWS::IAM::Role HostRole HostRole96745B4B
 └─ [~] AssumeRolePolicyDocument
     └─ [~] .Statement:
         └─ @@ -3,17 +3,7 @@
            [ ]     "Action": "sts:AssumeRole",
            [ ]     "Effect": "Allow",
            [ ]     "Principal": {
            [-]       "Service": {
            [-]         "Fn::Join": [
            [-]           "",
            [-]           [
            [-]             "ec2.",
            [-]             {
            [-]               "Ref": "AWS::URLSuffix"
            [-]             }
            [-]           ]
            [-]         ]
            [-]       }
            [+]       "Service": "ec2.amazonaws.com"
            [ ]     }
            [ ]   }
            [ ] ]
[~] AWS::EC2::LaunchTemplate LaunchTemplate LaunchTemplate04EC5460
 ├─ [+] TagSpecifications
 │   └─ [{"ResourceType":"launch-template","Tags":[{"Key":"Name","Value":"duckbot/LaunchTemplate"}]}]
 └─ [+] DependsOn
     └─ ["HostRole96745B4B","HostRoleDefaultPolicy61397894"]
[~] AWS::ECS::Service Service/Service ServiceD69D759B
 ├─ [~] DeploymentConfiguration
 │   └─ [+] Added: .Alarms
 └─ [+] DependsOn
     └─ ["TaskDefinitionTaskRoleFD40A61D"]



✨  Number of stacks with differences: 1
```

`Alarms` there is just an empty list that cdk added.
```yml
  ServiceD69D759B:
    Type: AWS::ECS::Service
    Properties:
      Cluster:
        Ref: ClusterEB0386A7
      DeploymentConfiguration:
        Alarms:
          AlarmNames: []
          Enable: false
          Rollback: false
        MaximumPercent: 100
        MinimumHealthyPercent: 0
```

##### Checklist

- [x] this is a source code change
  - [x] run `format` in the repository root
  - [ ] run `pytest` in the repository root
  - [ ] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [ ] update the wiki documentation if necessary
- [ ] or, this is **not** a source code change
