### PR TITLE
feat: crit hit/fail flavour on single d20 rolls

### DIFF
--- a/duckbot/cogs/games/dice.py
+++ b/duckbot/cogs/games/dice.py
@@ -1,7 +1,12 @@
+from typing import Optional
+
 import d20
 from discord.ext import commands
 
 from duckbot.util.messages import MAX_MESSAGE_LENGTH
+
+CRIT_HIT_FLAVOUR = ":dart: **Critical hit!**"
+CRIT_FAIL_FLAVOUR = ":skull: **Critical fail!**"
 
 
 class Dice(commands.Cog):
@@ -18,7 +23,11 @@ class Dice(commands.Cog):
             roller = self.make_roller(100_000)
             result = roller.roll(expression, allow_comments=True, stringifier=DiceStringifier())
             text = f"{result.result[:max_length]}..." if len(result.result) > max_length else result.result
-            await context.send(f"**Rolls**: {text}\n**Total**: {result.total}")
+            response = f"**Rolls**: {text}\n**Total**: {result.total}"
+            flavour = self._crit_flavour(result.expr)
+            if flavour:
+                response = f"{flavour}\n{response}"
+            await context.send(response)
         except d20.errors.TooManyRolls:
             await context.send(f"I can only roll up to {roller.context.max_rolls} dice.", delete_after=30)
         except d20.errors.RollError as e:
@@ -26,6 +35,24 @@ class Dice(commands.Cog):
 
     def make_roller(self, max_rolls: int):
         return d20.Roller(d20.RollContext(max_rolls))
+
+    @staticmethod
+    def _crit_flavour(expr) -> Optional[str]:
+        """Returns crit flavour if the expression rolled exactly one d20; otherwise None."""
+        rolled = []
+        stack = [expr]
+        while stack:
+            node = stack.pop()
+            if isinstance(node, d20.Dice) and node.size == 20:
+                rolled.extend(die.total for die in node.values)
+            stack.extend(node.children)
+        if len(rolled) != 1:
+            return None
+        if rolled[0] == 20:
+            return CRIT_HIT_FLAVOUR
+        if rolled[0] == 1:
+            return CRIT_FAIL_FLAVOUR
+        return None
 
 
 class DiceStringifier(d20.MarkdownStringifier):

--- a/duckbot/cogs/games/dice.py
+++ b/duckbot/cogs/games/dice.py
@@ -38,7 +38,6 @@ class Dice(commands.Cog):
 
     @staticmethod
     def _crit_flavour(expr) -> Optional[str]:
-        """Returns crit flavour if the expression rolled exactly one d20; otherwise None."""
         rolled = []
         stack = [expr]
         while stack:

--- a/duckbot/cogs/games/dice.py
+++ b/duckbot/cogs/games/dice.py
@@ -38,19 +38,18 @@ class Dice(commands.Cog):
 
     @staticmethod
     def _crit_flavour(expr) -> Optional[str]:
-        rolled = []
         stack = [expr]
         while stack:
             node = stack.pop()
             if isinstance(node, d20.Dice) and node.size == 20:
-                rolled.extend(die.total for die in node.values)
+                if node.num != 1:
+                    return None
+                if node.values[0].total == 20:
+                    return CRIT_HIT_FLAVOUR
+                if node.values[0].total == 1:
+                    return CRIT_FAIL_FLAVOUR
+                return None
             stack.extend(node.children)
-        if len(rolled) != 1:
-            return None
-        if rolled[0] == 20:
-            return CRIT_HIT_FLAVOUR
-        if rolled[0] == 1:
-            return CRIT_FAIL_FLAVOUR
         return None
 
 

--- a/tests/cogs/games/dice_test.py
+++ b/tests/cogs/games/dice_test.py
@@ -1,8 +1,10 @@
 from unittest import mock
 
 import d20
+import pytest
 
 from duckbot.cogs.games import Dice
+from duckbot.cogs.games.dice import CRIT_FAIL_FLAVOUR, CRIT_HIT_FLAVOUR
 from duckbot.util.messages import MAX_MESSAGE_LENGTH
 
 
@@ -37,49 +39,37 @@ async def test_roll_sends_result(roller, context):
     context.send.assert_called_once_with("**Rolls**: results\n**Total**: 1")
 
 
-@mock.patch("random.randrange", return_value=19)  # randrange(20) + 1 == 20
-async def test_roll_natural_20_shows_crit_hit(randrange, context):
+@pytest.mark.parametrize(
+    "flavour, expected_message",
+    [
+        (CRIT_HIT_FLAVOUR, f"{CRIT_HIT_FLAVOUR}\n**Rolls**: results\n**Total**: 20"),
+        (None, "**Rolls**: results\n**Total**: 20"),
+    ],
+)
+@mock.patch("duckbot.cogs.games.dice.Dice._crit_flavour")
+@mock.patch("d20.Roller")
+async def test_roll_includes_crit_flavour(roller, crit_flavour, flavour, expected_message, context):
+    roller.return_value.roll.return_value.result = "results"
+    roller.return_value.roll.return_value.total = 20
+    crit_flavour.return_value = flavour
     clazz = Dice()
     await clazz.roll(context, "1d20")
