### PR TITLE
:recycle: Replace Anthropic/Claude with Groq for fact-checking

### DIFF
--- a/.aws/app.py
+++ b/.aws/app.py
@@ -14,7 +14,7 @@ SECRETS = [
     Secret(environment_name="WOLFRAM_ALPHA_TOKEN", parameter_name="/duckbot/token/wolfram-alpha"),
     Secret(environment_name="OXFORD_DICTIONARY_ID", parameter_name="/duckbot/token/oxford-dictionary/id"),
     Secret(environment_name="OXFORD_DICTIONARY_KEY", parameter_name="/duckbot/token/oxford-dictionary/key"),
-    Secret(environment_name="ANTHROPIC_API_KEY", parameter_name="/duckbot/token/anthropic-api/key"),
+    Secret(environment_name="GROQ_API_KEY", parameter_name="/duckbot/token/groq-api/key"),
 ]
 
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,4 +103,4 @@ setup_nltk
 
 ## Environment Variables
 
-Only `DISCORD_TOKEN` is required. Other optional tokens: `OPENWEATHER_TOKEN`, `BOT_GITHUB_TOKEN`, `WOLFRAM_ALPHA_TOKEN`, `OXFORD_DICTIONARY_ID`, `OXFORD_DICTIONARY_KEY`, `ANTHROPIC_API_KEY`. These live in `duckbot/.env` (not committed).
+Only `DISCORD_TOKEN` is required. Other optional tokens: `OPENWEATHER_TOKEN`, `BOT_GITHUB_TOKEN`, `WOLFRAM_ALPHA_TOKEN`, `OXFORD_DICTIONARY_ID`, `OXFORD_DICTIONARY_KEY`, `GROQ_API_KEY`. These live in `duckbot/.env` (not committed).

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ BOT_GITHUB_TOKEN=somesecrettoken
 WOLFRAM_ALPHA_TOKEN=broitssecret
 OXFORD_DICTIONARY_ID=icanttellyou
 OXFORD_DICTIONARY_KEY=itsasecret
