### PR TITLE
:rotating_light: address mechanical SonarCloud issues

### DIFF
--- a/duckbot/cogs/corrections/typos.py
+++ b/duckbot/cogs/corrections/typos.py
@@ -22,7 +22,7 @@ class Typos(commands.Cog):
     async def get_previous_message(self, message: Message):
         # limit of 20 may be restricting, since it includes everyone's messages
         hist = [msg async for msg in message.channel.history(limit=20, before=message)]
-        by_same_author = list(x for x in hist if x.author.id == message.author.id)
+        by_same_author = [x for x in hist if x.author.id == message.author.id]
         if not by_same_author:
             return None
         else:

--- a/duckbot/cogs/games/satisfy/pretty.py
+++ b/duckbot/cogs/games/satisfy/pretty.py
@@ -133,4 +133,5 @@ def solution_summary(solution: dict[ModifiedRecipe, float]) -> SolutionSummary:
 
 
 def sum_by_item(lhs: Rates | dict[Item, float], rhs: Rates | dict[Item, float]) -> dict[Item, float]:
-    return {item: s for item in Item if (item in lhs or item in rhs) and not isclose(s := lhs.get(item, 0) + rhs.get(item, 0), 0, abs_tol=1e-4)}
+    pairs = [(item, lhs.get(item, 0) + rhs.get(item, 0)) for item in Item if (item in lhs or item in rhs)]
+    return {i: s for i, s in pairs if not isclose(s, 0, abs_tol=1e-4)}

--- a/duckbot/cogs/games/satisfy/pretty.py
+++ b/duckbot/cogs/games/satisfy/pretty.py
@@ -41,8 +41,8 @@ def factory_embed(factory: Factory) -> Embed:
 
     def group_recipes(names, limits={}):
         limits = {r.name: v for r, v in limits.items()}
-        names = names | {n for n in limits.keys()}
-        return sorted(list({n.split("#")[0] + (f" <= {rnd(limits.get(n))}" if n in limits else "") for n in names}))
+        names = names | set(limits)
+        return sorted({n.split("#")[0] + (f" <= {rnd(limits.get(n))}" if n in limits else "") for n in names})
 
     embed.add_field(name="Recipe Bank", value=factory.recipe_bank)
     embed.add_field(name="Recipe Includes", value="\n".join(group_recipes(factory.include_recipes)) if factory.include_recipes else "N/A")
@@ -97,7 +97,7 @@ def inout_str(inputs: Rates, outputs: Rates, scale_factor: float = 1.0) -> str:
 
 def build_consumption_map(solution: dict[ModifiedRecipe, float]) -> dict[Item, list[tuple[str, float]]]:
     flat = [(item, recipe.original_recipe.name, rate * count) for recipe, count in solution.items() for item, rate in recipe.inputs.items()]
-    items = set(item for item, _, _ in flat)
+    items = {item for item, _, _ in flat}
     return {item: [(name, amount) for i, name, amount in flat if i == item] for item in items}
 
 
