### PR TITLE
:bug: order player account insert before its ledger entry

### DIFF
--- a/duckbot/cogs/playmarket/market.py
+++ b/duckbot/cogs/playmarket/market.py
@@ -253,6 +253,7 @@ class PlayMarket(commands.Cog):
         if account is None:
             account = PlayerAccount(id=user_id, balance=0)
             session.add(account)
+            session.flush()
             self._credit(session, season_id, account, None, config.STARTING_BALANCE, "season_grant")
         return account
 

--- a/tests/fixtures/database.py
+++ b/tests/fixtures/database.py
@@ -1,7 +1,7 @@
 from unittest import mock
 
 import pytest
-from sqlalchemy import BigInteger, create_engine
+from sqlalchemy import BigInteger, create_engine, event
 from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import StaticPool
@@ -32,6 +32,7 @@ class InMemoryDatabase:
 
     def __init__(self):
         self.engine = create_engine("sqlite://", connect_args={"check_same_thread": False}, poolclass=StaticPool)
+        event.listen(self.engine, "connect", lambda conn, _: conn.execute("PRAGMA foreign_keys=ON"))
         self._sessions = sessionmaker(self.engine, expire_on_commit=False)  # keep rows readable after close
 
     def session(self, model):


### PR DESCRIPTION
##### Summary

The first `/market` interaction from any new player throws `ForeignKeyViolation: ... pm_ledger_user_id_fkey` in prod. A brand-new player's `PlayerAccount` and its `season_grant` `LedgerEntry` are added in the same unit of work with no `relationship()` linking them, so SQLAlchemy orders the `pm_ledger` insert before `pm_users` (table name order) — the ledger row references a user that doesn't exist yet. Fix: flush the account before crediting it, so the user row exists before the ledger FK references it.

The `in_memory_db` test fixture didn't catch this because SQLite ignores foreign keys unless asked. Enabling `PRAGMA foreign_keys=ON` makes it enforce them like Postgres; with that on, every test that grants a starting balance reproduced the prod failure, and all pass again after the flush.

Tested by running the playmarket suite with FK enforcement enabled (55 tests went red against the bug, green after the fix).

##### Checklist

- [x] this is a source code change
  - [x] run `format` in the repository root
  - [x] run `pytest` in the repository root
  - [ ] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [ ] update the wiki documentation if necessary
- [ ] or, this is **not** a source code change

🤖 Generated with [Claude Code](https://claude.com/claude-code)