### PR TITLE
feat: add bold and italic to mock text output

### DIFF
--- a/duckbot/cogs/text/mock_text.py
+++ b/duckbot/cogs/text/mock_text.py
@@ -1,11 +1,10 @@
 import random
-import re
 
 from discord.ext import commands
 
 import duckbot.util.messages
 
-WRAPPERS = ["", "**", "_"]
+WRAPPERS = ["", "**", "*"]
 
 
 class MockText(commands.Cog):
@@ -26,20 +25,17 @@ class MockText(commands.Cog):
 
     async def mockify(self, text: str):
         counter = 0
-        char_list = []
+        parts = []
         for char in text.lower():
             if char.isalpha():
                 if counter % 2 == 0:
                     char = char.upper()
                 counter += 1
-            char_list.append(char)
-        return "".join(self._wrap(t) for t in re.split(r"(\s+)", "".join(char_list)))
-
-    def _wrap(self, token: str) -> str:
-        if not any(c.isalpha() for c in token):
-            return token
-        wrapper = random.choice(WRAPPERS)
-        return f"{wrapper}{token}{wrapper}"
+                wrapper = random.choice(WRAPPERS)
+                parts.append(f"{wrapper}{char}{wrapper}")
+            else:
+                parts.append(char)
+        return "".join(parts)
 
     @mock_text_command.after_invoke
     async def delete_command_message(self, context: commands.Context):

--- a/duckbot/cogs/text/mock_text.py
+++ b/duckbot/cogs/text/mock_text.py
@@ -2,9 +2,9 @@ import random
 
 from discord.ext import commands
 
-import duckbot.util.messages
+from duckbot.util.messages import get_message_reference, try_delete
 
-WRAPPERS = ["", "**", "*"]
+WRAPPERS = ["**", "*", "`"]
 
 
 class MockText(commands.Cog):
@@ -12,34 +12,50 @@ class MockText(commands.Cog):
     async def mock_text_command(self, context: commands.Context, *, text: str = ""):
         await self.mock_text(context, text)
 
-    async def mock_text(self, context, text: str):
+    async def mock_text(self, context: commands.Context, text: str):
         if text == "":
-            mocked_text = await self.mockify(f"{context.message.author.display_name}, based on this, I should mock you... I need text dude.")
+            mocked_text = self.mockify(f"{context.message.author.display_name}, based on this, I should mock you... I need text dude.")
         else:
-            mocked_text = await self.mockify(text.strip())
-        reply = await duckbot.util.messages.get_message_reference(context.message)
+            mocked_text = self.mockify(text.strip())
+        reply = await get_message_reference(context.message)
         if reply:
             await reply.reply(mocked_text)
         else:
             await context.send(mocked_text)
 
-    async def mockify(self, text: str):
+    def mockify(self, text: str):
         counter = 0
-        previous_was_emphasis = False
         parts = []
-        for char in text.lower():
-            if char.isalpha():
-                if counter % 2 == 0:
-                    char = char.upper()
+        chars = list(text.lower())
+        i = 0
+        use_emphasis = True
+        prev_wrapper = None
+
+        while i < len(chars):
+            if not chars[i].isalpha():
+                parts.append(chars[i])
+                i += 1
+                continue
+
+            span_len = random.randint(1, 4)
+            span = []
+            while i < len(chars) and chars[i].isalpha() and len(span) < span_len:
+                span.append(chars[i].upper() if counter % 2 == 0 else chars[i])
                 counter += 1
-                wrapper = "" if previous_was_emphasis else random.choice(WRAPPERS)
-                previous_was_emphasis = wrapper != ""
-                parts.append(f"{wrapper}{char}{wrapper}")
+                i += 1
+
+            chunk = "".join(span)
+            if use_emphasis:
+                wrapper = random.choice([w for w in WRAPPERS if w != prev_wrapper])
+                parts.append(f"{wrapper}{chunk}{wrapper}")
+                prev_wrapper = wrapper
             else:
-                previous_was_emphasis = False
-                parts.append(char)
+                parts.append(chunk)
+
+            use_emphasis = not use_emphasis
+
         return "".join(parts)
 
     @mock_text_command.after_invoke
     async def delete_command_message(self, context: commands.Context):
