### PR TITLE
Issue 78

### DIFF
--- a/duckbot/cogs/corrections/__init__.py
+++ b/duckbot/cogs/corrections/__init__.py
@@ -3,7 +3,7 @@ from .bitcoin import Bitcoin
 from .kubernetes import Kubernetes
 from .tarlson import Tarlson
 from .typos import Typos
-
+from .timeout import Timeout
 
 async def setup(bot):
     await bot.add_cog(Bitcoin())
@@ -11,3 +11,4 @@ async def setup(bot):
     await bot.add_cog(Typos())
     await bot.add_cog(Bezos())
     await bot.add_cog(Tarlson())
+    await bot.add_cog(Timeout(bot))

--- a/duckbot/cogs/corrections/timeout.py
+++ b/duckbot/cogs/corrections/timeout.py
@@ -1,4 +1,5 @@
 import asyncio
+import datetime
 
 import discord
 from discord import Message
@@ -17,13 +18,15 @@ class Timeout(commands.Cog):
     @commands.Cog.listener("on_message")
     async def timeout_yellers(self, message: Message) -> None:
         """Give people a timeout for yelling too much."""
-        if not message.author.bot and self.is_yelling(message.content):
+        if not message.author.bot and isinstance(message.author, discord.Member) and self.is_yelling(message.content):
             await message.reply(f"That's too many yelling, {message.author.display_name}. Have a five minute timeout.")
-            # TODO: assign restricted role, wait, remove role, welcome back
+            await message.author.timeout(datetime.timedelta(seconds=TIMEOUT_SECONDS))
+            await asyncio.sleep(TIMEOUT_SECONDS)
+            await message.channel.send(f"Welcome back {message.author.display_name}! I hope you are more civil now.")
 
     def is_yelling(self, content: str) -> bool:
         """Returns True if the message is mostly uppercase."""
         letters = [c for c in content if c.isalpha()]
-        if len(letters) < 5:  # ignore very short messages
+        if len(letters) < 5:
             return False
         return sum(1 for c in letters if c.isupper()) / len(letters) >= YELLING_THRESHOLD

--- a/duckbot/cogs/corrections/timeout.py
+++ b/duckbot/cogs/corrections/timeout.py
@@ -1,0 +1,29 @@
+import asyncio
+
+import discord
+from discord import Message
+from discord.ext import commands
+
+from duckbot import DuckBot
+
+YELLING_THRESHOLD = 0.8  # 80% caps = yelling
+TIMEOUT_SECONDS = 300  # 5 minutes
+
+
+class Timeout(commands.Cog):
+    def __init__(self, bot: DuckBot) -> None:
+        self.bot = bot
+
+    @commands.Cog.listener("on_message")
+    async def timeout_yellers(self, message: Message) -> None:
+        """Give people a timeout for yelling too much."""
+        if not message.author.bot and self.is_yelling(message.content):
+            await message.reply(f"That's too many yelling, {message.author.display_name}. Have a five minute timeout.")
+            # TODO: assign restricted role, wait, remove role, welcome back
+
+    def is_yelling(self, content: str) -> bool:
+        """Returns True if the message is mostly uppercase."""
+        letters = [c for c in content if c.isalpha()]
+        if len(letters) < 5:  # ignore very short messages
+            return False
+        return sum(1 for c in letters if c.isupper()) / len(letters) >= YELLING_THRESHOLD

