### PR TITLE
:sparkles: toggle `/satisfy maximize` on repeat invocations

### DIFF
--- a/duckbot/cogs/games/satisfy/satisfy.py
+++ b/duckbot/cogs/games/satisfy/satisfy.py
@@ -66,7 +66,7 @@ class Satisfy(Cog):
         self.save(context, factory)
         await context.send(embed=factory_embed(factory), delete_after=60)
 
-    @satisfy.command(name="maximize", description="Toggle whether to maximize output of the given item.")
+    @satisfy.command(name="maximize", description="Toggle maximizing output of the given item.")
     async def toggle_maximize(self, context: Context, item: str):
         factory = self.factory(context)
         if Item[item] in factory.maximize:

--- a/duckbot/cogs/games/satisfy/satisfy.py
+++ b/duckbot/cogs/games/satisfy/satisfy.py
@@ -66,10 +66,13 @@ class Satisfy(Cog):
         self.save(context, factory)
         await context.send(embed=factory_embed(factory), delete_after=60)
 
-    @satisfy.command(name="maximize", description="Specify maximize output of desired item.")
-    async def add_maximize(self, context: Context, item: str):
+    @satisfy.command(name="maximize", description="Toggle whether to maximize output of the given item.")
+    async def toggle_maximize(self, context: Context, item: str):
         factory = self.factory(context)
-        factory.maximize.add(Item[item])
+        if Item[item] in factory.maximize:
+            factory.maximize.discard(Item[item])
+        else:
+            factory.maximize.add(Item[item])
         self.save(context, factory)
         await context.send(embed=factory_embed(factory), delete_after=60)
 
@@ -152,7 +155,7 @@ class Satisfy(Cog):
 
     @add_input.autocomplete("item")
     @add_target.autocomplete("item")
-    @add_maximize.autocomplete("item")
+    @toggle_maximize.autocomplete("item")
     async def items(self, interaction: Interaction, current: str) -> List[Choice[str]]:
         return choices(item_names, current)
 
@@ -187,7 +190,7 @@ class Satisfy(Cog):
     @reset.error
     @add_input.error
     @add_target.error
-    @add_maximize.error
+    @toggle_maximize.error
     @add_booster.error
     @recipe_bank.error
     @include_recipe.error

--- a/tests/cogs/games/satisfy/satisfy_test.py
+++ b/tests/cogs/games/satisfy/satisfy_test.py
@@ -72,6 +72,15 @@ async def test_toggle_maximize_removes_already_maximized_item(clazz, context, de
     assert clazz.factory(context) == default_factory
 
 
+async def test_toggle_maximize_removes_toggled_only(clazz, context, default_factory):
+    await clazz.toggle_maximize.callback(clazz, context, str(Item.IronOre))
+    await clazz.toggle_maximize.callback(clazz, context, str(Item.IronIngot))
+    await clazz.toggle_maximize.callback(clazz, context, str(Item.CopperOre))
+    await clazz.toggle_maximize.callback(clazz, context, str(Item.IronIngot))
+    default_factory.maximize = {Item.IronOre, Item.CopperOre}
+    assert clazz.factory(context) == default_factory
+
+
 async def test_add_booster_power_shard(clazz, context, default_factory):
     await clazz.add_booster.callback(clazz, context, str(Item.PowerShard), 10)
     default_factory.power_shards = 10

--- a/tests/cogs/games/satisfy/satisfy_test.py
+++ b/tests/cogs/games/satisfy/satisfy_test.py
@@ -55,13 +55,20 @@ async def test_add_target_stores_output_rate(clazz, context, default_factory):
     assert clazz.factory(context) == default_factory
 
 
-async def test_add_maximize_stores_maximizer(clazz, context, default_factory):
-    await clazz.add_maximize.callback(clazz, context, str(Item.IronOre))
+async def test_toggle_maximize_stores_maximizer(clazz, context, default_factory):
+    await clazz.toggle_maximize.callback(clazz, context, str(Item.IronOre))
     default_factory.maximize = {Item.IronOre}
     assert clazz.factory(context) == default_factory
 
-    await clazz.add_maximize.callback(clazz, context, str(Item.IronIngot))
+    await clazz.toggle_maximize.callback(clazz, context, str(Item.IronIngot))
     default_factory.maximize = {Item.IronOre, Item.IronIngot}
+    assert clazz.factory(context) == default_factory
+
+
+async def test_toggle_maximize_removes_already_maximized_item(clazz, context, default_factory):
+    await clazz.toggle_maximize.callback(clazz, context, str(Item.IronOre))
+    await clazz.toggle_maximize.callback(clazz, context, str(Item.IronOre))
+    default_factory.maximize = set()
     assert clazz.factory(context) == default_factory
 
 

--- a/wiki/Commands.md
+++ b/wiki/Commands.md
@@ -189,7 +189,7 @@ Tells the solver to maximize output of the given item. Should only be used when 
 
 Maximization occurs by item weights, so it will _not_ behave as you expect when multiple items are maximized. The solver will pick the item with the better rate to weight ratio. It is recommended to maximize a single item only.
 
-There's no way to remove a maximize item, a full reset of the factory is required.
+Running `/satisfy maximize` again for an item that is already being maximized will remove it from the maximize set.
 
 ```
 /satisfy booster   item amount


### PR DESCRIPTION
##### Summary

Re-running `/satisfy maximize` on an item that is already in the factory's maximize set now removes it, instead of being a silent no-op (set semantics). This removes the need to `/satisfy reset` the entire factory just to drop a single maximize item. Renamed the handler from `add_maximize` to `toggle_maximize` to reflect the new behaviour; the slash command name is unchanged. Wiki docs updated to reflect the new behaviour (previously claimed a full reset was required).

Tested manually by running the new unit test; relied on CI for the full suite since my local env isn't fully set up.

##### Checklist

- [x] this is a source code change
  - [x] run `format` in the repository root
  - [x] run `pytest` in the repository root
  - [ ] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [x] update the wiki documentation if necessary
- [ ] or, this is **not** a source code change