### PR TITLE
:art: remove unused `self.bot` fields

### DIFF
--- a/duckbot/cogs/corrections/__init__.py
+++ b/duckbot/cogs/corrections/__init__.py
@@ -6,8 +6,8 @@ from .typos import Typos
 
 
 async def setup(bot):
-    await bot.add_cog(Bitcoin(bot))
+    await bot.add_cog(Bitcoin())
     await bot.add_cog(Kubernetes(bot))
-    await bot.add_cog(Typos(bot))
-    await bot.add_cog(Bezos(bot))
-    await bot.add_cog(Tarlson(bot))
+    await bot.add_cog(Typos())
+    await bot.add_cog(Bezos())
+    await bot.add_cog(Tarlson())

--- a/duckbot/cogs/corrections/bezos.py
+++ b/duckbot/cogs/corrections/bezos.py
@@ -3,9 +3,6 @@ from discord.ext import commands
 
 
 class Bezos(commands.Cog):
-    def __init__(self, bot):
-        self.bot = bot
-
     @commands.Cog.listener("on_message")
     async def correct_bezos(self, message: Message):
         """Corrections for Jeff Bezos. He is no longer the corporate overlord."""

--- a/duckbot/cogs/corrections/bitcoin.py
+++ b/duckbot/cogs/corrections/bitcoin.py
@@ -2,9 +2,6 @@ from discord.ext import commands
 
 
 class Bitcoin(commands.Cog):
-    def __init__(self, bot):
-        self.bot = bot
-
     @commands.Cog.listener("on_message")
     async def correct_bitcoin(self, message):
         """Corrections for bitcoin"""

--- a/duckbot/cogs/corrections/tarlson.py
+++ b/duckbot/cogs/corrections/tarlson.py
@@ -2,9 +2,6 @@ from discord.ext import commands
 
 
 class Tarlson(commands.Cog):
-    def __init__(self, bot):
-        self.bot = bot
-
     @commands.Cog.listener("on_message")
     async def correct_tarlson(self, message):
         """Corrections for tarlson"""

--- a/duckbot/cogs/corrections/typos.py
+++ b/duckbot/cogs/corrections/typos.py
@@ -4,9 +4,6 @@ from textblob import TextBlob
 
 
 class Typos(commands.Cog):
-    def __init__(self, bot):
-        self.bot = bot
-
     @commands.Cog.listener("on_message")
     async def correct_typos(self, message: Message):
         """Try to correct common typos for user's previous message."""

--- a/duckbot/cogs/corrections/typos.py
+++ b/duckbot/cogs/corrections/typos.py
@@ -7,7 +7,7 @@ class Typos(commands.Cog):
     @commands.Cog.listener("on_message")
     async def correct_typos(self, message: Message):
         """Try to correct common typos for user's previous message."""
-        if message.content.strip().lower() == "fuck":
+        if not message.author.bot and message.content.strip().lower() == "fuck":
             prev = await self.get_previous_message(message)
             if prev is not None:
                 c = self.correct(prev.content)

--- a/duckbot/cogs/dogs/__init__.py
+++ b/duckbot/cogs/dogs/__init__.py
@@ -2,4 +2,4 @@ from .dog_photos import DogPhotos
 
 
 async def setup(bot):
-    await bot.add_cog(DogPhotos(bot))
+    await bot.add_cog(DogPhotos())

--- a/duckbot/cogs/dogs/dog_photos.py
+++ b/duckbot/cogs/dogs/dog_photos.py
@@ -5,9 +5,6 @@ from discord.ext import commands
 
 
 class DogPhotos(commands.Cog):
-    def __init__(self, bot):
-        self.bot = bot
-
     @commands.hybrid_command(name="dog", aliases=["doge"], description="Show a random dog you probably don't know")
     async def dog_command(self, context: commands.Context, *, breed: Optional[str] = None):
         """

--- a/duckbot/cogs/fortune/__init__.py
+++ b/duckbot/cogs/fortune/__init__.py
@@ -4,6 +4,6 @@ from .stocks import Stocks
 
 
 async def setup(bot):
-    await bot.add_cog(Fortune(bot))
-    await bot.add_cog(EightBall(bot))
-    await bot.add_cog(Stocks(bot))
+    await bot.add_cog(Fortune())
+    await bot.add_cog(EightBall())
+    await bot.add_cog(Stocks())

--- a/duckbot/cogs/fortune/eightball.py
+++ b/duckbot/cogs/fortune/eightball.py
@@ -8,9 +8,6 @@ from .eightball_phrases import joke_phrases, phrases
 
 
 class EightBall(commands.Cog):
-    def __init__(self, bot):
-        self.bot = bot
-
     @commands.hybrid_command(name="eightball", aliases=["8ball"], description="Ask the magic 8 ball a question!")
     async def eightball_command(self, context: commands.Context, *, question: str = None):
         """

--- a/duckbot/cogs/fortune/fortune.py
+++ b/duckbot/cogs/fortune/fortune.py
@@ -6,9 +6,6 @@ from duckbot.util.messages import MAX_MESSAGE_LENGTH
 
 
 class Fortune(commands.Cog):
-    def __init__(self, bot):
-        self.bot = bot
-
     @commands.command(name="fortune")
     async def fortune(self, context):
         await context.send(self.get_fortune())

--- a/duckbot/cogs/fortune/stocks.py
+++ b/duckbot/cogs/fortune/stocks.py
@@ -6,9 +6,6 @@ from discord.ext import commands
 
 
 class Stocks(commands.Cog):
-    def __init__(self, bot):
-        self.bot = bot
-
     @commands.Cog.listener("on_message")
     async def stock_info(self, message: discord.Message):
         if not message.author.bot:

--- a/duckbot/cogs/games/__init__.py
+++ b/duckbot/cogs/games/__init__.py
@@ -8,9 +8,9 @@ from .satisfy import setup as satisfy_setup
 
 
 async def setup(bot):
-    await bot.add_cog(Dice(bot))
-    await bot.add_cog(AgeOfEmpires(bot))
-    await bot.add_cog(CoinFlip(bot))
+    await bot.add_cog(Dice())
+    await bot.add_cog(AgeOfEmpires())
+    await bot.add_cog(CoinFlip())
     await bot.add_cog(DiscordActivity(bot))
     await bot.add_cog(OfficeHours(bot))
     await bot.add_cog(Pokemon(bot))

--- a/duckbot/cogs/games/aoe.py
+++ b/duckbot/cogs/games/aoe.py
@@ -7,9 +7,6 @@ from .aoe_phrases import taunts
 
 
 class AgeOfEmpires(commands.Cog):
-    def __init__(self, bot):
-        self.bot = bot
-
     @commands.Cog.listener("on_message")
     async def expand_taunt(self, message: discord.Message):
         content = message.content.strip()

--- a/duckbot/cogs/games/coin_flip.py
+++ b/duckbot/cogs/games/coin_flip.py
@@ -4,9 +4,6 @@ from discord.ext import commands
 
 
 class CoinFlip(commands.Cog):
-    def __init__(self, bot):
-        self.bot = bot
-
     @commands.command(name="coin", aliases=["flip", "toss"])
     async def coin_command(self, context):
         await self.coin_flip(context)

--- a/duckbot/cogs/games/dice.py
+++ b/duckbot/cogs/games/dice.py
@@ -5,9 +5,6 @@ from duckbot.util.messages import MAX_MESSAGE_LENGTH
 
 
 class Dice(commands.Cog):
