### PR TITLE
⬆️ Bump python from 3.10 to 3.13

### DIFF
--- a/.github/actions/setup-python-venv/action.yml
+++ b/.github/actions/setup-python-venv/action.yml
@@ -23,7 +23,7 @@ runs:
   - name: Set up Python
     uses: actions/setup-python@v6
     with:
-      python-version: '3.10'
+      python-version: '3.13'
 
   - name: Create path Output
     id: path

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,12 +2,12 @@
 
 ## Project Overview
 
-DuckBot is a Discord bot built with discord.py, written in Python 3.10. It uses a Cog-based architecture where each feature is a separate module under `duckbot/cogs/`.
+DuckBot is a Discord bot built with discord.py, written in Python 3.13. It uses a Cog-based architecture where each feature is a separate module under `duckbot/cogs/`.
 
 ## Development Setup
 
 ```sh
-python3.10 -m venv --clear --prompt duckbot venv
+python3.13 -m venv --clear --prompt duckbot venv
 . venv/bin/activate
 pip install --editable .[dev]
 setup_nltk
@@ -36,7 +36,7 @@ setup_nltk
 
 ## Code Style
 
-- **Formatter**: black (line length 200, target py310)
+- **Formatter**: black (line length 200, target py313)
 - **Import sorting**: isort (black-compatible profile)
 - **Linter**: flake8 (max line length 200, max complexity 10)
 - Unused imports in `__init__.py` files are allowed (F401 ignored)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # collect pip dependencies into a virtualenv, which we'll copy into the prod stage
-FROM python:3.10 as pip-dependencies
+FROM python:3.13 as pip-dependencies
 ENV VIRTUAL_ENV "/opt/venv"
 RUN python -m venv $VIRTUAL_ENV
 ENV PATH "$VIRTUAL_ENV/bin:$PATH"
@@ -13,7 +13,7 @@ COPY pyproject.toml .
 RUN pip install .
 RUN setup_nltk
 
-FROM python:3.10-slim as prod
+FROM python:3.13-slim as prod
 # ffmpeg: for discord audio
 # libpq-dev: postgres client libraries
 # libopenblas-dev: matplotlib dependencies

--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ https://user-images.githubusercontent.com/3149083/135654217-244d7457-9db9-4c30-a
 
 ## Development
 
-Before running DuckBot, you want to create a virtualenv to develop in. DuckBot runs on `python3.10`, so prefer to use that.
+Before running DuckBot, you want to create a virtualenv to develop in. DuckBot runs on `python3.13`, so prefer to use that.
 
 ```sh
-python3.10 -m venv --clear --prompt duckbot venv
+python3.13 -m venv --clear --prompt duckbot venv
 . venv/bin/activate
 pip install --editable .[dev]
 setup_nltk

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ name = "duckbot"
 version = "1.0"
 description = "A Discord bot for personal friend group"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.13"
 urls = { Homepage = "https://github.com/duck-dynasty/duckbot" }
 
 dependencies = [
@@ -18,6 +18,7 @@ dependencies = [
     "beautifulsoup4==4.14.3",
     "requests==2.32.5",
     "timezonefinder==8.2.0",
+    "tzdata==2025.3",
     "holidays==0.91",
     "pyowm==3.5.0",         # openweather
     "psycopg2==2.9.11",
@@ -69,7 +70,7 @@ setup_nltk = "scripts.setup_nltk:main"
 
 [tool.black]
 line-length = 200
-target-version = ["py310"]
+target-version = ["py313"]
 
 [tool.isort]
 profile = "black"

--- a/tests/fixtures/discord/bot.py
+++ b/tests/fixtures/discord/bot.py
@@ -27,13 +27,13 @@ async def bot(autospec, monkeypatch) -> DuckBot:
     b.command_prefix = "!"
 
     # stub the bot being started already
-    b.wait_until_ready = mock.Mock(spec=b.wait_until_ready)
+    b.wait_until_ready = mock.AsyncMock(spec=DuckBot.wait_until_ready)
 
     # set emojis to empty list; Mock has __aiter__ which causes discord.utils.get
     # to return an unawaited coroutine when iterating
     b.emojis = []
 
-    b.loop = mock.Mock(spec=asyncio.get_event_loop())
+    b.loop = mock.Mock(spec=asyncio.AbstractEventLoop)
     # mock out loop, it uses `asyncio.get_event_loop()` by default
     monkeypatch.setattr(discord.ext.tasks, "Loop", mock.Mock(spec=discord.ext.tasks.Loop))
     monkeypatch.setattr(discord.ext.tasks, "loop", mock.Mock(spec=discord.ext.tasks.loop))


### PR DESCRIPTION
##### Summary

Title. 3.10 is EOL in october, and apparently 3.11 is a big performance boost.

Not too many incompatabilities. Test fixtures needed an update as they were currently using a mock value to infer a spec, which is removed behaviour. Fix is to spec using a real object/function.

Tested various stuff on top of pytest, like /satisfy and music. Seems goochie. Draft while waiting for alembic, would want to test that too.

##### Checklist

- [x] this is a source code change
  - [x] run `format` in the repository root
  - [x] run `pytest` in the repository root
  - [ ] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [ ] update the wiki documentation if necessary
- [ ] or, this is **not** a source code change
