### PR TITLE
:bug: close matplotlib figure after saving weather graph

### DIFF
--- a/duckbot/cogs/weather/weather.py
+++ b/duckbot/cogs/weather/weather.py
@@ -189,4 +189,5 @@ class Weather(commands.Cog):
         plt.setp(left_axis.get_xticklabels(), rotation=30, horizontalalignment="right")
         figure.tight_layout()
         plt.savefig("weather.png", facecolor="ghostwhite")
+        plt.close(figure)
         return "weather.png"


### PR DESCRIPTION
##### Summary

`Weather.weather_graph` calls `plt.subplots()` then `plt.savefig()` but never closes the figure. pyplot's global figure manager (`Gcf`) keeps the figure alive, so every `/weather` call leaked a `Figure` (with its axes, artists, and per-hour text labels) until the bot restarted. Add `plt.close(figure)` after `savefig`, matching the pattern already used in `duckbot/cogs/games/satisfy/graph.py`.

Reproduced the leak with a minimal script: looping `subplots()` + `savefig()` five times grows `len(plt.get_fignums())` from 1→5; adding `plt.close(fig)` keeps it at 0.

Also. `1337`

##### Checklist

- [x] this is a source code change
  - [ ] run `format` in the repository root
  - [ ] run `pytest` in the repository root
  - [ ] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [ ] update the wiki documentation if necessary
- [ ] or, this is **not** a source code change