-        await duckbot.util.messages.try_delete(context.message)
+        await try_delete(context.message)

--- a/duckbot/cogs/text/mock_text.py
+++ b/duckbot/cogs/text/mock_text.py
@@ -1,6 +1,11 @@
+import random
+import re
+
 from discord.ext import commands
 
 import duckbot.util.messages
+
+WRAPPERS = ["", "**", "_"]
 
 
 class MockText(commands.Cog):
@@ -28,7 +33,13 @@ class MockText(commands.Cog):
                     char = char.upper()
                 counter += 1
             char_list.append(char)
-        return "".join(char_list)
+        return "".join(self._wrap(t) for t in re.split(r"(\s+)", "".join(char_list)))
+
+    def _wrap(self, token: str) -> str:
+        if not any(c.isalpha() for c in token):
+            return token
+        wrapper = random.choice(WRAPPERS)
+        return f"{wrapper}{token}{wrapper}"
 
     @mock_text_command.after_invoke
     async def delete_command_message(self, context: commands.Context):

--- a/duckbot/cogs/text/mock_text.py
+++ b/duckbot/cogs/text/mock_text.py
@@ -25,15 +25,18 @@ class MockText(commands.Cog):
 
     async def mockify(self, text: str):
         counter = 0
+        previous_was_emphasis = False  # enforce plain char between emphasis spans to avoid adjacent markdown collision
         parts = []
         for char in text.lower():
             if char.isalpha():
                 if counter % 2 == 0:
                     char = char.upper()
                 counter += 1
-                wrapper = random.choice(WRAPPERS)
+                wrapper = "" if previous_was_emphasis else random.choice(WRAPPERS)
+                previous_was_emphasis = wrapper != ""
                 parts.append(f"{wrapper}{char}{wrapper}")
             else:
+                previous_was_emphasis = False
                 parts.append(char)
         return "".join(parts)
 

--- a/duckbot/cogs/text/mock_text.py
+++ b/duckbot/cogs/text/mock_text.py
@@ -25,7 +25,7 @@ class MockText(commands.Cog):
 
     async def mockify(self, text: str):
         counter = 0
-        previous_was_emphasis = False  # enforce plain char between emphasis spans to avoid adjacent markdown collision
+        previous_was_emphasis = False
         parts = []
         for char in text.lower():
             if char.isalpha():