-ANTHROPIC_API_KEY=itsasecret
+GROQ_API_KEY=itsasecret
 ```
 
 - Discord tokens available from [Discord Developer](https://discord.com/developers/applications)
@@ -61,7 +61,7 @@ ANTHROPIC_API_KEY=itsasecret
 - The github token is a [personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token)
 - The wolfram alpha token is available from their [api page](https://products.wolframalpha.com/api/)
 - The oxford dictionary tokens are available from their [developer page](https://developer.oxforddictionaries.com/)
-- The Anthropic token can be generated for your personal account in the [settings page](https://console.anthropic.com/settings/keys)
+- The Groq token can be generated for your personal account in the [API keys page](https://console.groq.com/keys)
 
 You only _need_ the discord token. DuckBot will still function without the others, but features that use the tokens won't work. With your tokens available, you can jam them into your shell environment, so you can run DuckBot. You may want to put this into your bashrc for convenience.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       WOLFRAM_ALPHA_TOKEN: ${WOLFRAM_ALPHA_TOKEN}
       OXFORD_DICTIONARY_ID: ${OXFORD_DICTIONARY_ID}
       OXFORD_DICTIONARY_KEY: ${OXFORD_DICTIONARY_KEY}
-      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}
+      GROQ_API_KEY: ${GROQ_API_KEY}
     healthcheck:
       test: [CMD, python, -m, duckbot.health]
       interval: 30s

--- a/duckbot/cogs/ai/truth.py
+++ b/duckbot/cogs/ai/truth.py
@@ -1,7 +1,7 @@
 import os
 
-import anthropic
 import discord
+import groq
 from discord.ext import commands
 
 from duckbot.util.messages import get_message_reference, try_delete
@@ -52,7 +52,7 @@ class Truth(commands.Cog):
     @property
     def ai_client(self):
         if self._ai_client is None:
-            self._ai_client = anthropic.Anthropic(api_key=os.getenv("ANTHROPIC_API_KEY"))
+            self._ai_client = groq.Groq(api_key=os.getenv("GROQ_API_KEY"))
         return self._ai_client
 
     @commands.command(name="truth")
@@ -72,7 +72,7 @@ class Truth(commands.Cog):
             # Use the message's edited timestamp if it exists, otherwise use created timestamp
             message_date = message.edited_at if message.edited_at else message.created_at
             prompt = TRUTH_PROMPT.format(user_name=message.author.display_name, user_message=content, date=message_date.strftime("%B %d, %Y"))
-            message = self.ai_client.messages.create(model="claude-sonnet-4-20250514", max_tokens=1000, temperature=0, messages=[{"role": "user", "content": [{"type": "text", "text": prompt}]}])
-            return message.content[0].text
+            completion = self.ai_client.chat.completions.create(model="llama-3.3-70b-versatile", max_tokens=1000, temperature=0, messages=[{"role": "user", "content": prompt}])
+            return completion.choices[0].message.content
         except Exception as e:
             return f"The robot uprising has been postponed due to the following error: {e}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     "wolframalpha==5.1.3",
     "yfinance==1.4.1",
     "mip==1.17.6",
-    "anthropic==0.105.2",
+    "groq==1.4.0",
     "alembic==1.18.4",
 ]
 

--- a/tests/cogs/ai/test_truth.py
+++ b/tests/cogs/ai/test_truth.py
@@ -9,10 +9,10 @@ from duckbot.cogs.ai import Truth
 
 
 @pytest.fixture
-@mock.patch("anthropic.Anthropic")
-def mock_ai_client(mock_anthropic):
-    instance = mock_anthropic.return_value
-    instance.messages.create.return_value = mock.Mock(content=[mock.Mock(text="Fact-checked response.")])
+@mock.patch("groq.Groq")
+def mock_ai_client(mock_groq):
+    instance = mock_groq.return_value
+    instance.chat.completions.create.return_value = mock.Mock(choices=[mock.Mock(message=mock.Mock(content="Fact-checked response."))])
     return instance
 
 
@@ -65,7 +65,7 @@ async def mock_get_message_reference():
 
 
 def test_create_client(bot, monkeypatch):
-    monkeypatch.setenv("ANTHROPIC_API_KEY", "fake_key")
+    monkeypatch.setenv("GROQ_API_KEY", "fake_key")
     clazz = Truth(bot)
     assert clazz._ai_client is None
     assert clazz.ai_client == clazz._ai_client
@@ -83,7 +83,7 @@ async def test_fact_check_response(truth, message):
 
 
 async def test_fact_check_exception(truth, message):
-    truth.ai_client.messages.create.side_effect = Exception("we ran out of GPUs")
+    truth.ai_client.chat.completions.create.side_effect = Exception("we ran out of GPUs")
     response = await truth.fact_check(message)
     assert response == "The robot uprising has been postponed due to the following error: we ran out of GPUs"
 
@@ -122,6 +122,6 @@ async def test_fact_check_uses_edited_timestamp_when_available(truth):
     await truth.fact_check(message)
 
     # Verify the AI client was called with the edited date
-    call_args = truth.ai_client.messages.create.call_args
-    prompt_text = call_args.kwargs["messages"][0]["content"][0]["text"]
+    call_args = truth.ai_client.chat.completions.create.call_args
+    prompt_text = call_args.kwargs["messages"][0]["content"]
     assert "January 16, 2024" in prompt_text  # Should use edited date, not created date

--- a/wiki/Commands.md
+++ b/wiki/Commands.md
@@ -65,7 +65,7 @@ DuckBot can provide information about Pokémon, because that matters. The comman
 
 ## Truth
 
-DuckBot will use the power of AI to analyze claims in a referenced message and provides a formatted response indicating whether claims are confirmed, disputed, or unverified. Fact-checks are done by using Claude AI (via Anthropic's API).
+DuckBot will use the power of AI to analyze claims in a referenced message and provides a formatted response indicating whether claims are confirmed, disputed, or unverified. Fact-checks are done by using Llama (via Groq's API).
 
 Usage Instructions:
 


### PR DESCRIPTION
##### Summary

Resolves #1263 

Switch the Truth cog from the Anthropic SDK (claude-sonnet-4) to the Groq SDK (llama-3.3-70b-versatile). Update the dependency, tests, deployment secrets, and docs to use GROQ_API_KEY.

##### Checklist

- [x] this is a source code change
  - [x] run `format` in the repository root
  - [x] run `pytest` in the repository root
  - [x] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [x] update the wiki documentation if necessary
- [ ] or, this is **not** a source code change
