### PR TITLE
:bug: fix `/stop` disconnect throwing error

### DIFF
--- a/duckbot/cogs/audio/who_can_it_be_now.py
+++ b/duckbot/cogs/audio/who_can_it_be_now.py
@@ -71,14 +71,15 @@ class WhoCanItBeNow(commands.Cog):
     async def stop(self, context: Optional[commands.Context] = None):
         """Stops the music loop if it is playing."""
         if self.streaming:
+            self.streaming = False
             await self.voice_client.disconnect()
             try:
                 self.audio_task.cancel()
                 await self.audio_task
             except asyncio.CancelledError:
-                self.audio_task = None
+                pass
+            self.audio_task = None
             self.voice_client = None
-            self.streaming = False
             if context:
                 await context.send(":disappointed_relieved:", delete_after=30)
         elif context is not None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ requires-python = ">=3.10"
 urls = { Homepage = "https://github.com/duck-dynasty/duckbot" }
 
 dependencies = [
-    "discord.py[voice]==2.6.4",
+    "discord.py[voice]==2.7.0",
     "beautifulsoup4==4.14.3",
     "requests==2.32.5",
     "timezonefinder==8.2.0",

--- a/tests/cogs/audio/who_can_it_be_now_test.py
+++ b/tests/cogs/audio/who_can_it_be_now_test.py
@@ -73,11 +73,12 @@ async def test_task_loop_repeats_max_times(ffmpeg, vol, bot_spy, context, voice_
     await clazz.start(context)
     assert clazz.audio_task is not None
     assert clazz.streaming is True
-    for i in range(76):
+    for _ in range(76):  # drive the event loop and let auto-stop finish
         await clazz.stream.wait()
         await asyncio.sleep(0)
-        assert clazz.streaming is (i < 75)  # should be streaming 75 times only
     # stop() is called after song is played 75 times
+    assert voice_client.play.call_count == 75
+    assert clazz.streaming is False
     assert clazz.audio_task is None
     assert clazz.voice_client is None
     context.send.assert_called_once_with(":musical_note: :saxophone:", delete_after=30)


### PR DESCRIPTION
##### Summary

`discord.errors.ClientException: Not connected to voice` thrown on `stop`. Basically came down to a race condition, `streaming` sets to false late, but not before it restarts the song and weirdness ensues.

```
2026-03-01 18:52:39,117:ERROR:duckbot.cogs.audio.who_can_it_be_now: stop(, )
Traceback (most recent call last):
  File "/duckbot/duckbot/cogs/audio/who_can_it_be_now.py", line 77, in stop
    await self.audio_task
  File "/duckbot/duckbot/cogs/audio/who_can_it_be_now.py", line 55, in stream_audio
    self.voice_client.play(song, after=self.trigger_next_song)
  File "/opt/venv/lib/python3.10/site-packages/discord/voice_client.py", line 513, in play
    raise ClientException('Not connected to voice.')
discord.errors.ClientException: Not connected to voice.
```

##### Checklist

- [x] this is a source code change
  - [x] run `format` in the repository root
  - [x] run `pytest` in the repository root
  - [ ] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [ ] update the wiki documentation if necessary
- [ ] or, this is **not** a source code change