--- a/tests/cogs/text/mock_text_test.py
+++ b/tests/cogs/text/mock_text_test.py
@@ -51,28 +51,28 @@ async def test_mock_text_no_message_reply(get_message_reference, random_choice, 
 async def test_mockify_wraps_each_character_with_bold(random_choice):
     clazz = MockText()
     result = await clazz.mockify("hi")
-    assert result == "**H****i**"
+    assert result == "**H**i"
 
 
 @mock.patch("duckbot.cogs.text.mock_text.random.choice", return_value="*")
 async def test_mockify_wraps_each_character_with_italic(random_choice):
     clazz = MockText()
     result = await clazz.mockify("hi")
-    assert result == "*H**i*"
+    assert result == "*H*i"
 
 
-@mock.patch("duckbot.cogs.text.mock_text.random.choice", side_effect=["**", "*", ""])
+@mock.patch("duckbot.cogs.text.mock_text.random.choice", side_effect=["**", "*"])
 async def test_mockify_mixes_styles_per_character(random_choice):
     clazz = MockText()
     result = await clazz.mockify("abc")
-    assert result == "**A***b*C"
+    assert result == "**A**b*C*"
 
 
 @mock.patch("duckbot.cogs.text.mock_text.random.choice", return_value="**")
 async def test_mockify_does_not_wrap_punctuation_or_whitespace(random_choice):
     clazz = MockText()
     result = await clazz.mockify("hi ... bye")
-    assert result == "**H****i** ... **B****y****E**"
+    assert result == "**H**i ... **B**y**E**"
 
 
 async def test_delete_command_message(context):

--- a/tests/cogs/text/mock_text_test.py
+++ b/tests/cogs/text/mock_text_test.py
@@ -3,20 +3,23 @@ from unittest import mock
 import discord
 
 from duckbot.cogs.text import MockText
+from duckbot.cogs.text.mock_text import WRAPPERS
 
 
+@mock.patch("duckbot.cogs.text.mock_text.random.randint", return_value=1)
 @mock.patch("duckbot.cogs.text.mock_text.random.choice", return_value="")
-@mock.patch("duckbot.util.messages.get_message_reference", return_value=None)
-async def test_mock_text_mocks_message_not_reply(get_message_reference, random_choice, context):
+@mock.patch("duckbot.cogs.text.mock_text.get_message_reference", return_value=None)
+async def test_mock_text_mocks_message_not_reply(get_message_reference, random_choice, random_randint, context):
     clazz = MockText()
     await clazz.mock_text(context, "some' message% asd")
     context.send.assert_called_once_with("SoMe' MeSsAgE% aSd")
     get_message_reference.assert_called_once_with(context.message)
 
 
+@mock.patch("duckbot.cogs.text.mock_text.random.randint", return_value=1)
 @mock.patch("duckbot.cogs.text.mock_text.random.choice", return_value="")
-@mock.patch("duckbot.util.messages.get_message_reference")
-async def test_mock_text_mocks_message_reply(get_message_reference, random_choice, context, autospec):
+@mock.patch("duckbot.cogs.text.mock_text.get_message_reference")
+async def test_mock_text_mocks_message_reply(get_message_reference, random_choice, random_randint, context, autospec):
     reply = autospec.of(discord.Message)
     get_message_reference.return_value = reply
     clazz = MockText()
@@ -25,9 +28,10 @@ async def test_mock_text_mocks_message_reply(get_message_reference, random_choic
     get_message_reference.assert_called_once_with(context.message)
 
 
+@mock.patch("duckbot.cogs.text.mock_text.random.randint", return_value=1)
 @mock.patch("duckbot.cogs.text.mock_text.random.choice", return_value="")
-@mock.patch("duckbot.util.messages.get_message_reference", return_value=None)
-async def test_mock_text_no_message_not_reply(get_message_reference, random_choice, context):
+@mock.patch("duckbot.cogs.text.mock_text.get_message_reference", return_value=None)
+async def test_mock_text_no_message_not_reply(get_message_reference, random_choice, random_randint, context):
     context.message.author.display_name = "bob"
     clazz = MockText()
     await clazz.mock_text(context, "")
@@ -35,9 +39,10 @@ async def test_mock_text_no_message_not_reply(get_message_reference, random_choi
     get_message_reference.assert_called_once_with(context.message)
 
 
+@mock.patch("duckbot.cogs.text.mock_text.random.randint", return_value=1)
 @mock.patch("duckbot.cogs.text.mock_text.random.choice", return_value="")
-@mock.patch("duckbot.util.messages.get_message_reference")
-async def test_mock_text_no_message_reply(get_message_reference, random_choice, context, autospec):
+@mock.patch("duckbot.cogs.text.mock_text.get_message_reference")
+async def test_mock_text_no_message_reply(get_message_reference, random_choice, random_randint, context, autospec):
     reply = autospec.of(discord.Message)
     get_message_reference.return_value = reply
     context.message.author.display_name = "bob"
@@ -47,32 +52,54 @@ async def test_mock_text_no_message_reply(get_message_reference, random_choice, 
     get_message_reference.assert_called_once_with(context.message)
 
 
+@mock.patch("duckbot.cogs.text.mock_text.random.randint", return_value=1)
 @mock.patch("duckbot.cogs.text.mock_text.random.choice", return_value="**")
-async def test_mockify_wraps_each_character_with_bold(random_choice):
+async def test_mockify_wraps_emphasis_span_with_bold(random_choice, random_randint):
     clazz = MockText()
-    result = await clazz.mockify("hi")
-    assert result == "**H**i"
+    assert clazz.mockify("hi") == "**H**i"
 
 
+@mock.patch("duckbot.cogs.text.mock_text.random.randint", return_value=1)
 @mock.patch("duckbot.cogs.text.mock_text.random.choice", return_value="*")
-async def test_mockify_wraps_each_character_with_italic(random_choice):
+async def test_mockify_wraps_emphasis_span_with_italic(random_choice, random_randint):
     clazz = MockText()
-    result = await clazz.mockify("hi")
-    assert result == "*H*i"
+    assert clazz.mockify("hi") == "*H*i"
 
 
+@mock.patch("duckbot.cogs.text.mock_text.random.randint", return_value=1)
+@mock.patch("duckbot.cogs.text.mock_text.random.choice", return_value="`")
+async def test_mockify_wraps_emphasis_span_with_code(random_choice, random_randint):
+    clazz = MockText()
+    assert clazz.mockify("hi") == "`H`i"
+
+
+@mock.patch("duckbot.cogs.text.mock_text.random.randint", return_value=1)
 @mock.patch("duckbot.cogs.text.mock_text.random.choice", side_effect=["**", "*"])
-async def test_mockify_mixes_styles_per_character(random_choice):
+async def test_mockify_alternates_emphasis_and_plain(random_choice, random_randint):
     clazz = MockText()
-    result = await clazz.mockify("abc")
-    assert result == "**A**b*C*"
+    assert clazz.mockify("abc") == "**A**b*C*"
 
 
+@mock.patch("duckbot.cogs.text.mock_text.random.randint", return_value=4)
 @mock.patch("duckbot.cogs.text.mock_text.random.choice", return_value="**")
-async def test_mockify_does_not_wrap_punctuation_or_whitespace(random_choice):
+async def test_mockify_spans_multiple_characters(random_choice, random_randint):
     clazz = MockText()
-    result = await clazz.mockify("hi ... bye")
-    assert result == "**H**i ... **B**y**E**"
+    assert clazz.mockify("hello") == "**HeLl**O"
+
+
+@mock.patch("duckbot.cogs.text.mock_text.random.randint", return_value=1)
+@mock.patch("duckbot.cogs.text.mock_text.random.choice", return_value="**")
+async def test_mockify_does_not_wrap_punctuation_or_whitespace(random_choice, random_randint):
+    clazz = MockText()
+    assert clazz.mockify("hi ... bye") == "**H**i ... **B**y**E**"
+
+
+@mock.patch("duckbot.cogs.text.mock_text.random.randint", return_value=1)
+@mock.patch("duckbot.cogs.text.mock_text.random.choice", return_value="**")
+async def test_mockify_does_not_offer_previous_wrapper_as_choice(random_choice, random_randint):
+    clazz = MockText()
+    clazz.mockify("abcde")
+    assert set(random_choice.call_args_list[1][0][0]) == set(WRAPPERS) - {"**"}
 
 
 async def test_delete_command_message(context):

--- a/tests/cogs/text/mock_text_test.py
+++ b/tests/cogs/text/mock_text_test.py
@@ -47,18 +47,32 @@ async def test_mock_text_no_message_reply(get_message_reference, random_choice, 
     get_message_reference.assert_called_once_with(context.message)
 
 
-@mock.patch("duckbot.cogs.text.mock_text.random.choice", side_effect=["**", "_", ""])
-async def test_mockify_wraps_words_with_bold_and_italic(random_choice):
+@mock.patch("duckbot.cogs.text.mock_text.random.choice", return_value="**")
+async def test_mockify_wraps_each_character_with_bold(random_choice):
     clazz = MockText()
-    result = await clazz.mockify("one two three")
-    assert result == "**OnE** _tWo_ ThReE"
+    result = await clazz.mockify("hi")
+    assert result == "**H****i**"
+
+
+@mock.patch("duckbot.cogs.text.mock_text.random.choice", return_value="*")
+async def test_mockify_wraps_each_character_with_italic(random_choice):
+    clazz = MockText()
+    result = await clazz.mockify("hi")
+    assert result == "*H**i*"
+
+
+@mock.patch("duckbot.cogs.text.mock_text.random.choice", side_effect=["**", "*", ""])
+async def test_mockify_mixes_styles_per_character(random_choice):
+    clazz = MockText()
+    result = await clazz.mockify("abc")
+    assert result == "**A***b*C"
 
 
 @mock.patch("duckbot.cogs.text.mock_text.random.choice", return_value="**")
-async def test_mockify_skips_pure_punctuation_tokens(random_choice):
+async def test_mockify_does_not_wrap_punctuation_or_whitespace(random_choice):
     clazz = MockText()
     result = await clazz.mockify("hi ... bye")
-    assert result == "**Hi** ... **ByE**"
+    assert result == "**H****i** ... **B****y****E**"
 
 
 async def test_delete_command_message(context):

--- a/tests/cogs/text/mock_text_test.py
+++ b/tests/cogs/text/mock_text_test.py
@@ -5,16 +5,18 @@ import discord
 from duckbot.cogs.text import MockText
 
 
+@mock.patch("duckbot.cogs.text.mock_text.random.choice", return_value="")
 @mock.patch("duckbot.util.messages.get_message_reference", return_value=None)
-async def test_mock_text_mocks_message_not_reply(get_message_reference, context):
+async def test_mock_text_mocks_message_not_reply(get_message_reference, random_choice, context):
     clazz = MockText()
     await clazz.mock_text(context, "some' message% asd")
     context.send.assert_called_once_with("SoMe' MeSsAgE% aSd")
     get_message_reference.assert_called_once_with(context.message)
 
 
+@mock.patch("duckbot.cogs.text.mock_text.random.choice", return_value="")
 @mock.patch("duckbot.util.messages.get_message_reference")
-async def test_mock_text_mocks_message_reply(get_message_reference, context, autospec):
+async def test_mock_text_mocks_message_reply(get_message_reference, random_choice, context, autospec):
     reply = autospec.of(discord.Message)
     get_message_reference.return_value = reply
     clazz = MockText()
@@ -23,8 +25,9 @@ async def test_mock_text_mocks_message_reply(get_message_reference, context, aut
     get_message_reference.assert_called_once_with(context.message)
 
 
+@mock.patch("duckbot.cogs.text.mock_text.random.choice", return_value="")
 @mock.patch("duckbot.util.messages.get_message_reference", return_value=None)
-async def test_mock_text_no_message_not_reply(get_message_reference, context):
+async def test_mock_text_no_message_not_reply(get_message_reference, random_choice, context):
     context.message.author.display_name = "bob"
     clazz = MockText()
     await clazz.mock_text(context, "")
@@ -32,8 +35,9 @@ async def test_mock_text_no_message_not_reply(get_message_reference, context):
     get_message_reference.assert_called_once_with(context.message)
 
 
+@mock.patch("duckbot.cogs.text.mock_text.random.choice", return_value="")
 @mock.patch("duckbot.util.messages.get_message_reference")
-async def test_mock_text_no_message_reply(get_message_reference, context, autospec):
+async def test_mock_text_no_message_reply(get_message_reference, random_choice, context, autospec):
     reply = autospec.of(discord.Message)
     get_message_reference.return_value = reply
     context.message.author.display_name = "bob"
@@ -41,6 +45,20 @@ async def test_mock_text_no_message_reply(get_message_reference, context, autosp
     await clazz.mock_text(context, "")
     reply.reply.assert_called_once_with("BoB, bAsEd On ThIs, I sHoUlD mOcK yOu... I nEeD tExT dUdE.")
     get_message_reference.assert_called_once_with(context.message)
+
+
+@mock.patch("duckbot.cogs.text.mock_text.random.choice", side_effect=["**", "_", ""])
+async def test_mockify_wraps_words_with_bold_and_italic(random_choice):
+    clazz = MockText()
+    result = await clazz.mockify("one two three")
+    assert result == "**OnE** _tWo_ ThReE"
+
+
+@mock.patch("duckbot.cogs.text.mock_text.random.choice", return_value="**")
+async def test_mockify_skips_pure_punctuation_tokens(random_choice):
+    clazz = MockText()
+    result = await clazz.mockify("hi ... bye")
+    assert result == "**Hi** ... **ByE**"
 
 
 async def test_delete_command_message(context):


### PR DESCRIPTION
Adds per-character bold/italic formatting to `!mock`, chosen randomly per character.

Discord's markdown parser collapses adjacent asterisk spans (e.g. `**H****i**` renders as `***H***i**` — broken), so emphasis spans are separated by at least one plain character to prevent collision.

Closes #247

---

Will test locally to confirm Discord renders correctly before merging.