### PR TITLE
:bug: show user names in `!grass-stats`

### DIFF
--- a/duckbot/cogs/messages/touch_grass.py
+++ b/duckbot/cogs/messages/touch_grass.py
@@ -5,6 +5,8 @@ from discord import Message
 from discord.ext import commands
 from discord.utils import utcnow
 
+from duckbot.util.users import get_user
+
 from .touch_grass_phrases import phrases, work_phrases
 
 # Notification thresholds
@@ -14,10 +16,6 @@ OFF_HOURS_THRESHOLD = 120
 # Tracking and cooldown windows
 TRACKING_WINDOW_HOURS = 1
 COOLDOWN_SECONDS = 3600
-
-# Display formatting
-MAX_DISPLAY_NAME_LENGTH = 22
-LEADERBOARD_SEPARATOR_WIDTH = 34
 
 
 class TouchGrass(commands.Cog):
@@ -103,16 +101,11 @@ class TouchGrass(commands.Cog):
 
         lines = ["**Activity Leaderboard (Last 60 Minutes)**", "```"]
         lines.append(f"{'User':<24} {'Messages':>8}")
-        lines.append("-" * LEADERBOARD_SEPARATOR_WIDTH)
+        lines.append("-" * 34)
 
         for user_id, count in stats:
-            member = context.guild.get_member(user_id) if context.guild else None
-            if member:
-                name = member.display_name[:MAX_DISPLAY_NAME_LENGTH]
-            else:
-                user = self.bot.get_user(user_id)
-                name = user.display_name[:MAX_DISPLAY_NAME_LENGTH] if user else f"User-{user_id}"
-
+            user = await get_user(self.bot, user_id, context.guild)
+            name = user.display_name if user else f"User-{user_id}"
             lines.append(f"{name:<24} {count:>8}")
 
         lines.append("```")

--- a/duckbot/util/users/__init__.py
+++ b/duckbot/util/users/__init__.py
@@ -1,0 +1,1 @@
+from .get_user import get_user

--- a/duckbot/util/users/get_user.py
+++ b/duckbot/util/users/get_user.py
@@ -1,0 +1,14 @@
+from typing import Optional, Union
+
+import discord
+
+
+async def get_user(bot, user_id: int, guild: Optional[discord.Guild] = None) -> Optional[Union[discord.Member, discord.User]]:
+    """Returns the user with the given ID, checking cache first, then fetching via API if needed.
+    Prefers returning a guild Member (which has server-specific display names) if a guild is provided.
+    :param bot: the Discord bot
+    :param user_id: the user ID to look up
+    :param guild: optional guild to check for a member first"""
+    if guild:
+        return guild.get_member(user_id) or await guild.fetch_member(user_id)
+    return bot.get_user(user_id) or await bot.fetch_user(user_id)

--- a/tests/util/users/get_user_test.py
+++ b/tests/util/users/get_user_test.py
@@ -1,0 +1,31 @@
+from duckbot.util.users import get_user
+
+
+async def test_get_user_guild_member_in_cache(bot, guild, member):
+    guild.get_member.return_value = member
+    result = await get_user(bot, 123, guild)
+    assert result is member
+    guild.fetch_member.assert_not_called()
+
+
+async def test_get_user_guild_member_not_in_cache(bot, guild, member):
+    guild.get_member.return_value = None
+    guild.fetch_member.return_value = member
+    result = await get_user(bot, 123, guild)
+    assert result is member
+    guild.fetch_member.assert_called_once_with(123)
+
+
+async def test_get_user_no_guild_user_in_cache(bot, user):
+    bot.get_user.return_value = user
+    result = await get_user(bot, 123)
+    assert result is user
+    bot.fetch_user.assert_not_called()
+
+
+async def test_get_user_no_guild_user_not_in_cache(bot, user):
+    bot.get_user.return_value = None
+    bot.fetch_user.return_value = user
+    result = await get_user(bot, 123)
+    assert result is user
+    bot.fetch_user.assert_called_once_with(123)


### PR DESCRIPTION
##### Summary

fixes #1266 

`!grass-stats` was showing raw user IDs instead of display names because `get_member`/`get_user` only check the local bot cache, returning `None` for uncached users. `fetch_user` or `fetch_member` actually hit discord, skipping the cache.

I also removed the name truncation in the table. Because it'll be funnier.

##### Checklist

- [x] this is a source code change
  - [x] run `format` in the repository root
  - [x] run `pytest` in the repository root
  - [x] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [ ] update the wiki documentation if necessary