### PR TITLE
:bug: make `python -m duckbot` work again

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Test Connection to Discord
       run: |
         docker compose run --build --rm \
-          -e 'DUCKBOT_ARGS=connection-test' \
+          -e 'CONNECTION_TEST=true' \
           -e "DISCORD_TOKEN=$(cat .github/workflows/test-token.txt | base64 --decode)" \
           duckbot
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,6 @@ COPY --from=pip-dependencies "$VIRTUAL_ENV" "$VIRTUAL_ENV"
 COPY alembic.ini .
 COPY resources/ ./resources
 COPY duckbot/ ./duckbot
-ENV DUCKBOT_ARGS ""
+ENV RUN_MIGRATIONS "true"
 ENTRYPOINT [ "python" ]
 CMD [ "-u", "-m", "duckbot" ]

--- a/duckbot/__main__.py
+++ b/duckbot/__main__.py
@@ -16,7 +16,7 @@ from duckbot.db import Database
 async def run_duckbot(bot: commands.Bot):
     await bot.load_extension(duckbot.logs.__name__)
 
-    if "connection-test" in os.getenv("DUCKBOT_ARGS", ""):
+    if os.getenv("CONNECTION_TEST"):
         await bot.load_extension(duckbot.util.connection_test.__name__)
 
     await bot.load_extension(duckbot.health.__name__)
@@ -30,5 +30,6 @@ async def run_duckbot(bot: commands.Bot):
 
 
 if __name__ == "__main__":
-    Database().migrate()
+    if os.getenv("RUN_MIGRATIONS"):
+        Database().migrate()
     asyncio.run(run_duckbot(DuckBot()))

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -14,7 +14,7 @@ def set_discord_token_env(monkeypatch):
 
 
 async def test_run_duckbot_connection_test(bot_spy, monkeypatch):
-    monkeypatch.setenv("DUCKBOT_ARGS", "connection-test")
+    monkeypatch.setenv("CONNECTION_TEST", "true")
     await run_duckbot(bot_spy)
     assert_extensions_loaded(bot_spy, [duckbot.util.connection_test.__name__])
     bot_spy.start.assert_called_once_with(DISCORD_TOKEN)


### PR DESCRIPTION
##### Summary

When adding alembic, it ran migrations unconditionally at startup, so the "lite mode" `python -m duckbot` would fail since it had no db. This changes it so the db migrations are behind a flag.

##### Checklist

- [x] this is a source code change
  - [x] run `format` in the repository root
  - [x] run `pytest` in the repository root
  - [ ] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [ ] update the wiki documentation if necessary
- [ ] or, this is **not** a source code change
