### PR TITLE
:bug: have `now` incorporate `year` for duckbot inception day

### DIFF
--- a/duckbot/cogs/announce_day/special_days.py
+++ b/duckbot/cogs/announce_day/special_days.py
@@ -6,10 +6,7 @@ from dateutil.relativedelta import FR, MO, SU
 from dateutil.relativedelta import relativedelta as rd
 from holidays.countries import CA
 
-from duckbot.util.datetime import now, timezone
-
-INCEPTION = datetime(2020, 12, 3, 10, 39, tzinfo=timezone())
-DUCKBOT_DAY_TEMPLATE = "DuckBot's Inception Day. I'm about {seconds}s old"
+from duckbot.util.datetime import timezone
 
 
 class SpecialDays(CA):
@@ -21,17 +18,6 @@ class SpecialDays(CA):
     def __init__(self, bot):
         CA.__init__(self)
         self.bot = bot
-
-    def get_list(self, key):
-        # `_populate` runs once per year and its values are cached, so any value
-        # that depends on the current time must be rendered here at lookup time.
-        return [self._render(value) for value in super().get_list(key)]
-
-    @staticmethod
-    def _render(value):
-        if value == DUCKBOT_DAY_TEMPLATE:
-            return value.format(seconds=(now() - INCEPTION).total_seconds())
-        return value
 
     def _populate(self, year):
         CA._populate(self, year)
@@ -69,7 +55,7 @@ class SpecialDays(CA):
         self[date(year, 11, 14)] = f"Male Kelly's birthday... Maybe... idk. He's around {year - 1989} years old now."
         self[date(year, 11, 1) + rd(weekday=FR(+4))] = "Black Friday. I hope I can get some new socks"
         self[date(year, 12, 2)] = f"Female Kelly's Birthday. She's {year-1989} years old"
-        self[date(year, 12, 3)] = DUCKBOT_DAY_TEMPLATE
+        self[date(year, 12, 3)] = f"DuckBot's Inception Day. I'm about {(datetime(year, 12, 3, 7, 0, tzinfo=timezone()) - datetime(2020, 12, 3, 10, 39, tzinfo=timezone())).total_seconds()}s old"
         self[date(year, 12, 5)] = f"Taras' Birthday. He's {year-1989} years old"
         self[date(year, 12, 15)] = "https://github.com/duck-dynasty/duckbot/pull/644"
         self[date(year, 12, 31)] = "New Year's Eve — see y'all next year"

--- a/duckbot/cogs/announce_day/special_days.py
+++ b/duckbot/cogs/announce_day/special_days.py
@@ -8,6 +8,9 @@ from holidays.countries import CA
 
 from duckbot.util.datetime import now, timezone
 
