### PR TITLE
fix: convert underscore italics to asterisk italics in haiku embed

### DIFF
--- a/duckbot/cogs/messages/haiku.py
+++ b/duckbot/cogs/messages/haiku.py
@@ -1,7 +1,11 @@
+import re
+
 from discord import Colour, Embed
 from discord.ext import commands
 from discord.utils import remove_markdown
 from nltk.corpus import cmudict
+
+UNDERSCORE_ITALIC_RE = re.compile(r"(?<!_)_([^_\n]+?)_(?!_)")
 
 
 class Haiku(commands.Cog):
@@ -27,7 +31,8 @@ class Haiku(commands.Cog):
             else:
                 return  # it's not a haiku
         if i == len(words):
-            haiku = "\n".join(lines).replace("_", r"\_")
+            # Convert `_..._` italics to `*..*` so user underscores don't collide with the wrapping italic.
+            haiku = UNDERSCORE_ITALIC_RE.sub(r"*\1*", "\n".join(lines))
             embed = Embed(colour=Colour.dark_red()).add_field(name=":cherry_blossom: **Haiku Detected** :cherry_blossom:", value=f"_{haiku}_")
             await message.channel.send(embed=embed)
 

--- a/duckbot/cogs/messages/haiku.py
+++ b/duckbot/cogs/messages/haiku.py
@@ -5,7 +5,7 @@ from discord.ext import commands
 from discord.utils import remove_markdown
 from nltk.corpus import cmudict
 
-UNDERSCORE_ITALIC_RE = re.compile(r"(?<!_)_([^_\n]+?)_(?!_)")
+UNDERSCORE_ITALIC_RE = re.compile(r"(?<!\w)_([^_\n]+?)_(?!\w)")
 
 
 class Haiku(commands.Cog):

--- a/duckbot/cogs/messages/haiku.py
+++ b/duckbot/cogs/messages/haiku.py
@@ -27,7 +27,7 @@ class Haiku(commands.Cog):
             else:
                 return  # it's not a haiku
         if i == len(words):
-            haiku = "\n".join(lines)
+            haiku = "\n".join(lines).replace("_", r"\_")
             embed = Embed(colour=Colour.dark_red()).add_field(name=":cherry_blossom: **Haiku Detected** :cherry_blossom:", value=f"_{haiku}_")
             await message.channel.send(embed=embed)
 

--- a/tests/cogs/messages/haiku_test.py
+++ b/tests/cogs/messages/haiku_test.py
@@ -55,12 +55,12 @@ async def test_detect_haiku_finds_case_insensitive_haiku(message):
     [
         ("**five** seven five", "**five**\nseven\nfive"),
         ("*five* seven five", "*five*\nseven\nfive"),
-        ("_five_ seven five", "\\_five\\_\nseven\nfive"),
-        ("*five* _seven_ five", "*five*\n\\_seven\\_\nfive"),
+        ("_five_ seven five", "*five*\nseven\nfive"),
+        ("*five* _seven_ five", "*five*\n*seven*\nfive"),
         ("~~five~~ seven five", "~~five~~\nseven\nfive"),
         ("`five` seven five", "`five`\nseven\nfive"),
         ("||five|| seven five", "||five||\nseven\nfive"),
-        ("**five**, _seven_! ~~five~~.", "**five**\n\\_seven\\_\n~~five~~"),
+        ("**five**, _seven_! ~~five~~.", "**five**\n*seven*\n~~five~~"),
     ],
 )
 async def test_detect_haiku_preserves_markdown(message, clean_content, haiku_value):

--- a/tests/cogs/messages/haiku_test.py
+++ b/tests/cogs/messages/haiku_test.py
@@ -54,11 +54,13 @@ async def test_detect_haiku_finds_case_insensitive_haiku(message):
     "clean_content,haiku_value",
     [
         ("**five** seven five", "**five**\nseven\nfive"),
-        ("*five* _seven_ five", "*five*\n_seven_\nfive"),
+        ("*five* seven five", "*five*\nseven\nfive"),
+        ("_five_ seven five", "\\_five\\_\nseven\nfive"),
+        ("*five* _seven_ five", "*five*\n\\_seven\\_\nfive"),
         ("~~five~~ seven five", "~~five~~\nseven\nfive"),
         ("`five` seven five", "`five`\nseven\nfive"),
         ("||five|| seven five", "||five||\nseven\nfive"),
-        ("**five**, _seven_! ~~five~~.", "**five**\n_seven_\n~~five~~"),
+        ("**five**, _seven_! ~~five~~.", "**five**\n\\_seven\\_\n~~five~~"),
     ],
 )
 async def test_detect_haiku_preserves_markdown(message, clean_content, haiku_value):


### PR DESCRIPTION
## Summary

- `detect_haiku` wraps the haiku in `_..._` to italicise it in the embed, but user messages containing `_underscore italic_` cause the underscores to collide with the wrapper (e.g. `_five_ seven five` → embed value `__five_\nseven\nfive_`, where `__` is parsed as underline by Discord).
- Fix: convert `_word_` italics to `*word*` italics in the assembled haiku before building the embed value. Both render as italic in Discord, but `*` doesn't collide with the wrapping `_..._`. Double-underscore (`__word__`) is left alone via lookbehind/lookahead so underline is preserved.
- Added test cases for underscore-italic input (expecting asterisk-italic output) and other markdown variants.

Closes #1311.

## Test plan

- [x] `pytest tests/cogs/messages/haiku_test.py` — 65 tests, all pass
- [x] `flake8` clean on changed files
- [x] `black` / `isort` — no reformatting needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)