### PR TITLE
feat: add advantage/disadvantage keywords to !roll

### DIFF
--- a/duckbot/cogs/games/dice.py
+++ b/duckbot/cogs/games/dice.py
@@ -1,18 +1,29 @@
+import re
+
 import d20
 from discord.ext import commands
 
 from duckbot.util.messages import MAX_MESSAGE_LENGTH
+
+ADVANTAGE_REPLACEMENTS = {
+    "adv": "2d20kh1",
+    "advantage": "2d20kh1",
+    "dis": "2d20kl1",
+    "disadvantage": "2d20kl1",
+}
+ADVANTAGE_PATTERN = re.compile(r"^\s*(advantage|adv|disadvantage|dis)\b", re.IGNORECASE)
 
 
 class Dice(commands.Cog):
     @commands.hybrid_command(name="roll", aliases=["r"], description="Roll some Dungeons & Dragons style dice!")
     async def roll_command(self, context: commands.Context, *, expression: str = "1d20"):
         """
-        :param expression: The number and type of dice to roll. Default is 1d20
+        :param expression: The number and type of dice to roll. Default is 1d20. Use `adv` or `dis` for advantage/disadvantage.
         """
         await self.roll(context, expression)
 
     async def roll(self, context: commands.Context, expression: str):
+        expression = self._resolve_advantage(expression)
         max_length = MAX_MESSAGE_LENGTH - 50  # max-50 as a buffer for the added text
         try:
             roller = self.make_roller(100_000)
@@ -26,6 +37,11 @@ class Dice(commands.Cog):
 
     def make_roller(self, max_rolls: int):
         return d20.Roller(d20.RollContext(max_rolls))
+
+    @staticmethod
+    def _resolve_advantage(expression: str) -> str:
+        """Replaces a leading `adv`/`advantage`/`dis`/`disadvantage` keyword with the equivalent dice expression."""
+        return ADVANTAGE_PATTERN.sub(lambda m: ADVANTAGE_REPLACEMENTS[m.group(1).lower()], expression, count=1)
 
 
 class DiceStringifier(d20.MarkdownStringifier):

--- a/tests/cogs/games/dice_test.py
+++ b/tests/cogs/games/dice_test.py
@@ -1,6 +1,7 @@
 from unittest import mock
 
 import d20
+import pytest
 
 from duckbot.cogs.games import Dice
 from duckbot.util.messages import MAX_MESSAGE_LENGTH
@@ -35,3 +36,47 @@ async def test_roll_sends_result(roller, context):
     clazz = Dice()
     await clazz.roll(context, "1d20")
     context.send.assert_called_once_with("**Rolls**: results\n**Total**: 1")
+
+
+@pytest.mark.parametrize(
+    "expression,expected",
+    [
+        ("adv", "2d20kh1"),
+        ("advantage", "2d20kh1"),
+        ("dis", "2d20kl1"),
+        ("disadvantage", "2d20kl1"),
+        ("ADV", "2d20kh1"),
+        ("Dis", "2d20kl1"),
+        ("adv+5", "2d20kh1+5"),
+        ("adv +5", "2d20kh1 +5"),
+        ("disadvantage-2", "2d20kl1-2"),
+        ("  adv  ", "2d20kh1  "),
+        ("advanced", "advanced"),
+        ("disable", "disable"),
+        ("1d20", "1d20"),
+        ("1d20+adv", "1d20+adv"),
+        ("", ""),
+    ],
+)
+def test_resolve_advantage(expression, expected):
+    assert Dice._resolve_advantage(expression) == expected
+
+
+@mock.patch("d20.Roller")
+async def test_roll_adv_passes_2d20kh1_to_roller(roller, context):
+    roller.return_value.roll.return_value.result = "x"
+    roller.return_value.roll.return_value.total = 1
+    clazz = Dice()
+    await clazz.roll(context, "adv")
+    rolled_expression = roller.return_value.roll.call_args[0][0]
+    assert rolled_expression == "2d20kh1"
+
+
+@mock.patch("d20.Roller")
+async def test_roll_dis_with_modifier_passes_2d20kl1_plus_modifier(roller, context):
+    roller.return_value.roll.return_value.result = "x"
+    roller.return_value.roll.return_value.total = 1
+    clazz = Dice()
+    await clazz.roll(context, "dis+3")
+    rolled_expression = roller.return_value.roll.call_args[0][0]
+    assert rolled_expression == "2d20kl1+3"


### PR DESCRIPTION
## Summary

- `!roll adv` / `/roll adv` → `2d20kh1` (advantage). Aliases: `advantage`.
- `!roll dis` / `/roll dis` → `2d20kl1` (disadvantage). Aliases: `disadvantage`.
- Modifiers follow naturally: `!roll adv+5` → `2d20kh1+5`, `!roll dis-2` → `2d20kl1-2`.
- Case-insensitive; only matches at the start of the expression with a word boundary so things like `advanced` or `1d20+adv` are left alone.

No conflict with #1332 (crit hit/fail flavour): `2d20kh1` / `2d20kl1` roll two d20s, so the "exactly one d20" guard in `_crit_flavour` naturally skips them. You won't get "Critical hit!" on an advantage roll, which matches D&D convention.

Closes #198.

## Test plan

- [x] `pytest tests/cogs/games/dice_test.py` — 39 passed (15 new parametrized + 2 e2e)
- [x] `black` / `isort` / `flake8` clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)