### PR TITLE
:sparkles: use Ontario subdivision for Canadian holidays

### DIFF
--- a/duckbot/cogs/announce_day/special_days.py
+++ b/duckbot/cogs/announce_day/special_days.py
@@ -2,7 +2,7 @@ import math
 from datetime import date, datetime
 
 import discord
-from dateutil.relativedelta import FR, MO, SU
+from dateutil.relativedelta import FR, SU
 from dateutil.relativedelta import relativedelta as rd
 from holidays.countries import CA
 
@@ -16,7 +16,7 @@ class SpecialDays(CA):
     """
 
     def __init__(self, bot):
-        CA.__init__(self)
+        CA.__init__(self, subdiv="ON")
         self.bot = bot
 
     def _populate(self, year):
@@ -28,7 +28,6 @@ class SpecialDays(CA):
         self[date(year, 1, 31)] = f"Erin and Taras' Anniversary. It's been {year-2010} entire years"
         self[date(year, 2, 2)] = "Groundhog Day"
         self[date(year, 2, 14)] = "Valentine's Day"
-        self[date(year, 2, 1) + rd(weekday=MO(+3))] = "Family Day"
         self[date(year, 3, 9)] = f"Lachlan's Birthday. He is {year-1989} years old. All hail this magnificent and unsurpassed achievement in longevity. Glory be unto him"
         self[date(year, 3, 14)] = f"Pi Day ({math.pi}). Celebrate by eating half of a pie"
         self[date(year, 3, 17)] = "St. Patrick's Day"

--- a/tests/cogs/announce_day/special_days_test.py
+++ b/tests/cogs/announce_day/special_days_test.py
@@ -49,3 +49,21 @@ def test_populate_duckbot_day(now, bot, time, seconds):
 def test_populate_family_day(bot, date):
     clazz = SpecialDays(bot)
     assert clazz.get_list(date) == ["Family Day"]
+
+
+@pytest.mark.parametrize("date", [datetime(2024, 5, 20), datetime(2025, 5, 19), datetime(2026, 5, 18)])
+def test_populate_victoria_day(bot, date):
+    clazz = SpecialDays(bot)
+    assert clazz.get_list(date) == ["Victoria Day"]
+
+
+@pytest.mark.parametrize("date", [datetime(2024, 10, 14), datetime(2025, 10, 13), datetime(2026, 10, 12)])
+def test_populate_thanksgiving_day(bot, date):
+    clazz = SpecialDays(bot)
+    assert clazz.get_list(date) == ["Thanksgiving Day"]
+
+
+@pytest.mark.parametrize("date", [datetime(2024, 12, 26), datetime(2025, 12, 26), datetime(2026, 12, 26)])
+def test_populate_boxing_day(bot, date):
+    clazz = SpecialDays(bot)
+    assert clazz.get_list(date) == ["Boxing Day"]


### PR DESCRIPTION
##### Summary

Pass `subdiv="ON"` to `holidays.CA` so we pick up the Ontario-specific stat days — Victoria Day, Thanksgiving Day, and Boxing Day — in addition to the federal ones we already get. The explicit Family Day entry is dropped since the `ON` subdivision already provides it (otherwise `holidays.append()` would concatenate and the announcement would read "Family Day and Family Day").

Tested by running the announce_day unit tests locally; pre-existing unrelated failures in other test modules were ignored.

##### Checklist

- [x] this is a source code change
  - [x] run `format` in the repository root
  - [x] run `pytest` in the repository root
  - [ ] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [ ] update the wiki documentation if necessary
- [ ] or, this is **not** a source code change