### PR TITLE
:bug: strip markdown before checking if a message is a haiku

### DIFF
--- a/duckbot/cogs/messages/haiku.py
+++ b/duckbot/cogs/messages/haiku.py
@@ -1,5 +1,6 @@
 from discord import Colour, Embed
 from discord.ext import commands
+from discord.utils import remove_markdown
 from nltk.corpus import cmudict
 
 
@@ -31,7 +32,7 @@ class Haiku(commands.Cog):
             await message.channel.send(embed=embed)
 
     def get_words(self, message):
-        return message.clean_content.replace(",", "").replace(".", "").replace("!", "").replace("?", "").split()
+        return remove_markdown(message.clean_content).replace(",", "").replace(".", "").replace("!", "").replace("?", "").split()
 
     def get_haiku_line(self, words, target):
         i = 0

--- a/duckbot/cogs/messages/haiku.py
+++ b/duckbot/cogs/messages/haiku.py
@@ -32,13 +32,13 @@ class Haiku(commands.Cog):
             await message.channel.send(embed=embed)
 
     def get_words(self, message):
-        return remove_markdown(message.clean_content).replace(",", "").replace(".", "").replace("!", "").replace("?", "").split()
+        return message.clean_content.replace(",", "").replace(".", "").replace("!", "").replace("?", "").split()
 
     def get_haiku_line(self, words, target):
         i = 0
         line = []
         while target > 0 and i < len(words):
-            word = words[i].lower()
+            word = remove_markdown(words[i]).lower()
             if word in self.syllables:
                 line.append(words[i])
                 target -= self.syllables[word]

--- a/tests/cogs/messages/haiku_test.py
+++ b/tests/cogs/messages/haiku_test.py
@@ -1,5 +1,6 @@
 from unittest import mock
 
+import pytest
 from discord import Colour, Embed
 
 from duckbot.cogs.messages import Haiku
@@ -49,66 +50,23 @@ async def test_detect_haiku_finds_case_insensitive_haiku(message):
     message.channel.send.assert_called_once_with(embed=embed)
 
 
-async def test_detect_haiku_ignores_bold_markdown(message):
-    message.clean_content = "**five** seven five"
+@pytest.mark.parametrize(
+    "clean_content,haiku_value",
+    [
+        ("**five** seven five", "**five**\nseven\nfive"),
+        ("*five* _seven_ five", "*five*\n_seven_\nfive"),
+        ("~~five~~ seven five", "~~five~~\nseven\nfive"),
+        ("`five` seven five", "`five`\nseven\nfive"),
+        ("||five|| seven five", "||five||\nseven\nfive"),
+        ("**five**, _seven_! ~~five~~.", "**five**\n_seven_\n~~five~~"),
+    ],
+)
+async def test_detect_haiku_preserves_markdown(message, clean_content, haiku_value):
+    message.clean_content = clean_content
     clazz = Haiku()
     clazz.syllables = {"five": 5, "seven": 7}
     await clazz.detect_haiku(message)
-    embed = Embed(colour=Colour.dark_red()).add_field(name=EMBED_NAME, value="_five\nseven\nfive_")
-    message.channel.send.assert_called_once_with(embed=embed)
-
-
-async def test_detect_haiku_ignores_italic_markdown(message):
-    message.clean_content = "*five* _seven_ five"
-    clazz = Haiku()
-    clazz.syllables = {"five": 5, "seven": 7}
-    await clazz.detect_haiku(message)
-    embed = Embed(colour=Colour.dark_red()).add_field(name=EMBED_NAME, value="_five\nseven\nfive_")
-    message.channel.send.assert_called_once_with(embed=embed)
-
-
-async def test_detect_haiku_ignores_strikethrough_markdown(message):
-    message.clean_content = "~~five~~ seven five"
-    clazz = Haiku()
-    clazz.syllables = {"five": 5, "seven": 7}
-    await clazz.detect_haiku(message)
-    embed = Embed(colour=Colour.dark_red()).add_field(name=EMBED_NAME, value="_five\nseven\nfive_")
-    message.channel.send.assert_called_once_with(embed=embed)
-
-
-async def test_detect_haiku_ignores_code_markdown(message):
-    message.clean_content = "`five` seven five"
-    clazz = Haiku()
-    clazz.syllables = {"five": 5, "seven": 7}
-    await clazz.detect_haiku(message)
-    embed = Embed(colour=Colour.dark_red()).add_field(name=EMBED_NAME, value="_five\nseven\nfive_")
-    message.channel.send.assert_called_once_with(embed=embed)
-
-
-async def test_detect_haiku_ignores_spoiler_markdown(message):
-    message.clean_content = "||five|| seven five"
-    clazz = Haiku()
-    clazz.syllables = {"five": 5, "seven": 7}
-    await clazz.detect_haiku(message)
-    embed = Embed(colour=Colour.dark_red()).add_field(name=EMBED_NAME, value="_five\nseven\nfive_")
-    message.channel.send.assert_called_once_with(embed=embed)
-
-
-async def test_detect_haiku_ignores_block_quote_markdown(message):
-    message.clean_content = "> five seven five"
-    clazz = Haiku()
-    clazz.syllables = {"five": 5, "seven": 7}
-    await clazz.detect_haiku(message)
-    embed = Embed(colour=Colour.dark_red()).add_field(name=EMBED_NAME, value="_five\nseven\nfive_")
-    message.channel.send.assert_called_once_with(embed=embed)
-
-
-async def test_detect_haiku_ignores_combined_markdown(message):
-    message.clean_content = "**five**, _seven_! ~~five~~."
-    clazz = Haiku()
-    clazz.syllables = {"five": 5, "seven": 7}
-    await clazz.detect_haiku(message)
-    embed = Embed(colour=Colour.dark_red()).add_field(name=EMBED_NAME, value="_five\nseven\nfive_")
+    embed = Embed(colour=Colour.dark_red()).add_field(name=EMBED_NAME, value=f"_{haiku_value}_")
     message.channel.send.assert_called_once_with(embed=embed)
 
 

