### PR TITLE
:white_check_mark: add `solution_embed` tests

### DIFF
--- a/tests/cogs/games/satisfy/pretty_test.py
+++ b/tests/cogs/games/satisfy/pretty_test.py
@@ -1,0 +1,37 @@
+from unittest import mock
+
+from discord import Embed
+
+from duckbot.cogs.games.satisfy.pretty import solution_embed
+from duckbot.cogs.games.satisfy.recipe import ModifiedRecipe, all
+
+
+def recipe_by_name(name: str, power_shards: int = 0, sloops: int = 0) -> ModifiedRecipe:
+    return ModifiedRecipe(next(r for r in all() if r.name == name), power_shards, sloops)
+
+
+def test_solution_embed_renders_consumed_by_for_chained_recipes():
+    ingot = recipe_by_name("IronIngot")
+    plate = recipe_by_name("IronPlate")
+    result = solution_embed({ingot: 1.0, plate: 1.0})
+
+    expected = Embed()
+    expected.add_field(name="IronIngot", value="1.0 Smelter\n30.0 IronOre -> 30.0 IronIngot\n-# consumed by: IronPlate: 30.0", inline=False)
+    expected.add_field(name="IronPlate", value="1.0 Constructor\n30.0 IronIngot -> 20.0 IronPlate", inline=False)
+    expected.set_footer(text="30.0 IronOre -> 20.0 IronPlate")
+    assert result == [expected]
+
+
+# MAX_FIELDS shrunk to 1 so two recipes suffice; otherwise this test would need 26+ hand-written field literals.
+@mock.patch("duckbot.cogs.games.satisfy.pretty.MAX_FIELDS", 1)
+def test_solution_embed_splits_into_multiple_embeds_when_exceeding_max_fields():
+    ingot = recipe_by_name("IronIngot")
+    plate = recipe_by_name("IronPlate")
+    result = solution_embed({ingot: 1.0, plate: 1.0})
+
+    first = Embed()
+    first.add_field(name="IronIngot", value="1.0 Smelter\n30.0 IronOre -> 30.0 IronIngot\n-# consumed by: IronPlate: 30.0", inline=False)
+    second = Embed()
+    second.add_field(name="IronPlate", value="1.0 Constructor\n30.0 IronIngot -> 20.0 IronPlate", inline=False)
+    second.set_footer(text="30.0 IronOre -> 20.0 IronPlate")
+    assert result == [first, second]


### PR DESCRIPTION
##### Summary

Adds direct tests for `satisfy/pretty.py::solution_embed`, which had no dedicated test file. Two paths that previously had zero coverage:

- **`consumed_by_str` non-empty branch** (`pretty.py:108-111`) — exercised by passing a solution where one recipe's output feeds another, asserting full `Embed` equality on the rendered result.
- **`MAX_FIELDS` overflow / multi-embed split** (`pretty.py:62`) — exercised by patching `MAX_FIELDS` down to 1 so two real recipes suffice; asserts the result is two embeds with the footer set only on the last one. Patching the constant avoids hand-writing 26 field literals and a ~50-item summary footer in the test.

##### Checklist

- [x] this is a source code change
  - [x] run `format` in the repository root
  - [x] run `pytest` in the repository root
  - [ ] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [ ] update the wiki documentation if necessary
- [ ] or, this is **not** a source code change