@@ -105,7 +105,7 @@ def consumed_by_str(outputs: Rates, consumption_map: dict[Item, list[tuple[str, 
     consumers = [(name, amount) for item in outputs for name, amount in consumption_map.get(item, []) if name != current_recipe]
     if not consumers:
         return ""
-    names = set(name for name, _ in consumers)
+    names = {name for name, _ in consumers}
     grouped = {name: sum(amount for n, amount in consumers if n == name) for name in names}
     parts = [f"{name}: {rnd(amount)}" for name, amount in sorted(grouped.items())]
     return "-# consumed by: " + ", ".join(parts)
@@ -121,17 +121,16 @@ class SolutionSummary:
 
 def solution_summary(solution: dict[ModifiedRecipe, float]) -> SolutionSummary:
     raw_creation = [r.name for r in raw()]
-    inputs = reduce(sum_by_item, [r.inputs * -v for r, v in solution.items()], dict())
-    outputs = reduce(sum_by_item, [r.outputs * v for r, v in solution.items() if r.original_recipe.name not in raw_creation], dict())
+    inputs = reduce(sum_by_item, [r.inputs * -v for r, v in solution.items()], {})
+    outputs = reduce(sum_by_item, [r.outputs * v for r, v in solution.items() if r.original_recipe.name not in raw_creation], {})
     totals = sum_by_item(inputs, outputs)
     return SolutionSummary(
-        inputs=Rates(dict((k, -v) for k, v in totals.items() if v < 0)),
-        outputs=Rates(dict((k, v) for k, v in totals.items() if v > 0)),
+        inputs=Rates({k: -v for k, v in totals.items() if v < 0}),
+        outputs=Rates({k: v for k, v in totals.items() if v > 0}),
         total_shards=sum([ceil(n) * r.power_shards for r, n in solution.items()]),
         total_sloops=sum([ceil(n) * r.sloops for r, n in solution.items()]),
     )
 
 
 def sum_by_item(lhs: Rates | dict[Item, float], rhs: Rates | dict[Item, float]) -> dict[Item, float]:
-    sum = [(item, lhs.get(item, 0) + rhs.get(item, 0)) for item in Item if (item in lhs or item in rhs)]
-    return dict((i, s) for i, s in sum if not isclose(s, 0, abs_tol=1e-4))
+    return {item: s for item in Item if (item in lhs or item in rhs) and not isclose(s := lhs.get(item, 0) + rhs.get(item, 0), 0, abs_tol=1e-4)}

--- a/duckbot/cogs/games/satisfy/rates.py
+++ b/duckbot/cogs/games/satisfy/rates.py
@@ -7,7 +7,7 @@ from .item import Item
 
 
 class Rates:
-    def __init__(self, rates: dict[Item, float] = dict()):
+    def __init__(self, rates: dict[Item, float] = {}):
         self.rates = dict(rates)
 
     def items(self):
@@ -28,7 +28,7 @@ class Rates:
     def singleton_rate(self) -> float:
         if len(self.rates) != 1:
             raise AssertionError(f"{self} is not a singleton")
-        return next(x for x in self.items())[1]
+        return next(iter(self.items()))[1]
 
     def __bool__(self) -> bool:
         return bool(self.rates)
@@ -37,7 +37,7 @@ class Rates:
         if not isinstance(rhs, Rates) or set(self.rates.keys()) != set(rhs.rates.keys()):
             return False
         else:
-            return all([isclose(l, rhs.rates[i]) for i, l in self.items()])
+            return all(isclose(l, rhs.rates[i]) for i, l in self.items())
 
     def __add__(self, rates: Rates) -> Rates:
         return Rates(self.rates | rates.rates)
@@ -46,7 +46,7 @@ class Rates:
         return (self, output)
 
     def __mul__(self, scale_factor: float) -> Rates:
-        return Rates(dict((i, r * scale_factor) for i, r in self.items()))
+        return Rates({i: r * scale_factor for i, r in self.items()})
 
     def __str__(self) -> str:
         return f"Rates({str(self.rates)})"

--- a/duckbot/cogs/games/satisfy/recipe.py
+++ b/duckbot/cogs/games/satisfy/recipe.py
@@ -459,19 +459,19 @@ def refine(name: str | Item, inout: tuple[Rates, Rates]) -> Recipe:
 
 
 def can(packaged: Item, inout: tuple[Rates, Rates]) -> Recipe:
-    return recipe(packaged, Building.Packager, inout[0] + Item.EmptyCanister * list(inout[1].rates.values())[0] >> inout[1])
+    return recipe(packaged, Building.Packager, inout[0] + Item.EmptyCanister * next(iter(inout[1].rates.values())) >> inout[1])
 
 
 def uncan(unpacked: Item, inout: tuple[Rates, Rates]) -> Recipe:
-    return recipe(f"Unpackage{unpacked}", Building.Packager, inout[0] >> inout[1] + Item.EmptyCanister * list(inout[0].rates.values())[0])
+    return recipe(f"Unpackage{unpacked}", Building.Packager, inout[0] >> inout[1] + Item.EmptyCanister * next(iter(inout[0].rates.values())))
 
 
 def tank(packaged: Item, inout: tuple[Rates, Rates]) -> Recipe:
-    return recipe(packaged, Building.Packager, inout[0] + Item.EmptyFluidTank * list(inout[1].rates.values())[0] >> inout[1])
+    return recipe(packaged, Building.Packager, inout[0] + Item.EmptyFluidTank * next(iter(inout[1].rates.values())) >> inout[1])
 
 
 def untank(unpacked: Item, inout: tuple[Rates, Rates]) -> Recipe:
-    return recipe(f"Unpackage{unpacked}", Building.Packager, inout[0] >> inout[1] + Item.EmptyFluidTank * list(inout[0].rates.values())[0])
+    return recipe(f"Unpackage{unpacked}", Building.Packager, inout[0] >> inout[1] + Item.EmptyFluidTank * next(iter(inout[0].rates.values())))
 
 
 def blend(name: str | Item, inout: tuple[Rates, Rates]) -> Recipe:

--- a/duckbot/cogs/games/satisfy/satisfy.py
+++ b/duckbot/cogs/games/satisfy/satisfy.py
@@ -139,7 +139,7 @@ class Satisfy(Cog):
                 bank = [x for r in recipe_banks[factory.recipe_bank] for x in as_slooped(r)]
                 recipes = [r for r in bank if r.name not in factory.exclude_recipes]
                 includes = [x for r in all() for x in as_slooped(r) if x.name in factory.include_recipes]
-                factory.recipes = {r for r in (recipes + includes)}
+                factory.recipes = set(recipes + includes)
                 solution = optimize(factory)
                 if solution is None:
                     await context.send("Why do you hate possible?", delete_after=60)

--- a/duckbot/cogs/games/satisfy/solver.py
+++ b/duckbot/cogs/games/satisfy/solver.py
@@ -31,7 +31,7 @@ def optimize(factory: Factory) -> Optional[dict[ModifiedRecipe, float]]:
         def regular_limit():
             if recipe.sloops > 0:
                 return factory.sloops / recipe.sloops
-            item, rate = next(x for x in recipe.outputs.items())
+            item, rate = next(iter(recipe.outputs.items()))
             if recipe.inputs == Rates() and item in map_limits:
                 return (map_limits[item] - factory.inputs.get(item, 0)) / rate
             else:
@@ -41,7 +41,7 @@ def optimize(factory: Factory) -> Optional[dict[ModifiedRecipe, float]]:
 
     use_recipe = [model.add_var(name=r.name, lb=0, ub=upper_bound(r)) for r in recipes]
     generate_raw = {i: next((x * r.outputs.singleton_rate() for r, x in zip(recipes, use_recipe) if r.original_recipe.name == str(i)), 0) for i in map_limits.keys()}
-    can_generate = set(i for i in map_limits.keys() if str(i) in [r.original_recipe.name for r in recipes])
+    can_generate = {i for i in map_limits.keys() if str(i) in [r.original_recipe.name for r in recipes]}
 
     amount_by_item = amount_by_item_expressions(factory, recipes, use_recipe)
     items_must_be_non_negative(model, amount_by_item)
@@ -85,12 +85,12 @@ def amount_by_item_expressions(factory: Factory, recipes: List[ModifiedRecipe], 
     """
 
     def cost(recipe: ModifiedRecipe, use: Var | LinExpr):
-        costs = dict((item, -use * rate) for item, rate in recipe.inputs.items())
-        income = dict((item, use * rate) for item, rate in recipe.outputs.items())
+        costs = {item: -use * rate for item, rate in recipe.inputs.items()}
+        income = {item: use * rate for item, rate in recipe.outputs.items()}
         return costs, income
 
     recipe_costs = [sum_by_item(*cost(r, v)) for r, v in zip(recipes, use_recipe)]
-    initial_conditions = sum_by_item(factory.inputs, dict((i, -r) for i, r in factory.targets.items()))
+    initial_conditions = sum_by_item(factory.inputs, {i: -r for i, r in factory.targets.items()})
     return reduce(sum_by_item, recipe_costs, initial_conditions)
 
 

--- a/duckbot/cogs/text/dictionary.py
+++ b/duckbot/cogs/text/dictionary.py
@@ -36,7 +36,7 @@ class Dictionary(commands.Cog):
         embed = discord.Embed(title=word)
         response = requests.get(f"{self.url}/entries/en-us/{word}", headers=self.headers).json()
         results = response.get("results", [])
-        categories = sorted(set(lex.get("lexicalCategory", {}).get("id", None) for r in results for lex in r.get("lexicalEntries", [])))
+        categories = sorted({lex.get("lexicalCategory", {}).get("id", None) for r in results for lex in r.get("lexicalEntries", [])})
         for category in categories:
             text, pronunciation, lines = self.category_group_data(word, category, results)
             embed.add_field(name=f"{category}: **{text}**  /{pronunciation}/", value="\n".join(lines), inline=False)

--- a/tests/cogs/games/discord_activity_test.py
+++ b/tests/cogs/games/discord_activity_test.py
@@ -11,7 +11,7 @@ async def test_before_loop_waits_for_bot(bot):
     bot.wait_until_ready.assert_called()
 
 
-async def test_cog_unload_cancels_task(bot):
+def test_cog_unload_cancels_task(bot):
     clazz = DiscordActivity(bot)
     clazz.cog_unload()
     clazz.change_activity_loop.cancel.assert_called()

--- a/tests/cogs/games/satisfy/item_test.py
+++ b/tests/cogs/games/satisfy/item_test.py
@@ -20,12 +20,12 @@ def test_repr_returns_enum_name(item: Item):
 @pytest.mark.parametrize("item", Item)
 def test_mul_returns_rates(item: Item):
     n = random.random()
-    assert item * n == Rates(dict([(item, n)]))
+    assert item * n == Rates({item: n})
 
 
 @pytest.mark.parametrize("item", Item)
 def test_lt_alphabetical_order_by_name(item: Item):
-    rhs = random.choice([x for x in Item])
+    rhs = random.choice(list(Item))
     assert (item < rhs) == (item.name < rhs.name)
 
 

--- a/tests/cogs/games/satisfy/rates_test.py
+++ b/tests/cogs/games/satisfy/rates_test.py
@@ -17,7 +17,7 @@ another_rate = rate
 
 
 def test_init_dict(rate, another_rate):
-    d = {rate[0]: rate[1], another_rate[0]: another_rate[1]}
+    d = dict([rate, another_rate])
     rates = Rates(d)
     assert rates.rates == d and rates.rates is not d
 
@@ -95,7 +95,7 @@ def test_repr_returns_dict_string(rate):
 
 
 def test_add_returns_combined_rates(rate, another_rate):
-    assert to_rates(rate) + to_rates(another_rate) == Rates({rate[0]: rate[1], another_rate[0]: another_rate[1]})
+    assert to_rates(rate) + to_rates(another_rate) == Rates(dict([rate, another_rate]))
 
 
 def test_rshift_creates_rates_output(rate, another_rate):

--- a/tests/cogs/games/satisfy/rates_test.py
+++ b/tests/cogs/games/satisfy/rates_test.py
@@ -17,7 +17,7 @@ another_rate = rate
 
 
 def test_init_dict(rate, another_rate):
-    d = dict([rate, another_rate])
+    d = {rate[0]: rate[1], another_rate[0]: another_rate[1]}
     rates = Rates(d)
     assert rates.rates == d and rates.rates is not d
 
@@ -95,7 +95,7 @@ def test_repr_returns_dict_string(rate):
 
 
 def test_add_returns_combined_rates(rate, another_rate):
-    assert to_rates(rate) + to_rates(another_rate) == Rates(dict([rate, another_rate]))
+    assert to_rates(rate) + to_rates(another_rate) == Rates({rate[0]: rate[1], another_rate[0]: another_rate[1]})
 
 
 def test_rshift_creates_rates_output(rate, another_rate):

--- a/tests/cogs/games/satisfy/satisfy_test.py
+++ b/tests/cogs/games/satisfy/satisfy_test.py
@@ -206,7 +206,7 @@ async def test_solve_no_in_or_out(clazz, context, default_factory):
     context.send.assert_called_once_with("No.", delete_after=60)
 
 
-@mock.patch("duckbot.cogs.games.satisfy.satisfy.optimize", return_value=dict())
+@mock.patch("duckbot.cogs.games.satisfy.satisfy.optimize", return_value={})
 async def test_solve_all_defaults(opt, clazz, context, default_factory):
     default_factory.inputs = Item.IronOre * 30
     default_factory.maximize = {Item.IronOre}
@@ -218,7 +218,7 @@ async def test_solve_all_defaults(opt, clazz, context, default_factory):
     opt.assert_called_once_with(expected)
 
 
-@mock.patch("duckbot.cogs.games.satisfy.satisfy.optimize", return_value=dict())
+@mock.patch("duckbot.cogs.games.satisfy.satisfy.optimize", return_value={})
 async def test_solve_different_recipe_bank(opt, clazz, context, default_factory):
     default_factory.inputs = Item.IronOre * 30
     default_factory.maximize = {Item.IronOre}
@@ -231,7 +231,7 @@ async def test_solve_different_recipe_bank(opt, clazz, context, default_factory)
     opt.assert_called_once_with(expected)
 
 
-@mock.patch("duckbot.cogs.games.satisfy.satisfy.optimize", return_value=dict())
+@mock.patch("duckbot.cogs.games.satisfy.satisfy.optimize", return_value={})
 async def test_solve_recipe_includes(opt, clazz, context, default_factory):
     default_factory.inputs = Item.IronOre * 30
     default_factory.maximize = {Item.IronOre}
@@ -245,7 +245,7 @@ async def test_solve_recipe_includes(opt, clazz, context, default_factory):
     opt.assert_called_once_with(expected)
 
 
-@mock.patch("duckbot.cogs.games.satisfy.satisfy.optimize", return_value=dict())
+@mock.patch("duckbot.cogs.games.satisfy.satisfy.optimize", return_value={})
 async def test_solve_recipe_excludes(opt, clazz, context, default_factory):
     default_factory.inputs = Item.IronOre * 30
     default_factory.maximize = {Item.IronOre}

--- a/tests/cogs/games/satisfy/solver_test.py
+++ b/tests/cogs/games/satisfy/solver_test.py
@@ -30,12 +30,12 @@ def factory(*, input: Rates, target: Rates = Rates(), maximize: Set[Item] = set(
 
 
 def test_optimize_empty_factory_returns_empty():
-    assert optimize(factory(input=Rates())) == dict()
+    assert optimize(factory(input=Rates())) == {}
 
 
 def test_optimize_trivial_factory_returns_empty():
     rates = Item.IronOre * 30
-    assert optimize(factory(input=rates, target=rates)) == dict()
+    assert optimize(factory(input=rates, target=rates)) == {}
 
 
 def test_optimize_infeasible_returns_none():
@@ -46,47 +46,47 @@ def test_optimize_infeasible_returns_none():
 def test_optimize_simple_factory_target_returns_recipe():
     f = factory(input=Item.IronOre * 30, target=Item.IronIngot * 30, recipes=default_with_raw)
     recipe = recipe_by_name("IronIngot")
-    assert optimize(f) == dict([(recipe, approx(1))])
+    assert optimize(f) == {recipe: approx(1)}
 
 
 def test_optimize_simple_factory_maximize_returns_recipe():
-    f = factory(input=Item.IronOre * 30, maximize=set([Item.IronIngot]), recipes=default_no_raw)
+    f = factory(input=Item.IronOre * 30, maximize={Item.IronIngot}, recipes=default_no_raw)
     recipe = recipe_by_name("IronIngot")
-    assert optimize(f) == dict([(recipe, approx(1))])
+    assert optimize(f) == {recipe: approx(1)}
 
 
 def test_optimize_simple_sloop_target_returns_recipe():
     f = factory(input=Item.IronOre * 30, target=Item.IronIngot * 60, sloops=1, recipes=default_no_raw)
     recipe = recipe_by_name("IronIngot", sloops=1)
-    assert optimize(f) == dict([(recipe, approx(1))])
+    assert optimize(f) == {recipe: approx(1)}
 
 
 def test_optimize_simple_sloop_maximize_returns_recipe():
-    f = factory(input=Item.IronOre * 30, maximize=set([Item.IronIngot]), sloops=1, recipes=default_no_raw)
+    f = factory(input=Item.IronOre * 30, maximize={Item.IronIngot}, sloops=1, recipes=default_no_raw)
     recipe = recipe_by_name("IronIngot", sloops=1)
-    assert optimize(f) == dict([(recipe, approx(1))])
+    assert optimize(f) == {recipe: approx(1)}
 
 
 def test_optimize_limit_recipe():
-    f = factory(input=Item.IronOre * 30 + Item.Water * 1000, maximize=set([Item.IronIngot]), recipes=all_no_raw, limits={recipe_by_name("PureIronIngot"): 0.5})
+    f = factory(input=Item.IronOre * 30 + Item.Water * 1000, maximize={Item.IronIngot}, recipes=all_no_raw, limits={recipe_by_name("PureIronIngot"): 0.5})
     pure = recipe_by_name("PureIronIngot")
     smelt = recipe_by_name("IronIngot")
-    assert optimize(f) == dict([(pure, approx(0.5)), (smelt, approx(0.41666))])
+    assert optimize(f) == {pure: approx(0.5), smelt: approx(0.41666)}
 
 
 def test_optimize_limit_boosted_recipe():
-    f = factory(input=Item.IronOre * 30 + Item.Water * 1000, maximize=set([Item.IronIngot]), recipes=default_no_raw, limits={recipe_by_name("PureIronIngot", 1, 2): 0.5}, power_shards=10, sloops=2)
+    f = factory(input=Item.IronOre * 30 + Item.Water * 1000, maximize={Item.IronIngot}, recipes=default_no_raw, limits={recipe_by_name("PureIronIngot", 1, 2): 0.5}, power_shards=10, sloops=2)
     pure = recipe_by_name("PureIronIngot")
     pure_slooped = recipe_by_name("PureIronIngot", 1, 2)
     f.recipes = f.recipes + [pure, pure_slooped]  # exclude other pure irons so it's forced to use unslooped
-    assert optimize(f) == dict([(pure_slooped, approx(0.5)), (pure, approx(3.75 / 35))])
+    assert optimize(f) == {pure_slooped: approx(0.5), pure: approx(3.75 / 35)}
 
 
 def test_optimize_create_resources_returns_target():
     f = factory(input=Rates(), target=Item.IronIngot * 30, recipes=default_with_raw)
     ore = recipe_by_name("IronOre")
     ingot = recipe_by_name("IronIngot")
-    assert optimize(f) == dict([(ore, approx(0.5)), (ingot, approx(1))])
+    assert optimize(f) == {ore: approx(0.5), ingot: approx(1)}
 
 
 def test_optimize_create_resources_minimal_inputs_used():
@@ -96,15 +96,13 @@ def test_optimize_create_resources_minimal_inputs_used():
     wire = recipe_by_name("IronWire")
     plate = recipe_by_name("IronPlate")
     super_plate = recipe_by_name("StitchedIronPlate")
-    assert optimize(f) == dict(
-        [
-            (ore, approx(48.958 / 60.0)),
-            (ingot, approx(48.958 / 30.0)),
-            (wire, approx(1.0 + 2.0 / 3.0)),
-            (plate, approx(18.75 / 20.0)),
-            (super_plate, approx(1)),
-        ]
-    )
+    assert optimize(f) == {
+        ore: approx(48.958 / 60.0),
+        ingot: approx(48.958 / 30.0),
+        wire: approx(1.0 + 2.0 / 3.0),
+        plate: approx(18.75 / 20.0),
+        super_plate: approx(1),
+    }
 
 
 def test_optimize_create_resources_with_inputs_minimizes_inputs_used():
@@ -112,13 +110,11 @@ def test_optimize_create_resources_with_inputs_minimizes_inputs_used():
     ore = recipe_by_name(Item.IronOre)
     ingot = recipe_by_name(Item.IronIngot)
     plate = recipe_by_name(Item.IronPlate)
-    assert optimize(f) == dict(
-        [
-            (ore, approx(30.0 / 60.0)),
-            (ingot, approx(1.0)),
-            (plate, approx(2.0)),
-        ]
-    )
+    assert optimize(f) == {
+        ore: approx(30.0 / 60.0),
+        ingot: approx(1.0),
+        plate: approx(2.0),
+    }
 
 
 def test_optimize_create_resources_with_inputs_issue_995():
@@ -143,74 +139,70 @@ def test_optimize_create_cheap_resources_with_inputs():
 
 
 def test_optimize_maximize_oversupplied_minimizes_inputs_used():
-    f = factory(input=Item.Coal * 120 + Item.IronOre * 120 + Item.Limestone * 270, maximize=set([Item.EncasedIndustrialBeam]), recipes=all_no_raw)
+    f = factory(input=Item.Coal * 120 + Item.IronOre * 120 + Item.Limestone * 270, maximize={Item.EncasedIndustrialBeam}, recipes=all_no_raw)
     ingot = recipe_by_name("IronIngot")
     steel = recipe_by_name("SolidSteelIngot")
     concrete = recipe_by_name("Concrete")
     pipe = recipe_by_name("SteelPipe")
     butter = recipe_by_name("EncasedIndustrialPipe")
-    assert optimize(f) == dict(
-        [
-            (concrete, approx(6)),
-            (ingot, approx(3.6)),
-            (pipe, approx(5.4)),
-            (butter, approx(4.5)),
-            (steel, approx(2.7)),
-        ]
-    )
+    assert optimize(f) == {
+        concrete: approx(6),
+        ingot: approx(3.6),
+        pipe: approx(5.4),
+        butter: approx(4.5),
+        steel: approx(2.7),
+    }
 
 
 def test_optimize_two_step_returns_chain():
-    f = factory(input=Item.IronOre * 30, maximize=set([Item.IronPlate]), recipes=default_no_raw)
+    f = factory(input=Item.IronOre * 30, maximize={Item.IronPlate}, recipes=default_no_raw)
     ignot = recipe_by_name("IronIngot")
     plate = recipe_by_name("IronPlate")
-    assert optimize(f) == dict([(ignot, approx(1)), (plate, approx(1))])
+    assert optimize(f) == {ignot: approx(1), plate: approx(1)}
 
 
 def test_optimize_two_step_single_sloop_returns_chain():
-    f = factory(input=Item.IronOre * 30, maximize=set([Item.IronPlate]), sloops=1, recipes=default_no_raw)
+    f = factory(input=Item.IronOre * 30, maximize={Item.IronPlate}, sloops=1, recipes=default_no_raw)
     ignot = recipe_by_name("IronIngot")
     plate = recipe_by_name("IronPlate", sloops=1)
-    assert optimize(f) == dict([(ignot, approx(1)), (plate, approx(1))])
+    assert optimize(f) == {ignot: approx(1), plate: approx(1)}
 
 
 def test_optimize_two_step_many_sloop_returns_chain():
-    f = factory(input=Item.IronOre * 30, maximize=set([Item.IronPlate]), sloops=10, recipes=default_no_raw)
+    f = factory(input=Item.IronOre * 30, maximize={Item.IronPlate}, sloops=10, recipes=default_no_raw)
     ignot = recipe_by_name("IronIngot", sloops=1)
     plate = recipe_by_name("IronPlate", sloops=1)
-    assert optimize(f) == dict([(ignot, approx(1)), (plate, approx(2))])
+    assert optimize(f) == {ignot: approx(1), plate: approx(2)}
 
 
 def test_optimize_two_step_many_sloop_and_power_shards_returns_chain():
-    f = factory(input=Item.IronOre * 30, maximize=set([Item.IronPlate]), sloops=10, power_shards=10, recipes=default_no_raw)
+    f = factory(input=Item.IronOre * 30, maximize={Item.IronPlate}, sloops=10, power_shards=10, recipes=default_no_raw)
     ignot = recipe_by_name("IronIngot", sloops=1)
     plate = recipe_by_name("IronPlate", sloops=1, power_shards=2)
-    assert optimize(f) == dict([(ignot, approx(1)), (plate, approx(1))])
+    assert optimize(f) == {ignot: approx(1), plate: approx(1)}
 
 
 def test_optimize_fluid_excess_is_made_sinkable():
     f = factory(input=Item.CrudeOil * 30, target=Item.Plastic * 20, recipes=default_with_raw)
     plastic = recipe_by_name("Plastic")
     coke = recipe_by_name("PetroleumCoke")
-    assert optimize(f) == dict([(plastic, approx(1)), (coke, approx(0.25))])
+    assert optimize(f) == {plastic: approx(1), coke: approx(0.25)}
 
 
 def test_optimize_raw_resources_are_bound_by_map_limits():
-    f = factory(input=Rates(), maximize=set([Item.IronOre]), recipes=all())
+    f = factory(input=Rates(), maximize={Item.IronOre}, recipes=all())
     ore = recipe_by_name("IronOre")
     lime = recipe_by_name("Limestone")
     sam = recipe_by_name("Sam")
     reanimate = recipe_by_name("ReanimatedSam")
     convert = recipe_by_name("IronOre#Limestone")
-    assert optimize(f) == dict(
-        [
-            (ore, approx(92_100.0 / 60.0)),
-            (lime, approx(61_200.0 / 60.0)),
-            (sam, approx(10_200.0 / 60.0)),
-            (reanimate, approx(85)),
-            (convert, approx(255)),
-        ]
-    )
+    assert optimize(f) == {
+        ore: approx(92_100.0 / 60.0),
+        lime: approx(61_200.0 / 60.0),
+        sam: approx(10_200.0 / 60.0),
+        reanimate: approx(85),
+        convert: approx(255),
+    }
 
 
 def test_optimize_recycled_bois_returns_chain():
@@ -222,17 +214,15 @@ def test_optimize_recycled_bois_returns_chain():
     residual = recipe_by_name("ResidualRubber")
     plastic = recipe_by_name("RecycledPlastic")
     rubber = recipe_by_name("RecycledRubber")
-    assert optimize(f) == dict(
-        [
-            (goo, approx(0.9)),
-            (dilute, approx(1.2)),
-            (wudder, approx(1.2)),
-            (fuel, approx(1.2)),
-            (residual, approx(0.45)),
-            (plastic, approx(1.7)),
-            (rubber, approx(0.7)),
-        ]
-    )
+    assert optimize(f) == {
+        goo: approx(0.9),
+        dilute: approx(1.2),
+        wudder: approx(1.2),
+        fuel: approx(1.2),
+        residual: approx(0.45),
+        plastic: approx(1.7),
+        rubber: approx(0.7),
+    }
 
 
 def test_optimize_heavy_modular_frame_returns_chain():
@@ -248,21 +238,19 @@ def test_optimize_heavy_modular_frame_returns_chain():
     steel_pipe = recipe_by_name("SteelPipe")
     steel_rod = recipe_by_name("SteelRod")
     stitched_iron_plate = recipe_by_name("StitchedIronPlate")
-    assert optimize(f) == dict(
-        [
-            (concrete, approx(3.2)),
-            (encased_industrial_pipe, approx(1.6667)),
-            (heavy_encased_frame, approx(0.7111)),
-            (iron_ingot, approx(3.7926)),
-            (iron_wire, approx(2.3704)),
-            (modular_frame, approx(2.6667)),
-            (solid_steel_ingot, approx(1.8815)),
-            (steel_cast_plate, approx(0.5926)),
-            (steel_pipe, approx(3.2)),
-            (steel_rod, approx(0.6667)),
-            (stitched_iron_plate, approx(1.4222)),
-        ]
-    )
+    assert optimize(f) == {
+        concrete: approx(3.2),
+        encased_industrial_pipe: approx(1.6667),
+        heavy_encased_frame: approx(0.7111),
+        iron_ingot: approx(3.7926),
+        iron_wire: approx(2.3704),
+        modular_frame: approx(2.6667),
+        solid_steel_ingot: approx(1.8815),
+        steel_cast_plate: approx(0.5926),
+        steel_pipe: approx(3.2),
+        steel_rod: approx(0.6667),
+        stitched_iron_plate: approx(1.4222),
+    }
 
 
 def recipe_by_name(name: str | Item, power_shards: int = 0, sloops: int = 0) -> ModifiedRecipe:

--- a/tests/cogs/github/yolo_merge_test.py
+++ b/tests/cogs/github/yolo_merge_test.py
@@ -198,7 +198,7 @@ def check_suite(c) -> github.CheckSuite.CheckSuite:
 class MockPaginatedList(list):
     @property
     def reversed(self):
-        copy = [x for x in self]
+        copy = list(self)
         copy.reverse()
         return copy
 

--- a/tests/cogs/messages/touch_grass_test.py
+++ b/tests/cogs/messages/touch_grass_test.py
@@ -107,14 +107,14 @@ async def test_cooldown_expires_allows_new_notification(mock_utcnow, bot, messag
     clazz = TouchGrass(bot)
 
     # Send 40 messages at T=0 to trigger first notification
-    for i in range(40):
+    for _ in range(40):
         await clazz.track_activity(message)
 
     # 121 minutes later (cooldown expired and all old messages cleaned up)
     mock_utcnow.return_value = base_time + datetime.timedelta(minutes=121)
 
     # Send another 40 messages
-    for i in range(40):
+    for _ in range(40):
         await clazz.track_activity(message)
 
     # Should have notified twice
@@ -130,7 +130,7 @@ async def test_sliding_window_removes_old_messages(mock_utcnow, bot, message):
     clazz = TouchGrass(bot)
 
     # Send 20 messages at T=0
-    for i in range(20):
+    for _ in range(20):
         await clazz.track_activity(message)
 
     # 61 minutes later (outside window)
@@ -153,12 +153,12 @@ async def test_multiple_users_tracked_separately(mock_utcnow, bot, message):
 
     # User 1 sends 40 messages
     message.author.id = 12345
-    for i in range(40):
+    for _ in range(40):
         await clazz.track_activity(message)
 
     # User 2 sends 5 messages
     message.author.id = 67890
-    for i in range(5):
+    for _ in range(5):
         await clazz.track_activity(message)
 
     # User 1 should have 40 messages tracked
@@ -178,12 +178,12 @@ async def test_clean_old_messages_preserves_recent(mock_utcnow, bot, message):
     clazz = TouchGrass(bot)
 
     # Send 20 messages at T=0
-    for i in range(20):
+    for _ in range(20):
         await clazz.track_activity(message)
 
     # Send 20 messages at T=30min
     mock_utcnow.return_value = base_time + datetime.timedelta(minutes=30)
-    for i in range(20):
+    for _ in range(20):
         await clazz.track_activity(message)
 
     # At T=61min, clean up
@@ -291,11 +291,11 @@ async def test_show_activity_stats_with_activity(mock_utcnow, mock_get_user, bot
 
     # Simulate activity for two users
     message.author.id = 123
-    for i in range(5):
+    for _ in range(5):
         await clazz.track_activity(message)
 
     message.author.id = 456
-    for i in range(10):
+    for _ in range(10):
         await clazz.track_activity(message)
 
     def get_user_side_effect(bot, user_id, guild=None):
@@ -329,17 +329,17 @@ async def test_show_activity_stats_sorts_by_count(mock_utcnow, mock_get_user, bo
 
     # User 1: 3 messages
     message.author.id = 111
-    for i in range(3):
+    for _ in range(3):
         await clazz.track_activity(message)
 
     # User 2: 10 messages (most active)
     message.author.id = 222
-    for i in range(10):
+    for _ in range(10):
         await clazz.track_activity(message)
 
     # User 3: 5 messages
     message.author.id = 333
-    for i in range(5):
+    for _ in range(5):
         await clazz.track_activity(message)
 
     def get_user_side_effect(bot, user_id, guild=None):
@@ -375,7 +375,7 @@ async def test_show_activity_stats_excludes_old_messages(mock_utcnow, bot, conte
 
     # Send 10 messages at T=0
     message.author.id = 123
-    for i in range(10):
+    for _ in range(10):
         await clazz.track_activity(message)
 
     # Jump to 61 minutes later (old messages outside window)
@@ -400,7 +400,7 @@ async def test_show_activity_stats_unknown_user(mock_utcnow, mock_get_user, bot,
     clazz = TouchGrass(bot)
 
     message.author.id = 999
-    for i in range(5):
+    for _ in range(5):
         await clazz.track_activity(message)
 
     await clazz.show_activity_stats(context)
@@ -477,7 +477,7 @@ async def test_off_hours_40_messages_no_notification(mock_utcnow, bot, message):
 
     clazz = TouchGrass(bot)
 
-    for i in range(40):
+    for _ in range(40):
         await clazz.track_activity(message)
 
     message.channel.send.assert_not_called()
@@ -493,7 +493,7 @@ async def test_leaderboard_unaffected_by_time_of_day(mock_utcnow, mock_get_user,
 
     # Send 10 messages on a Saturday (well below 120 threshold)
     message.author.id = 123
-    for i in range(10):
+    for _ in range(10):
         await clazz.track_activity(message)
 
     user = mock.Mock()


### PR DESCRIPTION
##### Summary

Idiomatic-Python sweep that closes roughly 75 of the 82 open issues on [SonarCloud](https://sonarcloud.io/project/issues?issueStatuses=OPEN&id=duck-dynasty_duckbot). Mechanical changes only — no behavior changes.

Rules addressed:
- **S7494 / S7496 / S7498 / S7500** — collection construction: `dict()` / `set()` / `list()` constructor calls with literals or generator expressions replaced by literals and comprehensions
- **S8519** — `list(...)[0]` → `next(iter(...))` in the four packager helpers in `recipe.py`
- **S7508** — drop redundant `list()` inside `sorted()` in `pretty.py`
- **S7492** — unpack list comprehension in `Rates.__eq__`
- **S5806** — rename shadowing `sum` local in `pretty.sum_by_item`
- **S1481** — `for i in range(...)` → `for _ in range(...)` for unused indices in `touch_grass_test.py`
- **S7503** — drop unused `async` on `test_cog_unload_cancels_task`

##### Checklist

- [x] this is a source code change
  - [x] run `format` in the repository root
  - [x] run `pytest` in the repository root — 2890 passed, 30 skipped; one solver test crashed with a pre-existing CBC SIGILL (reproduces on main, unrelated to this change)
  - [ ] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [ ] update the wiki documentation if necessary
- [ ] or, this is **not** a source code change