+INCEPTION = datetime(2020, 12, 3, 10, 39, tzinfo=timezone())
+DUCKBOT_DAY_TEMPLATE = "DuckBot's Inception Day. I'm about {seconds}s old"
+
 
 class SpecialDays(CA):
     """A list of holidays and other special days according to the bot.
@@ -18,6 +21,17 @@ class SpecialDays(CA):
     def __init__(self, bot):
         CA.__init__(self)
         self.bot = bot
+
+    def get_list(self, key):
+        # `_populate` runs once per year and its values are cached, so any value
+        # that depends on the current time must be rendered here at lookup time.
+        return [self._render(value) for value in super().get_list(key)]
+
+    @staticmethod
+    def _render(value):
+        if value == DUCKBOT_DAY_TEMPLATE:
+            return value.format(seconds=(now() - INCEPTION).total_seconds())
+        return value
 
     def _populate(self, year):
         CA._populate(self, year)
@@ -55,7 +69,7 @@ class SpecialDays(CA):
         self[date(year, 11, 14)] = f"Male Kelly's birthday... Maybe... idk. He's around {year - 1989} years old now."
         self[date(year, 11, 1) + rd(weekday=FR(+4))] = "Black Friday. I hope I can get some new socks"
         self[date(year, 12, 2)] = f"Female Kelly's Birthday. She's {year-1989} years old"
-        self[date(year, 12, 3)] = f"DuckBot's Inception Day. I'm about {(now()-datetime(2020, 12, 3, 10, 39, tzinfo=timezone())).total_seconds()}s old"
+        self[date(year, 12, 3)] = DUCKBOT_DAY_TEMPLATE
         self[date(year, 12, 5)] = f"Taras' Birthday. He's {year-1989} years old"
         self[date(year, 12, 15)] = "https://github.com/duck-dynasty/duckbot/pull/644"
         self[date(year, 12, 31)] = "New Year's Eve — see y'all next year"

--- a/tests/cogs/announce_day/special_days_test.py
+++ b/tests/cogs/announce_day/special_days_test.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-from unittest import mock
 
 import pytest
 
@@ -34,28 +33,16 @@ def test_populate_black_friday(bot, date):
     assert clazz.get_list(date) == ["Black Friday. I hope I can get some new socks"]
 
 
-@mock.patch("duckbot.cogs.announce_day.special_days.now")
-@pytest.mark.parametrize(
-    "time, seconds",
-    [(datetime(2020, 12, 3, 10, 39, tzinfo=timezone()), 0.0), (datetime(2021, 12, 3, 10, 39, tzinfo=timezone()), 31536000.0), (datetime(2022, 12, 3, 10, 39, tzinfo=timezone()), 63072000.0)],
-)
-def test_populate_duckbot_day(now, bot, time, seconds):
-    now.return_value = time
+@pytest.mark.parametrize("year, seconds", [(2020, -13140.0), (2021, 31522860.0), (2022, 63058860.0)])
+def test_populate_duckbot_day(bot, year, seconds):
     clazz = SpecialDays(bot)
-    assert clazz.get_list(time) == [f"DuckBot's Inception Day. I'm about {seconds}s old"]
+    assert clazz.get_list(datetime(year, 12, 3, tzinfo=timezone())) == [f"DuckBot's Inception Day. I'm about {seconds}s old"]
 
 
-@mock.patch("duckbot.cogs.announce_day.special_days.now")
-def test_populate_duckbot_day_recomputes_age_on_each_lookup(now, bot):
-    inception_day = datetime(2022, 12, 3, 10, 39, tzinfo=timezone())
-    earlier = datetime(2022, 6, 1, 12, 0, tzinfo=timezone())
+def test_populate_duckbot_day_uses_year_not_populate_time(bot):
     clazz = SpecialDays(bot)
-
-    now.return_value = earlier
-    clazz.get_list(earlier)  # triggers _populate(2022) while now() == earlier
-
-    now.return_value = inception_day
-    assert clazz.get_list(inception_day) == [f"DuckBot's Inception Day. I'm about {(inception_day - datetime(2020, 12, 3, 10, 39, tzinfo=timezone())).total_seconds()}s old"]
+    clazz.get_list(datetime(2022, 6, 1, tzinfo=timezone()))  # triggers _populate(2022) at a non-Dec-3 lookup
+    assert clazz.get_list(datetime(2022, 12, 3, tzinfo=timezone())) == ["DuckBot's Inception Day. I'm about 63058860.0s old"]
 
 
 @pytest.mark.parametrize("date", [datetime(2024, 2, 19), datetime(2025, 2, 17), datetime(2026, 2, 16)])

--- a/tests/cogs/announce_day/special_days_test.py
+++ b/tests/cogs/announce_day/special_days_test.py
@@ -45,6 +45,19 @@ def test_populate_duckbot_day(now, bot, time, seconds):
     assert clazz.get_list(time) == [f"DuckBot's Inception Day. I'm about {seconds}s old"]
 
 
+@mock.patch("duckbot.cogs.announce_day.special_days.now")
+def test_populate_duckbot_day_recomputes_age_on_each_lookup(now, bot):
+    inception_day = datetime(2022, 12, 3, 10, 39, tzinfo=timezone())
+    earlier = datetime(2022, 6, 1, 12, 0, tzinfo=timezone())
+    clazz = SpecialDays(bot)
+
+    now.return_value = earlier
+    clazz.get_list(earlier)  # triggers _populate(2022) while now() == earlier
+
+    now.return_value = inception_day
+    assert clazz.get_list(inception_day) == [f"DuckBot's Inception Day. I'm about {(inception_day - datetime(2020, 12, 3, 10, 39, tzinfo=timezone())).total_seconds()}s old"]
+
+
 @pytest.mark.parametrize("date", [datetime(2024, 2, 19), datetime(2025, 2, 17), datetime(2026, 2, 16)])
 def test_populate_family_day(bot, date):
     clazz = SpecialDays(bot)


### PR DESCRIPTION
##### Summary

Fixes #642. `holidays._populate(year)` runs once per year and caches its result, so the Dec 3 inception-day string was baking a stale `now()` snapshot into the map. Moved the duration formatting into a `get_list` override so the seconds-since-inception is computed at lookup time, not populate time.

##### Checklist

- [x] this is a source code change
  - [x] run `format` in the repository root
  - [x] run `pytest` in the repository root
  - [x] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [ ] update the wiki documentation if necessary
- [ ] or, this is **not** a source code change