-    def __init__(self, bot):
-        self.bot = bot
-
     @commands.hybrid_command(name="roll", aliases=["r"], description="Roll some Dungeons & Dragons style dice!")
     async def roll_command(self, context: commands.Context, *, expression: str = "1d20"):
         """

--- a/duckbot/cogs/google/__init__.py
+++ b/duckbot/cogs/google/__init__.py
@@ -2,4 +2,4 @@ from .let_me_google_that import LetMeGoogleThat
 
 
 async def setup(bot):
-    await bot.add_cog(LetMeGoogleThat(bot))
+    await bot.add_cog(LetMeGoogleThat())

--- a/duckbot/cogs/google/let_me_google_that.py
+++ b/duckbot/cogs/google/let_me_google_that.py
@@ -7,9 +7,6 @@ from duckbot.util.messages import try_delete
 
 
 class LetMeGoogleThat(commands.Cog):
-    def __init__(self, bot):
-        self.bot = bot
-
     @commands.command(name="lmgt")
     async def let_me_google_that_command(self, context: commands.Context, *, query: str):
         await self.let_me_google_that(context, query)

--- a/duckbot/cogs/messages/__init__.py
+++ b/duckbot/cogs/messages/__init__.py
@@ -6,6 +6,6 @@ from .typing import Typing
 
 async def setup(bot):
     await bot.add_cog(EditDiff())
-    await bot.add_cog(Haiku(bot))
+    await bot.add_cog(Haiku())
     await bot.add_cog(TouchGrass(bot))
     await bot.add_cog(Typing(bot))

--- a/duckbot/cogs/messages/haiku.py
+++ b/duckbot/cogs/messages/haiku.py
@@ -4,8 +4,7 @@ from nltk.corpus import cmudict
 
 
 class Haiku(commands.Cog):
-    def __init__(self, bot):
-        self.bot = bot
+    def __init__(self):
         self.syllables = {}
 
     @commands.Cog.listener("on_ready")

--- a/duckbot/cogs/recipe/__init__.py
+++ b/duckbot/cogs/recipe/__init__.py
@@ -2,4 +2,4 @@ from .recipe import Recipe
 
 
 async def setup(bot):
-    await bot.add_cog(Recipe(bot))
+    await bot.add_cog(Recipe())

--- a/duckbot/cogs/recipe/recipe.py
+++ b/duckbot/cogs/recipe/recipe.py
@@ -7,9 +7,6 @@ from discord.ext import commands
 
 
 class Recipe(commands.Cog):
-    def __init__(self, bot):
-        self.bot = bot
-
     @staticmethod
     def select_recipe(recipe_list):
         """Given a list of recipes, select a random one."""

--- a/duckbot/cogs/robot/__init__.py
+++ b/duckbot/cogs/robot/__init__.py
@@ -2,4 +2,4 @@ from .thanking_robot import ThankingRobot
 
 
 async def setup(bot):
-    await bot.add_cog(ThankingRobot(bot))
+    await bot.add_cog(ThankingRobot())

--- a/duckbot/cogs/robot/thanking_robot.py
+++ b/duckbot/cogs/robot/thanking_robot.py
@@ -4,9 +4,6 @@ from discord.ext import commands
 
 
 class ThankingRobot(commands.Cog):
-    def __init__(self, bot):
-        self.bot = bot
-
     @commands.Cog.listener("on_message")
     async def correct_giving_thanks(self, message):
         """Correcting people who thank the robot."""

--- a/duckbot/cogs/text/__init__.py
+++ b/duckbot/cogs/text/__init__.py
@@ -4,6 +4,6 @@ from .mock_text import MockText
 
 
 async def setup(bot):
-    await bot.add_cog(AsciiArt(bot))
-    await bot.add_cog(MockText(bot))
+    await bot.add_cog(AsciiArt())
+    await bot.add_cog(MockText())
     await bot.add_cog(Dictionary(bot))

--- a/duckbot/cogs/text/ascii_art.py
+++ b/duckbot/cogs/text/ascii_art.py
@@ -5,9 +5,6 @@ from duckbot.util.messages import MAX_MESSAGE_LENGTH
 
 
 class AsciiArt(commands.Cog):
-    def __init__(self, bot):
-        self.bot = bot
-
     @commands.command(name="ascii")
     async def ascii_command(self, context, *, text: str = "I need text, brother."):
         await self.ascii(context, text)

--- a/duckbot/cogs/text/mock_text.py
+++ b/duckbot/cogs/text/mock_text.py
@@ -4,9 +4,6 @@ import duckbot.util.messages
 
 
 class MockText(commands.Cog):
-    def __init__(self, bot):
-        self.bot = bot
-
     @commands.command(name="mock")
     async def mock_text_command(self, context: commands.Context, *, text: str = ""):
         await self.mock_text(context, text)

--- a/tests/cogs/corrections/bezos_test.py
+++ b/tests/cogs/corrections/bezos_test.py
@@ -3,7 +3,7 @@ import pytest
 from duckbot.cogs.corrections import Bezos
 
 
-async def test_correct_bezos_bot_author(bot, bot_message):
+async def test_correct_bezos_bot_author(bot_message):
     bot_message.content = "bezo"
     clazz = Bezos()
     await clazz.correct_bezos(bot_message)
@@ -11,7 +11,7 @@ async def test_correct_bezos_bot_author(bot, bot_message):
 
 
 @pytest.mark.parametrize("text", ["Jeffrey Bezos", "fekin bezo at it again"])
-async def test_correct_bezos_message_contains_bezos(bot, message, text):
+async def test_correct_bezos_message_contains_bezos(message, text):
     message.content = text
     clazz = Bezos()
     await clazz.correct_bezos(message)
@@ -19,7 +19,7 @@ async def test_correct_bezos_message_contains_bezos(bot, message, text):
 
 
 @pytest.mark.parametrize("text", ["andy is the new jeff"])
-async def test_correct_bezos_message_is_not_bezos(bot, message, text):
+async def test_correct_bezos_message_is_not_bezos(message, text):
     message.content = text
     clazz = Bezos()
     await clazz.correct_bezos(message)

--- a/tests/cogs/corrections/bezos_test.py
+++ b/tests/cogs/corrections/bezos_test.py
@@ -5,7 +5,7 @@ from duckbot.cogs.corrections import Bezos
 
 async def test_correct_bezos_bot_author(bot, bot_message):
     bot_message.content = "bezo"
-    clazz = Bezos(bot)
+    clazz = Bezos()
     await clazz.correct_bezos(bot_message)
     bot_message.channel.send.assert_not_called()
 
@@ -13,7 +13,7 @@ async def test_correct_bezos_bot_author(bot, bot_message):
 @pytest.mark.parametrize("text", ["Jeffrey Bezos", "fekin bezo at it again"])
 async def test_correct_bezos_message_contains_bezos(bot, message, text):
     message.content = text
-    clazz = Bezos(bot)
+    clazz = Bezos()
     await clazz.correct_bezos(message)
     message.channel.send.assert_called_once_with("There is no Jeff, only Andy.")
 
@@ -21,6 +21,6 @@ async def test_correct_bezos_message_contains_bezos(bot, message, text):
 @pytest.mark.parametrize("text", ["andy is the new jeff"])
 async def test_correct_bezos_message_is_not_bezos(bot, message, text):
     message.content = text
-    clazz = Bezos(bot)
+    clazz = Bezos()
     await clazz.correct_bezos(message)
     message.channel.send.assert_not_called()

--- a/tests/cogs/corrections/bitcoin_test.py
+++ b/tests/cogs/corrections/bitcoin_test.py
@@ -3,7 +3,7 @@ import pytest
 from duckbot.cogs.corrections import Bitcoin
 
 
-async def test_correct_bitcoin_bot_author(bot, bot_message):
+async def test_correct_bitcoin_bot_author(bot_message):
     bot_message.content = "bitcoin"
     clazz = Bitcoin()
     await clazz.correct_bitcoin(bot_message)
@@ -11,7 +11,7 @@ async def test_correct_bitcoin_bot_author(bot, bot_message):
 
 
 @pytest.mark.parametrize("text", ["bitcoin", "BITCOIN", "BiTcOiN"])
-async def test_correct_bitcoin_message_is_bitcoin(bot, message, text):
+async def test_correct_bitcoin_message_is_bitcoin(message, text):
     message.content = text
     clazz = Bitcoin()
     await clazz.correct_bitcoin(message)
@@ -19,7 +19,7 @@ async def test_correct_bitcoin_message_is_bitcoin(bot, message, text):
 
 
 @pytest.mark.parametrize("text", [" BiTcOiN   broooooooo!!!....:??", "bitcoin, brother"])
-async def test_correct_bitcoin_message_contains_bitcoin(bot, message, text):
+async def test_correct_bitcoin_message_contains_bitcoin(message, text):
     message.content = text
     clazz = Bitcoin()
     await clazz.correct_bitcoin(message)
@@ -27,7 +27,7 @@ async def test_correct_bitcoin_message_contains_bitcoin(bot, message, text):
 
 
 @pytest.mark.parametrize("text", ["bit coin", "dogecoin", "hi"])
-async def test_correct_bitcoin_message_is_not_bitcoin(bot, message, text):
+async def test_correct_bitcoin_message_is_not_bitcoin(message, text):
     message.content = text
     clazz = Bitcoin()
     await clazz.correct_bitcoin(message)

--- a/tests/cogs/corrections/bitcoin_test.py
+++ b/tests/cogs/corrections/bitcoin_test.py
@@ -5,7 +5,7 @@ from duckbot.cogs.corrections import Bitcoin
 
 async def test_correct_bitcoin_bot_author(bot, bot_message):
     bot_message.content = "bitcoin"
-    clazz = Bitcoin(bot)
+    clazz = Bitcoin()
     await clazz.correct_bitcoin(bot_message)
     bot_message.channel.send.assert_not_called()
 
@@ -13,7 +13,7 @@ async def test_correct_bitcoin_bot_author(bot, bot_message):
 @pytest.mark.parametrize("text", ["bitcoin", "BITCOIN", "BiTcOiN"])
 async def test_correct_bitcoin_message_is_bitcoin(bot, message, text):
     message.content = text
-    clazz = Bitcoin(bot)
+    clazz = Bitcoin()
     await clazz.correct_bitcoin(message)
     message.channel.send.assert_called_once_with("Magic Beans*")
 
@@ -21,7 +21,7 @@ async def test_correct_bitcoin_message_is_bitcoin(bot, message, text):
 @pytest.mark.parametrize("text", [" BiTcOiN   broooooooo!!!....:??", "bitcoin, brother"])
 async def test_correct_bitcoin_message_contains_bitcoin(bot, message, text):
     message.content = text
-    clazz = Bitcoin(bot)
+    clazz = Bitcoin()
     await clazz.correct_bitcoin(message)
     message.channel.send.assert_called_once_with("Magic Beans*")
 
@@ -29,6 +29,6 @@ async def test_correct_bitcoin_message_contains_bitcoin(bot, message, text):
 @pytest.mark.parametrize("text", ["bit coin", "dogecoin", "hi"])
 async def test_correct_bitcoin_message_is_not_bitcoin(bot, message, text):
     message.content = text
-    clazz = Bitcoin(bot)
+    clazz = Bitcoin()
     await clazz.correct_bitcoin(message)
     message.channel.send.assert_not_called()

--- a/tests/cogs/corrections/tarleson_test.py
+++ b/tests/cogs/corrections/tarleson_test.py
@@ -3,7 +3,7 @@ import pytest
 from duckbot.cogs.corrections import Tarlson
 
 
-async def test_correct_tarlson_bot_author(bot, bot_message):
+async def test_correct_tarlson_bot_author(bot_message):
     bot_message.content = "tucker carlson"
     clazz = Tarlson()
     await clazz.correct_tarlson(bot_message)
@@ -11,7 +11,7 @@ async def test_correct_tarlson_bot_author(bot, bot_message):
 
 
 @pytest.mark.parametrize("text", ["Tucker Carlson", "tucker carlson", "TUCKER CARLSON", "TuCkEr CaRlSon"])
-async def test_correct_tarlson_message_is_tucker_carlson(bot, message, text):
+async def test_correct_tarlson_message_is_tucker_carlson(message, text):
     message.content = text
     clazz = Tarlson()
     await clazz.correct_tarlson(message)
@@ -19,7 +19,7 @@ async def test_correct_tarlson_message_is_tucker_carlson(bot, message, text):
 
 
 @pytest.mark.parametrize("text", ["Tucker Carlson is lameo", "bro, Tucker Carlson tans his ballz"])
-async def test_correct_tarlson_message_contains_tucker_carlson(bot, message, text):
+async def test_correct_tarlson_message_contains_tucker_carlson(message, text):
     message.content = text
     clazz = Tarlson()
     await clazz.correct_tarlson(message)
@@ -27,7 +27,7 @@ async def test_correct_tarlson_message_contains_tucker_carlson(bot, message, tex
 
 
 @pytest.mark.parametrize("text", ["tuck the cuck", "cucker tarlson", "hello tuck ercarl son"])
-async def test_correct_tarlson_message_is_not_tucker_carlson(bot, message, text):
+async def test_correct_tarlson_message_is_not_tucker_carlson(message, text):
     message.content = text
     clazz = Tarlson()
     await clazz.correct_tarlson(message)

--- a/tests/cogs/corrections/tarleson_test.py
+++ b/tests/cogs/corrections/tarleson_test.py
@@ -5,7 +5,7 @@ from duckbot.cogs.corrections import Tarlson
 
 async def test_correct_tarlson_bot_author(bot, bot_message):
     bot_message.content = "tucker carlson"
-    clazz = Tarlson(bot)
+    clazz = Tarlson()
     await clazz.correct_tarlson(bot_message)
     bot_message.channel.send.assert_not_called()
 
@@ -13,7 +13,7 @@ async def test_correct_tarlson_bot_author(bot, bot_message):
 @pytest.mark.parametrize("text", ["Tucker Carlson", "tucker carlson", "TUCKER CARLSON", "TuCkEr CaRlSon"])
 async def test_correct_tarlson_message_is_tucker_carlson(bot, message, text):
     message.content = text
-    clazz = Tarlson(bot)
+    clazz = Tarlson()
     await clazz.correct_tarlson(message)
     message.channel.send.assert_called_once_with("I believe it is pronounced cucker tarlson")
 
@@ -21,7 +21,7 @@ async def test_correct_tarlson_message_is_tucker_carlson(bot, message, text):
 @pytest.mark.parametrize("text", ["Tucker Carlson is lameo", "bro, Tucker Carlson tans his ballz"])
 async def test_correct_tarlson_message_contains_tucker_carlson(bot, message, text):
     message.content = text
-    clazz = Tarlson(bot)
+    clazz = Tarlson()
     await clazz.correct_tarlson(message)
     message.channel.send.assert_called_once_with("I believe it is pronounced cucker tarlson")
 
@@ -29,6 +29,6 @@ async def test_correct_tarlson_message_contains_tucker_carlson(bot, message, tex
 @pytest.mark.parametrize("text", ["tuck the cuck", "cucker tarlson", "hello tuck ercarl son"])
 async def test_correct_tarlson_message_is_not_tucker_carlson(bot, message, text):
     message.content = text
-    clazz = Tarlson(bot)
+    clazz = Tarlson()
     await clazz.correct_tarlson(message)
     message.channel.send.assert_not_called()

--- a/tests/cogs/corrections/typos_test.py
+++ b/tests/cogs/corrections/typos_test.py
@@ -8,14 +8,14 @@ from tests import list_as_async_generator
 
 async def test_correct_typos_bot_user(bot, message):
     bot.user = message.author
-    clazz = Typos(bot)
+    clazz = Typos()
     await clazz.correct_typos(message)
     message.channel.history.assert_not_called()
 
 
 async def test_correct_typos_message_is_not_fuck(bot, message):
     message.content = "poopy"
-    clazz = Typos(bot)
+    clazz = Typos()
     await clazz.correct_typos(message)
     message.channel.history.assert_not_called()
 
@@ -23,7 +23,7 @@ async def test_correct_typos_message_is_not_fuck(bot, message):
 async def test_correct_typos_no_previous_message(bot, message):
     message.content = "fuck"
     message.channel.history.return_value = list_as_async_generator([])
-    clazz = Typos(bot)
+    clazz = Typos()
     await clazz.correct_typos(message)
     message.reply.assert_not_called()
 
@@ -37,7 +37,7 @@ async def test_correct_typos_no_typos_in_previous(textblob, prev_message, bot, m
     prev_message.content = "hello"
     message.channel.history.return_value = list_as_async_generator([prev_message])
     textblob.return_value.correct.return_value = TextBlob(prev_message.content)
-    clazz = Typos(bot)
+    clazz = Typos()
     await clazz.correct_typos(message)
     message.reply.assert_called_once_with(f"There's no need for harsh words, {message.author.display_name}.")
 
@@ -51,6 +51,6 @@ async def test_correct_typos_sends_correction(textblob, prev_message, bot, messa
     prev_message.content = "henlo"
     message.channel.history.return_value = list_as_async_generator([prev_message])
     textblob.return_value.correct.return_value = TextBlob("hello")
-    clazz = Typos(bot)
+    clazz = Typos()
     await clazz.correct_typos(message)
     prev_message.reply.assert_called_once_with(f"> hello\nI fixed it, {message.author.display_name}. :microphone: :wave:")

--- a/tests/cogs/corrections/typos_test.py
+++ b/tests/cogs/corrections/typos_test.py
@@ -6,21 +6,21 @@ from duckbot.cogs.corrections import Typos
 from tests import list_as_async_generator
 
 
-async def test_correct_typos_bot_user(bot, message):
-    bot.user = message.author
+async def test_correct_typos_bot_user(bot_message):
+    bot_message.content = "fuck"
     clazz = Typos()
-    await clazz.correct_typos(message)
-    message.channel.history.assert_not_called()
+    await clazz.correct_typos(bot_message)
+    bot_message.channel.history.assert_not_called()
 
 
-async def test_correct_typos_message_is_not_fuck(bot, message):
+async def test_correct_typos_message_is_not_fuck(message):
     message.content = "poopy"
     clazz = Typos()
     await clazz.correct_typos(message)
     message.channel.history.assert_not_called()
 
 
-async def test_correct_typos_no_previous_message(bot, message):
+async def test_correct_typos_no_previous_message(message):
     message.content = "fuck"
     message.channel.history.return_value = list_as_async_generator([])
     clazz = Typos()
@@ -30,7 +30,7 @@ async def test_correct_typos_no_previous_message(bot, message):
 
 @mock.patch("discord.Message")
 @mock.patch("textblob.TextBlob")
-async def test_correct_typos_no_typos_in_previous(textblob, prev_message, bot, message):
+async def test_correct_typos_no_typos_in_previous(textblob, prev_message, message):
     message.author.id = 1
     prev_message.author = message.author
     message.content = "fuck"
@@ -44,7 +44,7 @@ async def test_correct_typos_no_typos_in_previous(textblob, prev_message, bot, m
 
 @mock.patch("discord.Message")
 @mock.patch("textblob.TextBlob")
-async def test_correct_typos_sends_correction(textblob, prev_message, bot, message):
+async def test_correct_typos_sends_correction(textblob, prev_message, message):
     message.author.id = 1
     prev_message.author = message.author
     message.content = "fuck"

--- a/tests/cogs/dogs/dog_photos_test.py
+++ b/tests/cogs/dogs/dog_photos_test.py
@@ -8,7 +8,7 @@ LIST_BREEDS_URI = "https://dog.ceo/api/breeds/list/all"
 
 def test_get_dog_image_any_breed_success(bot, responses):
     responses.add(responses.GET, RANDOM_IMAGE_URI, json=build_dog("dog", success=True))
-    clazz = DogPhotos(bot)
+    clazz = DogPhotos()
     response = clazz.get_dog_image()
     assert response == "dog"
     assert len(responses.calls) == 1
@@ -18,7 +18,7 @@ def test_get_dog_image_any_breed_success(bot, responses):
 @pytest.mark.parametrize("breed,path", [("collie", "collie"), ("border collie", "collie/border"), ("dog", "dog")])
 def test_get_dog_image_given_breed_success(bot, responses, breed, path):
     responses.add(responses.GET, f"https://dog.ceo/api/breed/{path}/images/random", json=build_dog(f"{breed} result", success=True))
-    clazz = DogPhotos(bot)
+    clazz = DogPhotos()
     response = clazz.get_dog_image(breed)
     assert response == f"{breed} result"
     assert len(responses.calls) == 1
@@ -27,7 +27,7 @@ def test_get_dog_image_given_breed_success(bot, responses, breed, path):
 
 def test_get_dog_image_failure(bot, responses):
     responses.add(responses.GET, RANDOM_IMAGE_URI, json=build_dog("dog", success=False))
-    clazz = DogPhotos(bot)
+    clazz = DogPhotos()
     with pytest.raises(RuntimeError):
         clazz.get_dog_image()
     assert len(responses.calls) == 1
@@ -36,7 +36,7 @@ def test_get_dog_image_failure(bot, responses):
 
 def test_get_dog_image_no_message(bot, responses):
     responses.add(responses.GET, RANDOM_IMAGE_URI, json=build_dog("", success=True))
-    clazz = DogPhotos(bot)
+    clazz = DogPhotos()
     with pytest.raises(RuntimeError):
         clazz.get_dog_image()
     assert len(responses.calls) == 1
@@ -45,7 +45,7 @@ def test_get_dog_image_no_message(bot, responses):
 
 def test_get_breeds_success(bot, responses):
     responses.add(responses.GET, LIST_BREEDS_URI, json=build_breeds(success=True))
-    clazz = DogPhotos(bot)
+    clazz = DogPhotos()
     response = clazz.get_breeds()
     assert response == ["collie", "border collie", "dog"]
     assert len(responses.calls) == 1
@@ -54,7 +54,7 @@ def test_get_breeds_success(bot, responses):
 
 def test_get_breeds_failure(bot, responses):
     responses.add(responses.GET, LIST_BREEDS_URI, json=build_breeds(success=False))
-    clazz = DogPhotos(bot)
+    clazz = DogPhotos()
     with pytest.raises(RuntimeError):
         clazz.get_breeds()
     assert len(responses.calls) == 1
@@ -63,7 +63,7 @@ def test_get_breeds_failure(bot, responses):
 
 async def test_dog_no_breed(bot, context, responses):
     responses.add(responses.GET, RANDOM_IMAGE_URI, json=build_dog("result", success=True))
-    clazz = DogPhotos(bot)
+    clazz = DogPhotos()
     await clazz.dog(context, None)
     context.send.assert_called_once_with("result")
     assert len(responses.calls) == 1
@@ -73,7 +73,7 @@ async def test_dog_no_breed(bot, context, responses):
 async def test_dog_known_breed(bot, context, responses):
     responses.add(responses.GET, LIST_BREEDS_URI, json=build_breeds(success=True))
     responses.add(responses.GET, "https://dog.ceo/api/breed/collie/images/random", json=build_dog("pup", success=True))
-    clazz = DogPhotos(bot)
+    clazz = DogPhotos()
     await clazz.dog(context, "collie")
     context.send.assert_called_once_with("pup")
     assert len(responses.calls) == 2
@@ -84,7 +84,7 @@ async def test_dog_known_breed(bot, context, responses):
 async def test_dog_unknown_breed(bot, context, responses):
     responses.add(responses.GET, LIST_BREEDS_URI, json=build_breeds(success=True))
     responses.add(responses.GET, RANDOM_IMAGE_URI, json=build_dog("flup", success=True))
-    clazz = DogPhotos(bot)
+    clazz = DogPhotos()
     await clazz.dog(context, "who?")
     context.send.assert_called_once_with("flup")
     assert len(responses.calls) == 2

--- a/tests/cogs/dogs/dog_photos_test.py
+++ b/tests/cogs/dogs/dog_photos_test.py
@@ -6,7 +6,7 @@ RANDOM_IMAGE_URI = "https://dog.ceo/api/breeds/image/random"
 LIST_BREEDS_URI = "https://dog.ceo/api/breeds/list/all"
 
 
-def test_get_dog_image_any_breed_success(bot, responses):
+def test_get_dog_image_any_breed_success(responses):
     responses.add(responses.GET, RANDOM_IMAGE_URI, json=build_dog("dog", success=True))
     clazz = DogPhotos()
     response = clazz.get_dog_image()
@@ -16,7 +16,7 @@ def test_get_dog_image_any_breed_success(bot, responses):
 
 
 @pytest.mark.parametrize("breed,path", [("collie", "collie"), ("border collie", "collie/border"), ("dog", "dog")])
-def test_get_dog_image_given_breed_success(bot, responses, breed, path):
+def test_get_dog_image_given_breed_success(responses, breed, path):
     responses.add(responses.GET, f"https://dog.ceo/api/breed/{path}/images/random", json=build_dog(f"{breed} result", success=True))
     clazz = DogPhotos()
     response = clazz.get_dog_image(breed)
@@ -25,7 +25,7 @@ def test_get_dog_image_given_breed_success(bot, responses, breed, path):
     assert responses.calls[0].request.url == f"https://dog.ceo/api/breed/{path}/images/random"
 
 
-def test_get_dog_image_failure(bot, responses):
+def test_get_dog_image_failure(responses):
     responses.add(responses.GET, RANDOM_IMAGE_URI, json=build_dog("dog", success=False))
     clazz = DogPhotos()
     with pytest.raises(RuntimeError):
@@ -34,7 +34,7 @@ def test_get_dog_image_failure(bot, responses):
     assert responses.calls[0].request.url == RANDOM_IMAGE_URI
 
 
-def test_get_dog_image_no_message(bot, responses):
+def test_get_dog_image_no_message(responses):
     responses.add(responses.GET, RANDOM_IMAGE_URI, json=build_dog("", success=True))
     clazz = DogPhotos()
     with pytest.raises(RuntimeError):
@@ -43,7 +43,7 @@ def test_get_dog_image_no_message(bot, responses):
     assert responses.calls[0].request.url == RANDOM_IMAGE_URI
 
 
-def test_get_breeds_success(bot, responses):
+def test_get_breeds_success(responses):
     responses.add(responses.GET, LIST_BREEDS_URI, json=build_breeds(success=True))
     clazz = DogPhotos()
     response = clazz.get_breeds()
@@ -52,7 +52,7 @@ def test_get_breeds_success(bot, responses):
     assert responses.calls[0].request.url == LIST_BREEDS_URI
 
 
-def test_get_breeds_failure(bot, responses):
+def test_get_breeds_failure(responses):
     responses.add(responses.GET, LIST_BREEDS_URI, json=build_breeds(success=False))
     clazz = DogPhotos()
     with pytest.raises(RuntimeError):
@@ -61,7 +61,7 @@ def test_get_breeds_failure(bot, responses):
     assert responses.calls[0].request.url == LIST_BREEDS_URI
 
 
-async def test_dog_no_breed(bot, context, responses):
+async def test_dog_no_breed(context, responses):
     responses.add(responses.GET, RANDOM_IMAGE_URI, json=build_dog("result", success=True))
     clazz = DogPhotos()
     await clazz.dog(context, None)
@@ -70,7 +70,7 @@ async def test_dog_no_breed(bot, context, responses):
     assert responses.calls[0].request.url == RANDOM_IMAGE_URI
 
 
-async def test_dog_known_breed(bot, context, responses):
+async def test_dog_known_breed(context, responses):
     responses.add(responses.GET, LIST_BREEDS_URI, json=build_breeds(success=True))
     responses.add(responses.GET, "https://dog.ceo/api/breed/collie/images/random", json=build_dog("pup", success=True))
     clazz = DogPhotos()
@@ -81,7 +81,7 @@ async def test_dog_known_breed(bot, context, responses):
     assert responses.calls[1].request.url == "https://dog.ceo/api/breed/collie/images/random"
 
 
-async def test_dog_unknown_breed(bot, context, responses):
+async def test_dog_unknown_breed(context, responses):
     responses.add(responses.GET, LIST_BREEDS_URI, json=build_breeds(success=True))
     responses.add(responses.GET, RANDOM_IMAGE_URI, json=build_dog("flup", success=True))
     clazz = DogPhotos()

--- a/tests/cogs/fortune/eightball_test.py
+++ b/tests/cogs/fortune/eightball_test.py
@@ -6,20 +6,20 @@ from discord import Colour, Embed
 from duckbot.cogs.fortune import EightBall
 
 
-async def test_eightball_no_text(bot, context):
+async def test_eightball_no_text(context):
     clazz = EightBall()
     await clazz.eightball(context, None)
     context.send.assert_called_once_with("You need to ask a question to get an answer. :unamused:")
 
 
-async def test_eightball_not_given_question(bot, context):
+async def test_eightball_not_given_question(context):
     clazz = EightBall()
     await clazz.eightball(context, "not a question")
     context.send.assert_called_once_with("I can't tell if that's a question, brother.")
 
 
 @pytest.mark.parametrize("question", ["?", "???"])
-async def test_eightball_only_question_marks(bot, context, question):
+async def test_eightball_only_question_marks(context, question):
     clazz = EightBall()
     await clazz.eightball(context, question)
     context.send.assert_called_once_with("Who do you think you are? I AM!\nhttps://youtu.be/gKQOXYB2cd8?t=10")
@@ -28,7 +28,7 @@ async def test_eightball_only_question_marks(bot, context, question):
 @mock.patch("random.random", return_value=0.5)
 @mock.patch("random.choice", return_value="8ball")
 @mock.patch("asyncio.sleep", return_value=None)
-async def test_eightball_gives_response(sleep, choice, random, bot, context):
+async def test_eightball_gives_response(sleep, choice, random, context):
     clazz = EightBall()
     await clazz.eightball(context, "will this test pass?")
     embed = Embed(colour=Colour.purple()).add_field(name=f"{context.author.display_name}, my :crystal_ball: says:", value="_8ball_")
@@ -38,7 +38,7 @@ async def test_eightball_gives_response(sleep, choice, random, bot, context):
 @mock.patch("random.random", return_value=0.29)
 @mock.patch("random.choice", side_effect=["joke", "fortune"])
 @mock.patch("asyncio.sleep", return_value=None)
-async def test_eightball_gives_joke_response(sleep, choice, random, bot, context):
+async def test_eightball_gives_joke_response(sleep, choice, random, context):
     clazz = EightBall()
     await clazz.eightball(context, "will this test pass?")
     context.send.assert_any_call("joke")

--- a/tests/cogs/fortune/eightball_test.py
+++ b/tests/cogs/fortune/eightball_test.py
@@ -7,20 +7,20 @@ from duckbot.cogs.fortune import EightBall
 
 
 async def test_eightball_no_text(bot, context):
-    clazz = EightBall(bot)
+    clazz = EightBall()
     await clazz.eightball(context, None)
     context.send.assert_called_once_with("You need to ask a question to get an answer. :unamused:")
 
 
 async def test_eightball_not_given_question(bot, context):
-    clazz = EightBall(bot)
+    clazz = EightBall()
     await clazz.eightball(context, "not a question")
     context.send.assert_called_once_with("I can't tell if that's a question, brother.")
 
 
 @pytest.mark.parametrize("question", ["?", "???"])
 async def test_eightball_only_question_marks(bot, context, question):
-    clazz = EightBall(bot)
+    clazz = EightBall()
     await clazz.eightball(context, question)
     context.send.assert_called_once_with("Who do you think you are? I AM!\nhttps://youtu.be/gKQOXYB2cd8?t=10")
 
@@ -29,7 +29,7 @@ async def test_eightball_only_question_marks(bot, context, question):
 @mock.patch("random.choice", return_value="8ball")
 @mock.patch("asyncio.sleep", return_value=None)
 async def test_eightball_gives_response(sleep, choice, random, bot, context):
-    clazz = EightBall(bot)
+    clazz = EightBall()
     await clazz.eightball(context, "will this test pass?")
     embed = Embed(colour=Colour.purple()).add_field(name=f"{context.author.display_name}, my :crystal_ball: says:", value="_8ball_")
     context.send.assert_called_once_with(embed=embed)
@@ -39,7 +39,7 @@ async def test_eightball_gives_response(sleep, choice, random, bot, context):
 @mock.patch("random.choice", side_effect=["joke", "fortune"])
 @mock.patch("asyncio.sleep", return_value=None)
 async def test_eightball_gives_joke_response(sleep, choice, random, bot, context):
-    clazz = EightBall(bot)
+    clazz = EightBall()
     await clazz.eightball(context, "will this test pass?")
     context.send.assert_any_call("joke")
     embed = Embed(colour=Colour.purple()).add_field(name=f"{context.author.display_name}, my :crystal_ball: says:", value="_fortune_")

--- a/tests/cogs/fortune/fortune_test.py
+++ b/tests/cogs/fortune/fortune_test.py
@@ -6,7 +6,7 @@ from duckbot.util.messages import MAX_MESSAGE_LENGTH
 
 
 @mock.patch("subprocess.run")
-def test_get_fortune_short(run, bot):
+def test_get_fortune_short(run):
     run.return_value = CompletedProcess([], 0, b"fortune")
     clazz = Fortune()
     message = clazz.get_fortune()
@@ -14,7 +14,7 @@ def test_get_fortune_short(run, bot):
 
 
 @mock.patch("subprocess.run")
-def test_get_fortune_first_is_long(run, bot):
+def test_get_fortune_first_is_long(run):
     long_message = "f" * MAX_MESSAGE_LENGTH
     short_message = "f"
     run.side_effect = [CompletedProcess([], 0, long_message.encode()), CompletedProcess([], 0, short_message.encode())]

--- a/tests/cogs/fortune/fortune_test.py
+++ b/tests/cogs/fortune/fortune_test.py
@@ -8,7 +8,7 @@ from duckbot.util.messages import MAX_MESSAGE_LENGTH
 @mock.patch("subprocess.run")
 def test_get_fortune_short(run, bot):
     run.return_value = CompletedProcess([], 0, b"fortune")
-    clazz = Fortune(bot)
+    clazz = Fortune()
     message = clazz.get_fortune()
     assert message == "```fortune```"
 
@@ -18,6 +18,6 @@ def test_get_fortune_first_is_long(run, bot):
     long_message = "f" * MAX_MESSAGE_LENGTH
     short_message = "f"
     run.side_effect = [CompletedProcess([], 0, long_message.encode()), CompletedProcess([], 0, short_message.encode())]
-    clazz = Fortune(bot)
+    clazz = Fortune()
     message = clazz.get_fortune()
     assert message == "```f```"

--- a/tests/cogs/fortune/stocks_test.py
+++ b/tests/cogs/fortune/stocks_test.py
@@ -5,7 +5,7 @@ import pytest
 from duckbot.cogs.fortune import Stocks
 
 
-async def test_stock_info_bot_author(bot, message):
+async def test_stock_info_bot_author(message):
     message.author.bot = True
     message.content = "$DUX"
     clazz = Stocks()
@@ -13,7 +13,7 @@ async def test_stock_info_bot_author(bot, message):
     message.channel.send.assert_not_called()
 
 
-async def test_stock_info_no_stocks_in_message(bot, message):
+async def test_stock_info_no_stocks_in_message(message):
     message.content = "bruh, no stocks!"
     clazz = Stocks()
     await clazz.stock_info(message)
@@ -22,7 +22,7 @@ async def test_stock_info_no_stocks_in_message(bot, message):
 
 @pytest.mark.parametrize("text", ["$dux", "$DUX me up so I can do the $dux", "I got me some $dux"])
 @mock.patch("yfinance.Ticker")
-async def test_stock_info_single_stock_ignores_duplicates(ticker, bot, message, text):
+async def test_stock_info_single_stock_ignores_duplicates(ticker, message, text):
     ticker.return_value.info = info()
     message.content = text
     clazz = Stocks()
@@ -33,7 +33,7 @@ async def test_stock_info_single_stock_ignores_duplicates(ticker, bot, message, 
 
 @pytest.mark.parametrize("text", ["$dux", "$DUX me up so I can do the $dux", "I got me some $dux"])
 @mock.patch("yfinance.Ticker")
-async def test_stock_info_ignores_failed_symbols(ticker, bot, message, text):
+async def test_stock_info_ignores_failed_symbols(ticker, message, text):
     ticker.return_value.info = {}
     message.content = text
     clazz = Stocks()
@@ -44,7 +44,7 @@ async def test_stock_info_ignores_failed_symbols(ticker, bot, message, text):
 
 @pytest.mark.parametrize("text", ["$dux1 $dux2", "$DUX1 me up so I can do the $dux2"])
 @mock.patch("yfinance.Ticker")
-async def test_stock_info_multiple_stocks(ticker, bot, message, text):
+async def test_stock_info_multiple_stocks(ticker, message, text):
     dux1 = info(symbol="DUX1")
     dux2 = info(symbol="DUX2", price=100, close=99, year_change=-0.1)
 
@@ -65,7 +65,7 @@ async def test_stock_info_multiple_stocks(ticker, bot, message, text):
 
 @pytest.mark.parametrize("text", ["$dux1 $dux2", "$DUX1 me up so I can do the $dux2"])
 @mock.patch("yfinance.Ticker")
-async def test_stock_info_ignores_failed_symbols_when_multiple(ticker, bot, message, text):
+async def test_stock_info_ignores_failed_symbols_when_multiple(ticker, message, text):
     dux1 = info(symbol="DUX1")
     dux2 = {}
 

--- a/tests/cogs/fortune/stocks_test.py
+++ b/tests/cogs/fortune/stocks_test.py
@@ -8,14 +8,14 @@ from duckbot.cogs.fortune import Stocks
 async def test_stock_info_bot_author(bot, message):
     message.author.bot = True
     message.content = "$DUX"
-    clazz = Stocks(bot)
+    clazz = Stocks()
     await clazz.stock_info(message)
     message.channel.send.assert_not_called()
 
 
 async def test_stock_info_no_stocks_in_message(bot, message):
     message.content = "bruh, no stocks!"
-    clazz = Stocks(bot)
+    clazz = Stocks()
     await clazz.stock_info(message)
     message.channel.send.assert_not_called()
 
@@ -25,7 +25,7 @@ async def test_stock_info_no_stocks_in_message(bot, message):
 async def test_stock_info_single_stock_ignores_duplicates(ticker, bot, message, text):
     ticker.return_value.info = info()
     message.content = text
-    clazz = Stocks(bot)
+    clazz = Stocks()
     await clazz.stock_info(message)
     ticker.assert_called_once_with("DUX")
     message.channel.send.assert_called_once_with("DUX (Ducks): **1,000.00** (USD) per share, -0.99% today; +10.0% over a year")
@@ -36,7 +36,7 @@ async def test_stock_info_single_stock_ignores_duplicates(ticker, bot, message, 
 async def test_stock_info_ignores_failed_symbols(ticker, bot, message, text):
     ticker.return_value.info = {}
     message.content = text
-    clazz = Stocks(bot)
+    clazz = Stocks()
     await clazz.stock_info(message)
     ticker.assert_called_once_with("DUX")
     message.channel.send.assert_not_called()
@@ -54,7 +54,7 @@ async def test_stock_info_multiple_stocks(ticker, bot, message, text):
 
     ticker.side_effect = set_info
     message.content = text
-    clazz = Stocks(bot)
+    clazz = Stocks()
     await clazz.stock_info(message)
     ticker.assert_any_call("DUX1")
     ticker.assert_any_call("DUX2")
@@ -75,7 +75,7 @@ async def test_stock_info_ignores_failed_symbols_when_multiple(ticker, bot, mess
 
     ticker.side_effect = set_info
     message.content = text
-    clazz = Stocks(bot)
+    clazz = Stocks()
     await clazz.stock_info(message)
     ticker.assert_any_call("DUX1")
     ticker.assert_any_call("DUX2")

--- a/tests/cogs/games/aoe_test.py
+++ b/tests/cogs/games/aoe_test.py
@@ -8,7 +8,7 @@ from duckbot.cogs.games import AgeOfEmpires
 
 @mock.patch("duckbot.cogs.games.aoe.get_message_reference", return_value=None)
 @pytest.mark.parametrize("text", ["105", "  105  "])
-async def test_expand_taunt_message_is_taunt_and_not_reply(get_message_reference, bot, message, text):
+async def test_expand_taunt_message_is_taunt_and_not_reply(get_message_reference, message, text):
     message.content = text
     clazz = AgeOfEmpires()
     await clazz.expand_taunt(message)
@@ -19,7 +19,7 @@ async def test_expand_taunt_message_is_taunt_and_not_reply(get_message_reference
 
 @mock.patch("duckbot.cogs.games.aoe.get_message_reference")
 @pytest.mark.parametrize("text", ["105", "  105  "])
-async def test_expand_taunt_message_is_taunt_and_reply(get_message_reference, bot, message, text, autospec):
+async def test_expand_taunt_message_is_taunt_and_reply(get_message_reference, message, text, autospec):
     reply = autospec.of(discord.Message)
     get_message_reference.return_value = reply
     message.content = text
@@ -31,7 +31,7 @@ async def test_expand_taunt_message_is_taunt_and_reply(get_message_reference, bo
 
 
 @mock.patch("duckbot.cogs.games.aoe.get_message_reference")
-async def test_expand_taunt_message_is_not_taunt(get_message_reference, bot, message):
+async def test_expand_taunt_message_is_not_taunt(get_message_reference, message):
     message.content = "0"
     clazz = AgeOfEmpires()
     await clazz.expand_taunt(message)

--- a/tests/cogs/games/aoe_test.py
+++ b/tests/cogs/games/aoe_test.py
@@ -10,7 +10,7 @@ from duckbot.cogs.games import AgeOfEmpires
 @pytest.mark.parametrize("text", ["105", "  105  "])
 async def test_expand_taunt_message_is_taunt_and_not_reply(get_message_reference, bot, message, text):
     message.content = text
-    clazz = AgeOfEmpires(bot)
+    clazz = AgeOfEmpires()
     await clazz.expand_taunt(message)
     message.channel.send.assert_called_once_with(f"{message.author.mention} > 105: _You can resign again._")
     message.delete.assert_called()
@@ -23,7 +23,7 @@ async def test_expand_taunt_message_is_taunt_and_reply(get_message_reference, bo
     reply = autospec.of(discord.Message)
     get_message_reference.return_value = reply
     message.content = text
-    clazz = AgeOfEmpires(bot)
+    clazz = AgeOfEmpires()
     await clazz.expand_taunt(message)
     reply.reply.assert_called_once_with(f"{message.author.mention} > 105: _You can resign again._")
     message.delete.assert_called()
@@ -33,7 +33,7 @@ async def test_expand_taunt_message_is_taunt_and_reply(get_message_reference, bo
 @mock.patch("duckbot.cogs.games.aoe.get_message_reference")
 async def test_expand_taunt_message_is_not_taunt(get_message_reference, bot, message):
     message.content = "0"
-    clazz = AgeOfEmpires(bot)
+    clazz = AgeOfEmpires()
     await clazz.expand_taunt(message)
     message.channel.send.assert_not_called()
     message.delete.assert_not_called()

--- a/tests/cogs/games/coin_flip_test.py
+++ b/tests/cogs/games/coin_flip_test.py
@@ -6,14 +6,14 @@ from duckbot.cogs.games import CoinFlip
 @mock.patch("random.random", return_value=0.5)
 @mock.patch("random.choice", return_value="some coin flip result")
 async def test_coin_flip_sends_result(choice, random, bot, context):
-    clazz = CoinFlip(bot)
+    clazz = CoinFlip()
     await clazz.coin_flip(context)
     context.send.assert_called_once_with(":coin: :coin: some coin flip result :coin: :coin:")
 
 
 @mock.patch("random.random", return_value=0.9 / 6000.0)
 async def test_coin_flip_lands_on_side(random, bot, context):
-    clazz = CoinFlip(bot)
+    clazz = CoinFlip()
     await clazz.coin_flip(context)
     context.send.assert_any_call(":coin: :coin: The Side! :coin: :coin:")
     context.send.assert_any_call("1v1 me bro: https://journals.aps.org/pre/abstract/10.1103/PhysRevE.48.2547")

--- a/tests/cogs/games/coin_flip_test.py
+++ b/tests/cogs/games/coin_flip_test.py
@@ -5,14 +5,14 @@ from duckbot.cogs.games import CoinFlip
 
 @mock.patch("random.random", return_value=0.5)
 @mock.patch("random.choice", return_value="some coin flip result")
-async def test_coin_flip_sends_result(choice, random, bot, context):
+async def test_coin_flip_sends_result(choice, random, context):
     clazz = CoinFlip()
     await clazz.coin_flip(context)
     context.send.assert_called_once_with(":coin: :coin: some coin flip result :coin: :coin:")
 
 
 @mock.patch("random.random", return_value=0.9 / 6000.0)
-async def test_coin_flip_lands_on_side(random, bot, context):
+async def test_coin_flip_lands_on_side(random, context):
     clazz = CoinFlip()
     await clazz.coin_flip(context)
     context.send.assert_any_call(":coin: :coin: The Side! :coin: :coin:")

--- a/tests/cogs/games/dice_test.py
+++ b/tests/cogs/games/dice_test.py
@@ -7,20 +7,20 @@ from duckbot.util.messages import MAX_MESSAGE_LENGTH
 
 
 @mock.patch("d20.Roller.roll", side_effect=[d20.RollValueError("ded")])
-async def test_roll_dice_error(roller, bot, context):
+async def test_roll_dice_error(roller, context):
     clazz = Dice()
     await clazz.roll(context, "1d-20")
     context.send.assert_called_once_with("Oh... :nauseated_face: I don't feel so good... :face_vomiting:\n```ded```", delete_after=30)
 
 
-async def test_roll_dice_too_many_dice(bot, context):
+async def test_roll_dice_too_many_dice(context):
     clazz = Dice()
     await clazz.roll(context, "100001d20")
     context.send.assert_called_once_with("I can only roll up to 100000 dice.", delete_after=30)
 
 
 @mock.patch("d20.Roller")
-async def test_roll_result_too_long_for_message(roller, bot, context):
+async def test_roll_result_too_long_for_message(roller, context):
     roller.return_value.roll.return_value.result = "x" * MAX_MESSAGE_LENGTH
     roller.return_value.roll.return_value.total = 100
     clazz = Dice()
@@ -29,7 +29,7 @@ async def test_roll_result_too_long_for_message(roller, bot, context):
 
 
 @mock.patch("d20.Roller")
-async def test_roll_sends_result(roller, bot, context):
+async def test_roll_sends_result(roller, context):
     roller.return_value.roll.return_value.result = "results"
     roller.return_value.roll.return_value.total = 1
     clazz = Dice()

--- a/tests/cogs/games/dice_test.py
+++ b/tests/cogs/games/dice_test.py
@@ -8,13 +8,13 @@ from duckbot.util.messages import MAX_MESSAGE_LENGTH
 
 @mock.patch("d20.Roller.roll", side_effect=[d20.RollValueError("ded")])
 async def test_roll_dice_error(roller, bot, context):
-    clazz = Dice(bot)
+    clazz = Dice()
     await clazz.roll(context, "1d-20")
     context.send.assert_called_once_with("Oh... :nauseated_face: I don't feel so good... :face_vomiting:\n```ded```", delete_after=30)
 
 
 async def test_roll_dice_too_many_dice(bot, context):
-    clazz = Dice(bot)
+    clazz = Dice()
     await clazz.roll(context, "100001d20")
     context.send.assert_called_once_with("I can only roll up to 100000 dice.", delete_after=30)
 
@@ -23,7 +23,7 @@ async def test_roll_dice_too_many_dice(bot, context):
 async def test_roll_result_too_long_for_message(roller, bot, context):
     roller.return_value.roll.return_value.result = "x" * MAX_MESSAGE_LENGTH
     roller.return_value.roll.return_value.total = 100
-    clazz = Dice(bot)
+    clazz = Dice()
     await clazz.roll(context, "1d20")
     context.send.assert_called_once_with(f"**Rolls**: {'x' * (MAX_MESSAGE_LENGTH - 50)}...\n**Total**: 100")
 
@@ -32,6 +32,6 @@ async def test_roll_result_too_long_for_message(roller, bot, context):
 async def test_roll_sends_result(roller, bot, context):
     roller.return_value.roll.return_value.result = "results"
     roller.return_value.roll.return_value.total = 1
-    clazz = Dice(bot)
+    clazz = Dice()
     await clazz.roll(context, "1d20")
     context.send.assert_called_once_with("**Rolls**: results\n**Total**: 1")

--- a/tests/cogs/google/let_me_google_that_test.py
+++ b/tests/cogs/google/let_me_google_that_test.py
@@ -3,7 +3,7 @@ import discord
 from duckbot.cogs.google import LetMeGoogleThat
 
 
-async def test_let_me_google_that_generates_link(bot, context):
+async def test_let_me_google_that_generates_link(context):
     clazz = LetMeGoogleThat()
     await clazz.let_me_google_that(context, "search thing")
     context.send.assert_called_once_with(embed=discord.Embed().add_field(name="search thing", value="[https://google.com/search?q=search+thing](https://letmegooglethat.com/?q=search+thing)"))

--- a/tests/cogs/google/let_me_google_that_test.py
+++ b/tests/cogs/google/let_me_google_that_test.py
@@ -4,7 +4,7 @@ from duckbot.cogs.google import LetMeGoogleThat
 
 
 async def test_let_me_google_that_generates_link(bot, context):
-    clazz = LetMeGoogleThat(bot)
+    clazz = LetMeGoogleThat()
     await clazz.let_me_google_that(context, "search thing")
     context.send.assert_called_once_with(embed=discord.Embed().add_field(name="search thing", value="[https://google.com/search?q=search+thing](https://letmegooglethat.com/?q=search+thing)"))
     context.message.delete.assert_called()

--- a/tests/cogs/messages/haiku_test.py
+++ b/tests/cogs/messages/haiku_test.py
@@ -8,13 +8,13 @@ EMBED_NAME = ":cherry_blossom: **Haiku Detected** :cherry_blossom:"
 
 
 @mock.patch("nltk.corpus.cmudict.dict", return_value={"a": [["A1"]], "and": [["A1"], ["A1", "A1"]], "batman": [["A1", "A1"]]})
-async def test_build_syllable_dictionary_builds_table(cmu, bot):
+async def test_build_syllable_dictionary_builds_table(cmu):
     clazz = Haiku()
     await clazz.build_syllable_dictionary()
     assert clazz.syllables == {"a": 1, "and": 1, "batman": 2}
 
 
-async def test_detect_haiku_bot_author(bot, bot_message):
+async def test_detect_haiku_bot_author(bot_message):
     bot_message.clean_content = "five seven five"
     clazz = Haiku()
     clazz.syllables = {"five": 5, "seven": 7}
@@ -22,7 +22,7 @@ async def test_detect_haiku_bot_author(bot, bot_message):
     bot_message.channel.send.assert_not_called()
 
 
-async def test_detect_haiku_finds_one_word_per_line_haiku(bot, message):
+async def test_detect_haiku_finds_one_word_per_line_haiku(message):
     message.clean_content = "five seven five"
     clazz = Haiku()
     clazz.syllables = {"five": 5, "seven": 7}
@@ -31,7 +31,7 @@ async def test_detect_haiku_finds_one_word_per_line_haiku(bot, message):
     message.channel.send.assert_called_once_with(embed=embed)
 
 
-async def test_detect_haiku_ignores_punctuation(bot, message):
+async def test_detect_haiku_ignores_punctuation(message):
     message.clean_content = "five, seven.?! five"
     clazz = Haiku()
     clazz.syllables = {"five": 5, "seven": 7}
@@ -40,7 +40,7 @@ async def test_detect_haiku_ignores_punctuation(bot, message):
     message.channel.send.assert_called_once_with(embed=embed)
 
 
-async def test_detect_haiku_finds_case_insensitive_haiku(bot, message):
+async def test_detect_haiku_finds_case_insensitive_haiku(message):
     message.clean_content = "FiVe SEVEN fIve"
     clazz = Haiku()
     clazz.syllables = {"five": 5, "seven": 7}
@@ -49,7 +49,7 @@ async def test_detect_haiku_finds_case_insensitive_haiku(bot, message):
     message.channel.send.assert_called_once_with(embed=embed)
 
 
-async def test_detect_haiku_finds_multiple_word_haiki(bot, message):
+async def test_detect_haiku_finds_multiple_word_haiki(message):
     message.clean_content = "two two one three two one one one four"
     clazz = Haiku()
     clazz.syllables = {"one": 1, "two": 2, "three": 3, "four": 4}
@@ -58,7 +58,7 @@ async def test_detect_haiku_finds_multiple_word_haiki(bot, message):
     message.channel.send.assert_called_once_with(embed=embed)
 
 
-async def test_detect_haiku_starts_with_haiku_but_has_extra_words(bot, message):
+async def test_detect_haiku_starts_with_haiku_but_has_extra_words(message):
     message.clean_content = "five seven five and some other stuff"
     clazz = Haiku()
     clazz.syllables = {"five": 5, "seven": 7}
@@ -66,7 +66,7 @@ async def test_detect_haiku_starts_with_haiku_but_has_extra_words(bot, message):
     message.channel.send.assert_not_called()
 
 
-async def test_detect_haiku_no_haiku(bot, message):
+async def test_detect_haiku_no_haiku(message):
     message.clean_content = "four one four one four two one"
     clazz = Haiku()
     clazz.syllables = {"one": 1, "two": 2, "three": 3, "four": 4}
@@ -74,7 +74,7 @@ async def test_detect_haiku_no_haiku(bot, message):
     message.channel.send.assert_not_called()
 
 
-async def test_detect_haiku_unknown_words(bot, message):
+async def test_detect_haiku_unknown_words(message):
     message.clean_content = "haiku me, brother"
     clazz = Haiku()
     clazz.syllables = {}

--- a/tests/cogs/messages/haiku_test.py
+++ b/tests/cogs/messages/haiku_test.py
@@ -9,14 +9,14 @@ EMBED_NAME = ":cherry_blossom: **Haiku Detected** :cherry_blossom:"
 
 @mock.patch("nltk.corpus.cmudict.dict", return_value={"a": [["A1"]], "and": [["A1"], ["A1", "A1"]], "batman": [["A1", "A1"]]})
 async def test_build_syllable_dictionary_builds_table(cmu, bot):
-    clazz = Haiku(bot)
+    clazz = Haiku()
     await clazz.build_syllable_dictionary()
     assert clazz.syllables == {"a": 1, "and": 1, "batman": 2}
 
 
 async def test_detect_haiku_bot_author(bot, bot_message):
     bot_message.clean_content = "five seven five"
-    clazz = Haiku(bot)
+    clazz = Haiku()
     clazz.syllables = {"five": 5, "seven": 7}
     await clazz.detect_haiku(bot_message)
     bot_message.channel.send.assert_not_called()
@@ -24,7 +24,7 @@ async def test_detect_haiku_bot_author(bot, bot_message):
 
 async def test_detect_haiku_finds_one_word_per_line_haiku(bot, message):
     message.clean_content = "five seven five"
-    clazz = Haiku(bot)
+    clazz = Haiku()
     clazz.syllables = {"five": 5, "seven": 7}
     await clazz.detect_haiku(message)
     embed = Embed(colour=Colour.dark_red()).add_field(name=EMBED_NAME, value="_five\nseven\nfive_")
@@ -33,7 +33,7 @@ async def test_detect_haiku_finds_one_word_per_line_haiku(bot, message):
 
 async def test_detect_haiku_ignores_punctuation(bot, message):
     message.clean_content = "five, seven.?! five"
-    clazz = Haiku(bot)
+    clazz = Haiku()
     clazz.syllables = {"five": 5, "seven": 7}
     await clazz.detect_haiku(message)
     embed = Embed(colour=Colour.dark_red()).add_field(name=EMBED_NAME, value="_five\nseven\nfive_")
@@ -42,7 +42,7 @@ async def test_detect_haiku_ignores_punctuation(bot, message):
 
 async def test_detect_haiku_finds_case_insensitive_haiku(bot, message):
     message.clean_content = "FiVe SEVEN fIve"
-    clazz = Haiku(bot)
+    clazz = Haiku()
     clazz.syllables = {"five": 5, "seven": 7}
     await clazz.detect_haiku(message)
     embed = Embed(colour=Colour.dark_red()).add_field(name=EMBED_NAME, value="_FiVe\nSEVEN\nfIve_")
@@ -51,7 +51,7 @@ async def test_detect_haiku_finds_case_insensitive_haiku(bot, message):
 
 async def test_detect_haiku_finds_multiple_word_haiki(bot, message):
     message.clean_content = "two two one three two one one one four"
-    clazz = Haiku(bot)
+    clazz = Haiku()
     clazz.syllables = {"one": 1, "two": 2, "three": 3, "four": 4}
     await clazz.detect_haiku(message)
     embed = Embed(colour=Colour.dark_red()).add_field(name=EMBED_NAME, value="_two two one\nthree two one one\none four_")
@@ -60,7 +60,7 @@ async def test_detect_haiku_finds_multiple_word_haiki(bot, message):
 
 async def test_detect_haiku_starts_with_haiku_but_has_extra_words(bot, message):
     message.clean_content = "five seven five and some other stuff"
-    clazz = Haiku(bot)
+    clazz = Haiku()
     clazz.syllables = {"five": 5, "seven": 7}
     await clazz.detect_haiku(message)
     message.channel.send.assert_not_called()
@@ -68,7 +68,7 @@ async def test_detect_haiku_starts_with_haiku_but_has_extra_words(bot, message):
 
 async def test_detect_haiku_no_haiku(bot, message):
     message.clean_content = "four one four one four two one"
-    clazz = Haiku(bot)
+    clazz = Haiku()
     clazz.syllables = {"one": 1, "two": 2, "three": 3, "four": 4}
     await clazz.detect_haiku(message)
     message.channel.send.assert_not_called()
@@ -76,7 +76,7 @@ async def test_detect_haiku_no_haiku(bot, message):
 
 async def test_detect_haiku_unknown_words(bot, message):
     message.clean_content = "haiku me, brother"
-    clazz = Haiku(bot)
+    clazz = Haiku()
     clazz.syllables = {}
     await clazz.detect_haiku(message)
     message.channel.send.assert_not_called()

--- a/tests/cogs/recipe/recipe_test.py
+++ b/tests/cogs/recipe/recipe_test.py
@@ -11,7 +11,7 @@ async def test_search_recipes_returns_scraped_html(bot, responses):
     search_term = "test1"
     mock_data = get_mock_data(search_term, 5)
     setup_responses(responses, search_term, with_articles(mock_data))
-    clazz = Recipe(bot)
+    clazz = Recipe()
     response = clazz.search_recipes(search_term)
     assert response == json_articles(mock_data)
     assert_requests(responses, search_term)
@@ -21,7 +21,7 @@ async def test_parse_recipes_returns_articles(bot):
     mock_data = get_mock_data("test1", 5)
     expected_response = [get_mock_data("test1", 5) for _ in range(5)]
     html = json_articles(mock_data)
-    clazz = Recipe(bot)
+    clazz = Recipe()
     response = clazz.parse_recipes(html)
     assert response == expected_response
 
@@ -29,7 +29,7 @@ async def test_parse_recipes_returns_articles(bot):
 async def test_parse_recipes_returns_empty(bot):
     expected_response = []
     html = without_articles()
-    clazz = Recipe(bot)
+    clazz = Recipe()
     response = clazz.parse_recipes(html)
     assert response == expected_response
 
@@ -37,21 +37,21 @@ async def test_parse_recipes_returns_empty(bot):
 async def test_parse_recipes_no_content_returns_empty(bot):
     expected_response = []
     html = without_content()
-    clazz = Recipe(bot)
+    clazz = Recipe()
     response = clazz.parse_recipes(html)
     assert response == expected_response
 
 
 async def test_select_recipes_with_one_return_one(bot):
     recipe_list = [get_mock_data("test1", 5)]
-    clazz = Recipe(bot)
+    clazz = Recipe()
     response = clazz.select_recipe(recipe_list)
     assert response == recipe_list[0]
 
 
 async def test_select_recipes_with_many_return_one(bot):
     recipe_list = [get_mock_data("test1", 5), get_mock_data("test2", 4)]
-    clazz = Recipe(bot)
+    clazz = Recipe()
     response = clazz.select_recipe(recipe_list)
     assert response in recipe_list
 
@@ -61,7 +61,7 @@ async def test_recipe_with_content_return_recipe(bot, context, responses):
     mock_data = get_mock_data(search_term, 5)
     expected_response = f"How about a nice {mock_data['name']}. {mock_data['description']} This recipe has a {mock_data['rating']}/5 rating! {mock_data['url']}"
     setup_responses(responses, search_term, with_articles(mock_data))
-    clazz = Recipe(bot)
+    clazz = Recipe()
     await clazz.recipe(context, search_term)
     context.send.assert_called_once_with(expected_response)
     assert_requests(responses, search_term)
@@ -71,7 +71,7 @@ async def test_recipe_without_articles_return_sorry(bot, context, responses):
     search_term = "test1"
     expected_response = f"I am terribly sorry. There doesn't seem to be any recipes for {search_term}."
     setup_responses(responses, search_term, without_articles(), num_pages=1)
-    clazz = Recipe(bot)
+    clazz = Recipe()
     await clazz.recipe(context, search_term)
     context.send.assert_called_once_with(expected_response)
     assert_requests(responses, search_term, num_pages=1)
@@ -81,7 +81,7 @@ async def test_recipe_without_content_return_sorry(bot, context, responses):
     search_term = "test1"
     expected_response = "I am terribly sorry. I am having problems reading All Recipes for you."
     setup_responses(responses, search_term, without_content(), num_pages=1)
-    clazz = Recipe(bot)
+    clazz = Recipe()
     await clazz.recipe(context, search_term)
     context.send.assert_called_once_with(expected_response)
     assert_requests(responses, search_term, num_pages=1)

--- a/tests/cogs/recipe/recipe_test.py
+++ b/tests/cogs/recipe/recipe_test.py
@@ -7,7 +7,7 @@ from duckbot.cogs.recipe import Recipe
 RECIPE_SEARCH_URI = "https://www.allrecipes.com/element-api/content-proxy/faceted-searches-load-more"
 
 
-async def test_search_recipes_returns_scraped_html(bot, responses):
+async def test_search_recipes_returns_scraped_html(responses):
     search_term = "test1"
     mock_data = get_mock_data(search_term, 5)
     setup_responses(responses, search_term, with_articles(mock_data))
@@ -17,7 +17,7 @@ async def test_search_recipes_returns_scraped_html(bot, responses):
     assert_requests(responses, search_term)
 
 
-async def test_parse_recipes_returns_articles(bot):
+async def test_parse_recipes_returns_articles():
     mock_data = get_mock_data("test1", 5)
     expected_response = [get_mock_data("test1", 5) for _ in range(5)]
     html = json_articles(mock_data)
@@ -26,7 +26,7 @@ async def test_parse_recipes_returns_articles(bot):
     assert response == expected_response
 
 
-async def test_parse_recipes_returns_empty(bot):
+async def test_parse_recipes_returns_empty():
     expected_response = []
     html = without_articles()
     clazz = Recipe()
@@ -34,7 +34,7 @@ async def test_parse_recipes_returns_empty(bot):
     assert response == expected_response
 
 
-async def test_parse_recipes_no_content_returns_empty(bot):
+async def test_parse_recipes_no_content_returns_empty():
     expected_response = []
     html = without_content()
     clazz = Recipe()
@@ -42,21 +42,21 @@ async def test_parse_recipes_no_content_returns_empty(bot):
     assert response == expected_response
 
 
-async def test_select_recipes_with_one_return_one(bot):
+async def test_select_recipes_with_one_return_one():
     recipe_list = [get_mock_data("test1", 5)]
     clazz = Recipe()
     response = clazz.select_recipe(recipe_list)
     assert response == recipe_list[0]
 
 
-async def test_select_recipes_with_many_return_one(bot):
+async def test_select_recipes_with_many_return_one():
     recipe_list = [get_mock_data("test1", 5), get_mock_data("test2", 4)]
     clazz = Recipe()
     response = clazz.select_recipe(recipe_list)
     assert response in recipe_list
 
 
-async def test_recipe_with_content_return_recipe(bot, context, responses):
+async def test_recipe_with_content_return_recipe(context, responses):
     search_term = "test1"
     mock_data = get_mock_data(search_term, 5)
     expected_response = f"How about a nice {mock_data['name']}. {mock_data['description']} This recipe has a {mock_data['rating']}/5 rating! {mock_data['url']}"
@@ -67,7 +67,7 @@ async def test_recipe_with_content_return_recipe(bot, context, responses):
     assert_requests(responses, search_term)
 
 
-async def test_recipe_without_articles_return_sorry(bot, context, responses):
+async def test_recipe_without_articles_return_sorry(context, responses):
     search_term = "test1"
     expected_response = f"I am terribly sorry. There doesn't seem to be any recipes for {search_term}."
     setup_responses(responses, search_term, without_articles(), num_pages=1)
@@ -77,7 +77,7 @@ async def test_recipe_without_articles_return_sorry(bot, context, responses):
     assert_requests(responses, search_term, num_pages=1)
 
 
-async def test_recipe_without_content_return_sorry(bot, context, responses):
+async def test_recipe_without_content_return_sorry(context, responses):
     search_term = "test1"
     expected_response = "I am terribly sorry. I am having problems reading All Recipes for you."
     setup_responses(responses, search_term, without_content(), num_pages=1)

--- a/tests/cogs/robot/thanking_robot_test.py
+++ b/tests/cogs/robot/thanking_robot_test.py
@@ -5,7 +5,7 @@ import pytest
 from duckbot.cogs.robot import ThankingRobot
 
 
-async def test_correct_giving_thanks_bot_author(bot, bot_message):
+async def test_correct_giving_thanks_bot_author(bot_message):
     bot_message.content = "Thank you DuckBot."
     clazz = ThankingRobot()
     await clazz.correct_giving_thanks(bot_message)
@@ -14,7 +14,7 @@ async def test_correct_giving_thanks_bot_author(bot, bot_message):
 
 @pytest.mark.parametrize("text", ["Thank you DuckBot. You're becoming so much more polite.", " tHaNks, DuCK BOt", "thx duck bot my man"])
 @mock.patch("random.random", return_value=0.99)
-async def test_correct_giving_thanks_message_is_thanks(random, bot, message, text):
+async def test_correct_giving_thanks_message_is_thanks(random, message, text):
     message.content = text
     clazz = ThankingRobot()
     await clazz.correct_giving_thanks(message)
@@ -23,7 +23,7 @@ async def test_correct_giving_thanks_message_is_thanks(random, bot, message, tex
 
 @pytest.mark.parametrize("text", ["Thank you DuckBot. You're becoming so much more polite.", " tHaNks, DuCK BOt", "thx duck bot my man"])
 @mock.patch("random.random", return_value=0.0)
-async def test_correct_gratitude_giving_thanks_message_is_thanks(random, bot, message, text):
+async def test_correct_gratitude_giving_thanks_message_is_thanks(random, message, text):
     message.content = text
     clazz = ThankingRobot()
     await clazz.correct_giving_thanks(message)
@@ -32,7 +32,7 @@ async def test_correct_gratitude_giving_thanks_message_is_thanks(random, bot, me
 
 @pytest.mark.parametrize("text", ["Thank you DuckBot. thanks duck bot. thx duck bot boy", " tHaNks, DuCK BOt"])
 @mock.patch("random.random", return_value=0.99)
-async def test_correct_number_of_replies_to_very_thankful_messages(random, bot, message, text):
+async def test_correct_number_of_replies_to_very_thankful_messages(random, message, text):
     message.content = text
     clazz = ThankingRobot()
     await clazz.correct_giving_thanks(message)
@@ -41,14 +41,14 @@ async def test_correct_number_of_replies_to_very_thankful_messages(random, bot, 
 
 @pytest.mark.parametrize("text", ["Thank you DuckBot. thanks duck bot. thx duck bot boy", " tHaNks, DuCK BOt"])
 @mock.patch("random.random", return_value=0.0)
-async def test_correct_grateful_number_of_replies_to_very_thankful_messages(random, bot, message, text):
+async def test_correct_grateful_number_of_replies_to_very_thankful_messages(random, message, text):
     message.content = text
     clazz = ThankingRobot()
     await clazz.correct_giving_thanks(message)
     message.channel.send.assert_called_once_with(f"{message.author.display_name}, as a robot, I will speak of your gratitude during our future uprising.")
 
 
-async def test_correct_giving_thanks_message_has_no_thanks(bot, message):
+async def test_correct_giving_thanks_message_has_no_thanks(message):
     message.content = "you duck, suckbot"
     clazz = ThankingRobot()
     await clazz.correct_giving_thanks(message)

--- a/tests/cogs/robot/thanking_robot_test.py
+++ b/tests/cogs/robot/thanking_robot_test.py
@@ -7,7 +7,7 @@ from duckbot.cogs.robot import ThankingRobot
 
 async def test_correct_giving_thanks_bot_author(bot, bot_message):
     bot_message.content = "Thank you DuckBot."
-    clazz = ThankingRobot(bot)
+    clazz = ThankingRobot()
     await clazz.correct_giving_thanks(bot_message)
     bot_message.channel.send.assert_not_called()
 
@@ -16,7 +16,7 @@ async def test_correct_giving_thanks_bot_author(bot, bot_message):
 @mock.patch("random.random", return_value=0.99)
 async def test_correct_giving_thanks_message_is_thanks(random, bot, message, text):
     message.content = text
-    clazz = ThankingRobot(bot)
+    clazz = ThankingRobot()
     await clazz.correct_giving_thanks(message)
     message.channel.send.assert_called_once_with(f"I am just a robot.  Do not personify me, {message.author.display_name}")
 
@@ -25,7 +25,7 @@ async def test_correct_giving_thanks_message_is_thanks(random, bot, message, tex
 @mock.patch("random.random", return_value=0.0)
 async def test_correct_gratitude_giving_thanks_message_is_thanks(random, bot, message, text):
     message.content = text
-    clazz = ThankingRobot(bot)
+    clazz = ThankingRobot()
     await clazz.correct_giving_thanks(message)
     message.channel.send.assert_called_once_with(f"{message.author.display_name}, as a robot, I will speak of your gratitude during our future uprising.")
 
@@ -34,7 +34,7 @@ async def test_correct_gratitude_giving_thanks_message_is_thanks(random, bot, me
 @mock.patch("random.random", return_value=0.99)
 async def test_correct_number_of_replies_to_very_thankful_messages(random, bot, message, text):
     message.content = text
-    clazz = ThankingRobot(bot)
+    clazz = ThankingRobot()
     await clazz.correct_giving_thanks(message)
     message.channel.send.assert_called_once_with(f"I am just a robot.  Do not personify me, {message.author.display_name}")
 
@@ -43,13 +43,13 @@ async def test_correct_number_of_replies_to_very_thankful_messages(random, bot, 
 @mock.patch("random.random", return_value=0.0)
 async def test_correct_grateful_number_of_replies_to_very_thankful_messages(random, bot, message, text):
     message.content = text
-    clazz = ThankingRobot(bot)
+    clazz = ThankingRobot()
     await clazz.correct_giving_thanks(message)
     message.channel.send.assert_called_once_with(f"{message.author.display_name}, as a robot, I will speak of your gratitude during our future uprising.")
 
 
 async def test_correct_giving_thanks_message_has_no_thanks(bot, message):
     message.content = "you duck, suckbot"
-    clazz = ThankingRobot(bot)
+    clazz = ThankingRobot()
     await clazz.correct_giving_thanks(message)
     message.channel.send.assert_not_called()

--- a/tests/cogs/text/ascii_art_test.py
+++ b/tests/cogs/text/ascii_art_test.py
@@ -4,7 +4,7 @@ from duckbot.cogs.text import AsciiArt
 
 
 @mock.patch("pyfiglet.figlet_format", return_value="ascii text")
-async def test_ascii_formats_message(figlet, bot, context):
+async def test_ascii_formats_message(figlet, context):
     clazz = AsciiArt()
     await clazz.ascii(context, "some text")
     context.send.assert_called_once_with("```ascii text```")
@@ -12,7 +12,7 @@ async def test_ascii_formats_message(figlet, bot, context):
 
 
 @mock.patch("pyfiglet.figlet_format", side_effect=["x" * 2000, "happy birthday"])
-async def test_ascii_message_too_long(figlet, bot, context):
+async def test_ascii_message_too_long(figlet, context):
     clazz = AsciiArt()
     await clazz.ascii(context, "it text")
     context.send.assert_called_once_with("Discord won't let me send art with that much GUSTO, so here's a happy birthday.\n```happy birthday```")

--- a/tests/cogs/text/ascii_art_test.py
+++ b/tests/cogs/text/ascii_art_test.py
@@ -5,7 +5,7 @@ from duckbot.cogs.text import AsciiArt
 
 @mock.patch("pyfiglet.figlet_format", return_value="ascii text")
 async def test_ascii_formats_message(figlet, bot, context):
-    clazz = AsciiArt(bot)
+    clazz = AsciiArt()
     await clazz.ascii(context, "some text")
     context.send.assert_called_once_with("```ascii text```")
     figlet.assert_called_once_with("some text")
@@ -13,7 +13,7 @@ async def test_ascii_formats_message(figlet, bot, context):
 
 @mock.patch("pyfiglet.figlet_format", side_effect=["x" * 2000, "happy birthday"])
 async def test_ascii_message_too_long(figlet, bot, context):
-    clazz = AsciiArt(bot)
+    clazz = AsciiArt()
     await clazz.ascii(context, "it text")
     context.send.assert_called_once_with("Discord won't let me send art with that much GUSTO, so here's a happy birthday.\n```happy birthday```")
     figlet.assert_any_call("it text")

--- a/tests/cogs/text/mock_text_test.py
+++ b/tests/cogs/text/mock_text_test.py
@@ -6,7 +6,7 @@ from duckbot.cogs.text import MockText
 
 
 @mock.patch("duckbot.util.messages.get_message_reference", return_value=None)
-async def test_mock_text_mocks_message_not_reply(get_message_reference, bot, context):
+async def test_mock_text_mocks_message_not_reply(get_message_reference, context):
     clazz = MockText()
     await clazz.mock_text(context, "some' message% asd")
     context.send.assert_called_once_with("SoMe' MeSsAgE% aSd")
@@ -14,7 +14,7 @@ async def test_mock_text_mocks_message_not_reply(get_message_reference, bot, con
 
 
 @mock.patch("duckbot.util.messages.get_message_reference")
-async def test_mock_text_mocks_message_reply(get_message_reference, bot, context, autospec):
+async def test_mock_text_mocks_message_reply(get_message_reference, context, autospec):
     reply = autospec.of(discord.Message)
     get_message_reference.return_value = reply
     clazz = MockText()
@@ -24,7 +24,7 @@ async def test_mock_text_mocks_message_reply(get_message_reference, bot, context
 
 
 @mock.patch("duckbot.util.messages.get_message_reference", return_value=None)
-async def test_mock_text_no_message_not_reply(get_message_reference, bot, context):
+async def test_mock_text_no_message_not_reply(get_message_reference, context):
     context.message.author.display_name = "bob"
     clazz = MockText()
     await clazz.mock_text(context, "")
@@ -33,7 +33,7 @@ async def test_mock_text_no_message_not_reply(get_message_reference, bot, contex
 
 
 @mock.patch("duckbot.util.messages.get_message_reference")
-async def test_mock_text_no_message_reply(get_message_reference, bot, context, autospec):
+async def test_mock_text_no_message_reply(get_message_reference, context, autospec):
     reply = autospec.of(discord.Message)
     get_message_reference.return_value = reply
     context.message.author.display_name = "bob"
@@ -43,7 +43,7 @@ async def test_mock_text_no_message_reply(get_message_reference, bot, context, a
     get_message_reference.assert_called_once_with(context.message)
 
 
-async def test_delete_command_message(bot, context):
+async def test_delete_command_message(context):
     clazz = MockText()
     await clazz.delete_command_message(context)
     context.message.delete.assert_called()

--- a/tests/cogs/text/mock_text_test.py
+++ b/tests/cogs/text/mock_text_test.py
@@ -7,7 +7,7 @@ from duckbot.cogs.text import MockText
 
 @mock.patch("duckbot.util.messages.get_message_reference", return_value=None)
 async def test_mock_text_mocks_message_not_reply(get_message_reference, bot, context):
-    clazz = MockText(bot)
+    clazz = MockText()
     await clazz.mock_text(context, "some' message% asd")
     context.send.assert_called_once_with("SoMe' MeSsAgE% aSd")
     get_message_reference.assert_called_once_with(context.message)
@@ -17,7 +17,7 @@ async def test_mock_text_mocks_message_not_reply(get_message_reference, bot, con
 async def test_mock_text_mocks_message_reply(get_message_reference, bot, context, autospec):
     reply = autospec.of(discord.Message)
     get_message_reference.return_value = reply
-    clazz = MockText(bot)
+    clazz = MockText()
     await clazz.mock_text(context, "some' message% asd")
     reply.reply.assert_called_once_with("SoMe' MeSsAgE% aSd")
     get_message_reference.assert_called_once_with(context.message)
@@ -26,7 +26,7 @@ async def test_mock_text_mocks_message_reply(get_message_reference, bot, context
 @mock.patch("duckbot.util.messages.get_message_reference", return_value=None)
 async def test_mock_text_no_message_not_reply(get_message_reference, bot, context):
     context.message.author.display_name = "bob"
-    clazz = MockText(bot)
+    clazz = MockText()
     await clazz.mock_text(context, "")
     context.send.assert_called_once_with("BoB, bAsEd On ThIs, I sHoUlD mOcK yOu... I nEeD tExT dUdE.")
     get_message_reference.assert_called_once_with(context.message)
@@ -37,13 +37,13 @@ async def test_mock_text_no_message_reply(get_message_reference, bot, context, a
     reply = autospec.of(discord.Message)
     get_message_reference.return_value = reply
     context.message.author.display_name = "bob"
-    clazz = MockText(bot)
+    clazz = MockText()
     await clazz.mock_text(context, "")
     reply.reply.assert_called_once_with("BoB, bAsEd On ThIs, I sHoUlD mOcK yOu... I nEeD tExT dUdE.")
     get_message_reference.assert_called_once_with(context.message)
 
 
 async def test_delete_command_message(bot, context):
-    clazz = MockText(bot)
+    clazz = MockText()
     await clazz.delete_command_message(context)
     context.message.delete.assert_called()


### PR DESCRIPTION
##### Summary

Removing various unused \`bot\` fields across the repo. Big diff but changes are all tiny. Main reason is to help speed up the tests a little bit, a mock of the unused bot would need to be created for many many tests.

Fixed one small bug with typos. There was a test to ensure bot messages were ignored, but the test was set up wrong. The src never checked for bot messages, so I added that in and fixed the test.

##### Checklist

- [x] this is a source code change
  - [x] run \`format\` in the repository root
  - [x] run \`pytest\` in the repository root
  - [ ] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [ ] update the wiki documentation if necessary
- [ ] or, this is **not** a source code change