--- a/tests/cogs/messages/haiku_test.py
+++ b/tests/cogs/messages/haiku_test.py
@@ -49,6 +49,69 @@ async def test_detect_haiku_finds_case_insensitive_haiku(message):
     message.channel.send.assert_called_once_with(embed=embed)
 
 
+async def test_detect_haiku_ignores_bold_markdown(message):
+    message.clean_content = "**five** seven five"
+    clazz = Haiku()
+    clazz.syllables = {"five": 5, "seven": 7}
+    await clazz.detect_haiku(message)
+    embed = Embed(colour=Colour.dark_red()).add_field(name=EMBED_NAME, value="_five\nseven\nfive_")
+    message.channel.send.assert_called_once_with(embed=embed)
+
+
+async def test_detect_haiku_ignores_italic_markdown(message):
+    message.clean_content = "*five* _seven_ five"
+    clazz = Haiku()
+    clazz.syllables = {"five": 5, "seven": 7}
+    await clazz.detect_haiku(message)
+    embed = Embed(colour=Colour.dark_red()).add_field(name=EMBED_NAME, value="_five\nseven\nfive_")
+    message.channel.send.assert_called_once_with(embed=embed)
+
+
+async def test_detect_haiku_ignores_strikethrough_markdown(message):
+    message.clean_content = "~~five~~ seven five"
+    clazz = Haiku()
+    clazz.syllables = {"five": 5, "seven": 7}
+    await clazz.detect_haiku(message)
+    embed = Embed(colour=Colour.dark_red()).add_field(name=EMBED_NAME, value="_five\nseven\nfive_")
+    message.channel.send.assert_called_once_with(embed=embed)
+
+
+async def test_detect_haiku_ignores_code_markdown(message):
+    message.clean_content = "`five` seven five"
+    clazz = Haiku()
+    clazz.syllables = {"five": 5, "seven": 7}
+    await clazz.detect_haiku(message)
+    embed = Embed(colour=Colour.dark_red()).add_field(name=EMBED_NAME, value="_five\nseven\nfive_")
+    message.channel.send.assert_called_once_with(embed=embed)
+
+
+async def test_detect_haiku_ignores_spoiler_markdown(message):
+    message.clean_content = "||five|| seven five"
+    clazz = Haiku()
+    clazz.syllables = {"five": 5, "seven": 7}
+    await clazz.detect_haiku(message)
+    embed = Embed(colour=Colour.dark_red()).add_field(name=EMBED_NAME, value="_five\nseven\nfive_")
+    message.channel.send.assert_called_once_with(embed=embed)
+
+
+async def test_detect_haiku_ignores_block_quote_markdown(message):
+    message.clean_content = "> five seven five"
+    clazz = Haiku()
+    clazz.syllables = {"five": 5, "seven": 7}
+    await clazz.detect_haiku(message)
+    embed = Embed(colour=Colour.dark_red()).add_field(name=EMBED_NAME, value="_five\nseven\nfive_")
+    message.channel.send.assert_called_once_with(embed=embed)
+
+
+async def test_detect_haiku_ignores_combined_markdown(message):
+    message.clean_content = "**five**, _seven_! ~~five~~."
+    clazz = Haiku()
+    clazz.syllables = {"five": 5, "seven": 7}
+    await clazz.detect_haiku(message)
+    embed = Embed(colour=Colour.dark_red()).add_field(name=EMBED_NAME, value="_five\nseven\nfive_")
+    message.channel.send.assert_called_once_with(embed=embed)
+
+
 async def test_detect_haiku_finds_multiple_word_haiki(message):
     message.clean_content = "two two one three two one one one four"
     clazz = Haiku()


### PR DESCRIPTION
##### Summary

Closes #669. `Haiku.get_words` now runs `discord.utils.remove_markdown` over `message.clean_content` before stripping punctuation, so `**five** seven five` and friends register as haiku.

##### Checklist

- [x] this is a source code change
  - [x] run `format` in the repository root
  - [x] run `pytest` in the repository root
  - [x] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [ ] update the wiki documentation if necessary
- [ ] or, this is **not** a source code change