--- a/tests/cogs/corrections/timeout_test.py
+++ b/tests/cogs/corrections/timeout_test.py
@@ -1,0 +1,45 @@
+from unittest import mock
+from duckbot.cogs.corrections import Timeout
+
+
+async def test_timeout_bot_user(bot, bot_message):
+    bot_message.content = "HELLO THIS IS YELLING"
+    clazz = Timeout(bot)
+    await clazz.timeout_yellers(bot_message)
+    bot_message.reply.assert_not_called()
+
+
+async def test_timeout_short_message(bot, message):
+    message.content = "HI"
+    clazz = Timeout(bot)
+    await clazz.timeout_yellers(message)
+    message.reply.assert_not_called()
+
+
+async def test_timeout_lowercase_message(bot, message):
+    message.content = "hello this is not yelling"
+    clazz = Timeout(bot)
+    await clazz.timeout_yellers(message)
+    message.reply.assert_not_called()
+
+
+async def test_timeout_yelling_message(bot, message):
+    message.content = "HELLO THIS IS YELLING"
+    clazz = Timeout(bot)
+    await clazz.timeout_yellers(message)
+    message.reply.assert_called_once()
+
+
+async def test_is_yelling_all_caps(bot):
+    clazz = Timeout(bot)
+    assert clazz.is_yelling("HELLO THIS IS YELLING") is True
+
+
+async def test_is_yelling_lowercase(bot):
+    clazz = Timeout(bot)
+    assert clazz.is_yelling("hello this is not yelling") is False
+
+
+async def test_is_yelling_short_message(bot):
+    clazz = Timeout(bot)
+    assert clazz.is_yelling("HI") is False

--- a/tests/cogs/corrections/timeout_test.py
+++ b/tests/cogs/corrections/timeout_test.py
@@ -1,6 +1,7 @@
 from unittest import mock
+import discord
 from duckbot.cogs.corrections import Timeout
-
+from duckbot.cogs.corrections.timeout import TIMEOUT_SECONDS
 
 async def test_timeout_bot_user(bot, bot_message):
     bot_message.content = "HELLO THIS IS YELLING"
@@ -23,12 +24,15 @@ async def test_timeout_lowercase_message(bot, message):
     message.reply.assert_not_called()
 
 
-async def test_timeout_yelling_message(bot, message):
+@mock.patch("duckbot.cogs.corrections.timeout.asyncio.sleep")
+async def test_timeout_yelling_message(sleep, bot, message):
     message.content = "HELLO THIS IS YELLING"
+    message.author = mock.MagicMock(spec=discord.Member)
+    message.author.bot = False
     clazz = Timeout(bot)
     await clazz.timeout_yellers(message)
     message.reply.assert_called_once()
-
+    sleep.assert_called_once_with(TIMEOUT_SECONDS)
 
 async def test_is_yelling_all_caps(bot):
     clazz = Timeout(bot)
@@ -43,3 +47,13 @@ async def test_is_yelling_lowercase(bot):
 async def test_is_yelling_short_message(bot):
     clazz = Timeout(bot)
     assert clazz.is_yelling("HI") is False
+
+@mock.patch("duckbot.cogs.corrections.timeout.asyncio.sleep")
+async def test_timeout_no_timeout_in_dm(sleep, bot, message):
+    message.content = "HELLO THIS IS YELLING"
+    message.author = mock.MagicMock(spec=discord.User)
+    message.author.bot = False
+    clazz = Timeout(bot)
+    await clazz.timeout_yellers(message)
+    message.reply.assert_not_called()
+    sleep.assert_not_called()


### PR DESCRIPTION
**Summary**

This adds a much-requested timeout feature for users who yell in the server. Currently, there is no automated way to discourage all-caps messages — DuckBot simply ignores them. This PR implements the behavior described in #78: when a user sends a message that is 80%+ uppercase letters, DuckBot warns them, applies Discord's native 5-minute member timeout, and welcomes them back afterward.

**Fixes #78**

**Example behavior:**

> `Human: GUYS I DID THE THING`
> `DuckBot: That's too many yelling, Human. Have a five minute timeout.`
> _* five minutes later_
> `DuckBot: Welcome back Human! I hope you are more civil now.`

**Test output:**

`2971 passed, 31 skipped`

**Checklist**

this is a source code change
- [x]  ran format in the repository root
- [x]  ran pytest in the repository root — 2971 passed, 31 skipped
- [x]  fixes #78
- [x]  wiki documentation not applicable for this change