-    sent = context.send.call_args[0][0]
-    assert ":dart: **Critical hit!**" in sent
+    context.send.assert_called_once_with(expected_message)
 
 
-@mock.patch("random.randrange", return_value=0)  # randrange(20) + 1 == 1
-async def test_roll_natural_1_shows_crit_fail(randrange, context):
-    clazz = Dice()
-    await clazz.roll(context, "1d20")
-    sent = context.send.call_args[0][0]
-    assert ":skull: **Critical fail!**" in sent
-
-
-@mock.patch("random.randrange", return_value=9)  # 10
-async def test_roll_middle_value_has_no_flavour(randrange, context):
-    clazz = Dice()
-    await clazz.roll(context, "1d20")
-    sent = context.send.call_args[0][0]
-    assert "Critical" not in sent
-
-
-@mock.patch("random.randrange", return_value=19)
-async def test_roll_natural_20_with_modifier_still_crits(randrange, context):
-    clazz = Dice()
-    await clazz.roll(context, "1d20+5")
-    sent = context.send.call_args[0][0]
-    assert ":dart: **Critical hit!**" in sent
-
-
-@mock.patch("random.randrange", return_value=19)
-async def test_roll_2d20_does_not_crit_even_with_20(randrange, context):
-    clazz = Dice()
-    await clazz.roll(context, "2d20")
-    sent = context.send.call_args[0][0]
-    assert "Critical" not in sent
-
-
-@mock.patch("random.randrange", return_value=19)
-async def test_roll_d6_does_not_crit(randrange, context):
-    clazz = Dice()
-    await clazz.roll(context, "1d6")
-    sent = context.send.call_args[0][0]
-    assert "Critical" not in sent
+@pytest.mark.parametrize(
+    "expression, randrange_val, expected",
+    [
+        ("1d20", 19, CRIT_HIT_FLAVOUR),
+        ("1d20", 0, CRIT_FAIL_FLAVOUR),
+        ("1d20", 9, None),
+        ("1d20+5", 19, CRIT_HIT_FLAVOUR),
+        ("2d20", 19, None),
+        ("1d6", 5, None),
+    ],
+)
+@mock.patch("random.randrange")
+def test_crit_flavour(randrange, expression, randrange_val, expected):
+    randrange.return_value = randrange_val
+    result = d20.roll(expression)
+    assert Dice._crit_flavour(result.expr) == expected

--- a/tests/cogs/games/dice_test.py
+++ b/tests/cogs/games/dice_test.py
@@ -35,3 +35,51 @@ async def test_roll_sends_result(roller, context):
     clazz = Dice()
     await clazz.roll(context, "1d20")
     context.send.assert_called_once_with("**Rolls**: results\n**Total**: 1")
+
+
+@mock.patch("random.randrange", return_value=19)  # randrange(20) + 1 == 20
+async def test_roll_natural_20_shows_crit_hit(randrange, context):
+    clazz = Dice()
+    await clazz.roll(context, "1d20")
+    sent = context.send.call_args[0][0]
+    assert ":dart: **Critical hit!**" in sent
+
+
+@mock.patch("random.randrange", return_value=0)  # randrange(20) + 1 == 1
+async def test_roll_natural_1_shows_crit_fail(randrange, context):
+    clazz = Dice()
+    await clazz.roll(context, "1d20")
+    sent = context.send.call_args[0][0]
+    assert ":skull: **Critical fail!**" in sent
+
+
+@mock.patch("random.randrange", return_value=9)  # 10
+async def test_roll_middle_value_has_no_flavour(randrange, context):
+    clazz = Dice()
+    await clazz.roll(context, "1d20")
+    sent = context.send.call_args[0][0]
+    assert "Critical" not in sent
+
+
+@mock.patch("random.randrange", return_value=19)
+async def test_roll_natural_20_with_modifier_still_crits(randrange, context):
+    clazz = Dice()
+    await clazz.roll(context, "1d20+5")
+    sent = context.send.call_args[0][0]
+    assert ":dart: **Critical hit!**" in sent
+
+
+@mock.patch("random.randrange", return_value=19)
+async def test_roll_2d20_does_not_crit_even_with_20(randrange, context):
+    clazz = Dice()
+    await clazz.roll(context, "2d20")
+    sent = context.send.call_args[0][0]
+    assert "Critical" not in sent
+
+
+@mock.patch("random.randrange", return_value=19)
+async def test_roll_d6_does_not_crit(randrange, context):
+    clazz = Dice()
+    await clazz.roll(context, "1d6")
+    sent = context.send.call_args[0][0]
+    assert "Critical" not in sent


### PR DESCRIPTION
Adds critical hit/fail flavour text to `!roll` when a single `1d20` rolls a natural 20 or 1.

Does not conflict with the natural 20 advantage/disadvantage mechanic — that feature would apply before the roll, while this only reads the final rolled value.

Closes #196

---

Will test locally to confirm the flavour text appears correctly in Discord before merging.