### PR TITLE
fix: use eastern timezone for pokemon of the day

### DIFF
--- a/duckbot/cogs/games/pokemon.py
+++ b/duckbot/cogs/games/pokemon.py
@@ -8,6 +8,8 @@ from discord import Interaction
 from discord.app_commands import Choice
 from discord.ext import commands
 
+from duckbot.util.datetime import now
+
 ANCHOR_DATE = date(2020, 12, 3)
 POTD_SEED = 80081355
 
@@ -81,7 +83,7 @@ class Pokemon(commands.Cog):
         ids = list(range(1, n + 1))
         rng = random.Random(POTD_SEED)
         rng.shuffle(ids)
-        days_since_anchor = (date.today() - ANCHOR_DATE).days
+        days_since_anchor = (now().date() - ANCHOR_DATE).days
         return ids[days_since_anchor % n]
 
     def get_pokemon(self, name_or_id: str) -> dict:

--- a/tests/cogs/games/pokemon_test.py
+++ b/tests/cogs/games/pokemon_test.py
@@ -37,9 +37,8 @@ async def test_pokemon_no_args_shows_potd(bot, context, responses):
     responses.add(responses.GET, f"{POKEMON_API}/{potd_id}", json=build_pokemon_data(name="testmon", pokemon_id=potd_id))
     responses.add(responses.GET, f"{SPECIES_API}/{potd_id}/", json=build_species_data(pokemon_id=potd_id))
     clazz = Pokemon(bot)
-    with patch("duckbot.cogs.games.pokemon.date") as mock_date:
-        mock_date.today.return_value = ANCHOR_DATE
-        mock_date.side_effect = lambda *a, **kw: date(*a, **kw)
+    with patch("duckbot.cogs.games.pokemon.now") as mock_now:
+        mock_now.return_value.date.return_value = ANCHOR_DATE
         await clazz.pokemon(context, None)
     context.send.assert_called_once()
     embed = context.send.call_args.kwargs["embed"]
@@ -137,9 +136,8 @@ def test_get_genus_no_english_returns_empty():
 def test_potd_deterministic(bot):
     clazz = Pokemon(bot)
     clazz._pokemon_count = 1025
-    with patch("duckbot.cogs.games.pokemon.date") as mock_date:
-        mock_date.today.return_value = date(2025, 6, 15)
-        mock_date.side_effect = lambda *a, **kw: date(*a, **kw)
+    with patch("duckbot.cogs.games.pokemon.now") as mock_now:
+        mock_now.return_value.date.return_value = date(2025, 6, 15)
         id1 = clazz._get_pokemon_of_the_day_id()
         id2 = clazz._get_pokemon_of_the_day_id()
     assert id1 == id2
@@ -149,11 +147,10 @@ def test_potd_deterministic(bot):
 def test_potd_different_days_give_different_pokemon(bot):
     clazz = Pokemon(bot)
     clazz._pokemon_count = 1025
-    with patch("duckbot.cogs.games.pokemon.date") as mock_date:
-        mock_date.side_effect = lambda *a, **kw: date(*a, **kw)
-        mock_date.today.return_value = date(2025, 6, 15)
+    with patch("duckbot.cogs.games.pokemon.now") as mock_now:
+        mock_now.return_value.date.return_value = date(2025, 6, 15)
         id1 = clazz._get_pokemon_of_the_day_id()
-        mock_date.today.return_value = date(2025, 6, 16)
+        mock_now.return_value.date.return_value = date(2025, 6, 16)
         id2 = clazz._get_pokemon_of_the_day_id()
     assert id1 != id2
 


### PR DESCRIPTION
## Summary

- `_get_pokemon_of_the_day_id` used `date.today()` which depends on system local time — in prod that's UTC, so the POTD rolled over at 7 PM eastern.
- Switched to `duckbot.util.datetime.now().date()` so the day boundary matches the rest of the bot (US/Eastern).
- Updated the three tests that mocked `date.today` to mock `now` instead.

Closes #1285.

## Test plan

- [x] `pytest tests/cogs/games/pokemon_test.py` — 34 passed
- [x] `black` / `isort` / `flake8` clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)