### PR TITLE
fix: typos found by codespell

### DIFF
--- a/duckbot/cogs/games/satisfy/solver.py
+++ b/duckbot/cogs/games/satisfy/solver.py
@@ -114,7 +114,7 @@ def sloops_used(model: Model, factory: Factory, recipes: List[ModifiedRecipe], u
 def limited_item_used(model: Model, item: str, limit: int, recipes: List[ModifiedRecipe], use_recipe: List[Var], amount_recipe_uses: Callable[[ModifiedRecipe], int]) -> LinExpr:
     """Power shards and sloopers are a limited, indivisible item that can be put into machines. This sums up the
     number of shards or sloops used based on recipe usage. The number of items used is `ceil(num_recipe)`,
-    and the total of those must be constrainted by the amount available to the factory."""
+    and the total of those must be constrained by the amount available to the factory."""
     item_cost = [
         (
             r,

--- a/tests/discord_test_ext.py
+++ b/tests/discord_test_ext.py
@@ -1,7 +1,6 @@
 from discord.ext.commands import Bot
 
 
-# `cog_type` rather than `type` to avoid shadowing the builtin, and chosen over `tpye` to avoid spelling confusion.
 def assert_cog_added_of_type(bot: Bot, cog_type):
     """Asserts a cog of the given type was added to the bot."""
     called = False

--- a/tests/discord_test_ext.py
+++ b/tests/discord_test_ext.py
@@ -1,12 +1,12 @@
 from discord.ext.commands import Bot
 
 
-def assert_cog_added_of_type(bot: Bot, tpye):
+def assert_cog_added_of_type(bot: Bot, type):
     """Asserts a cog of the given type was added to the bot."""
     called = False
     for invocation in bot.add_cog.call_args_list:
-        if isinstance(invocation[0][0], tpye):
+        if isinstance(invocation[0][0], type):
             called = True
     if not called:
         # this fails with a decent assertion failure message
-        bot.add_cog.assert_any_call(tpye)
+        bot.add_cog.assert_any_call(type)

--- a/tests/discord_test_ext.py
+++ b/tests/discord_test_ext.py
@@ -1,12 +1,13 @@
 from discord.ext.commands import Bot
 
 
-def assert_cog_added_of_type(bot: Bot, type):
+# `cog_type` rather than `type` to avoid shadowing the builtin, and chosen over `tpye` to avoid spelling confusion.
+def assert_cog_added_of_type(bot: Bot, cog_type):
     """Asserts a cog of the given type was added to the bot."""
     called = False
     for invocation in bot.add_cog.call_args_list:
-        if isinstance(invocation[0][0], type):
+        if isinstance(invocation[0][0], cog_type):
             called = True
     if not called:
         # this fails with a decent assertion failure message
-        bot.add_cog.assert_any_call(type)
+        bot.add_cog.assert_any_call(cog_type)


### PR DESCRIPTION
## Summary

Two real typos found by running `codespell` over the repo:

- `tests/discord_test_ext.py` — helper parameter renamed to `cog_type`. The original `tpye` was an intentional misspelling to dodge the `type` builtin; `cog_type` clears both the shadowing and the misspelling. All ~40 callers pass positionally so the rename is safe.
- `duckbot/cogs/games/satisfy/solver.py:117` — docstring `constrainted` → `constrained`.

Every other codespell hit is intentional (the `kubernets` misspelling the corrections cog catches, `Welp`/`ded` slang, Satisfactory's `ore` items, `inout` variable names, `Provence`/`fount` real English, `crossReferences` from the Oxford API, etc.). Wiring codespell into the lint pipeline would need a ~10-word allowlist — happy to do that in a follow-up if it's worth it.

## Test plan

- [x] `pytest tests/ -k setup_test` — 24 passed (covers all callers of the renamed helper)
- [x] `pytest tests/cogs/games/satisfy/solver_test.py` — passed
- [x] `flake8` clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)