### PR TITLE
:bug: resolve market user names

### DIFF
--- a/duckbot/cogs/playmarket/market.py
+++ b/duckbot/cogs/playmarket/market.py
@@ -9,6 +9,7 @@ from sqlalchemy import String, cast, or_
 
 from duckbot.db import Database
 from duckbot.util.datetime import now
+from duckbot.util.users import get_user
 
 from . import config, lmsr
 from .models import LedgerEntry, Market, PlayerAccount, Position, Season, SeasonResult
@@ -70,7 +71,7 @@ class PlayMarket(commands.Cog):
             account = self.account(session, season.id, context.author.id)
             rows = session.query(Position, Market).join(Market, Position.market_id == Market.id).filter(Position.user_id == account.id, Market.status == "OPEN").order_by(Market.id.desc()).all()
             session.commit()
-            lines = [f"**{self._name(context, account.id)}** — {_coins(account.balance)} coins"]
+            lines = [f"**{await self._name(context, account.id)}** — {_coins(account.balance)} coins"]
             lines += [f"**{m.id}** {m.question} — YES {_pct(self._price(m))} · you hold {_coins(p.yes_shares)} YES / {_coins(p.no_shares)} NO" for p, m in rows if p.yes_shares or p.no_shares]
         await context.send("\n".join(lines))
 
@@ -104,7 +105,7 @@ class PlayMarket(commands.Cog):
             session.commit()
         if not ranked:
             return await context.send("Nobody's played yet. Buncha cowards.")
-        lines = [f"{i}. {self._name(context, uid)} — {_coins(worth)} coins" for i, (uid, worth) in enumerate(ranked, start=1)]
+        lines = [f"{i}. {await self._name(context, uid)} — {_coins(worth)} coins" for i, (uid, worth) in enumerate(ranked, start=1)]
         await context.send("**Leaderboard**\n" + "\n".join(lines))
 
     # --- market commands --------------------------------------------------
@@ -327,9 +328,8 @@ class PlayMarket(commands.Cog):
     async def _is_admin(self, context) -> bool:
         return await context.bot.is_owner(context.author) or context.author.id in config.ADMIN_IDS
 
-    def _name(self, context, user_id) -> str:
-        member = context.guild.get_member(user_id) if context.guild else None
-        user = member or self.bot.get_user(user_id)
+    async def _name(self, context, user_id) -> str:
+        user = await get_user(self.bot, user_id, context.guild)
         return user.display_name if user else str(user_id)
 
 

--- a/duckbot/util/users/get_user.py
+++ b/duckbot/util/users/get_user.py
@@ -6,9 +6,13 @@ import discord
 async def get_user(bot, user_id: int, guild: Optional[discord.Guild] = None) -> Optional[Union[discord.Member, discord.User]]:
     """Returns the user with the given ID, checking cache first, then fetching via API if needed.
     Prefers returning a guild Member (which has server-specific display names) if a guild is provided.
+    Returns None if the user can't be found, e.g. they've left the guild.
     :param bot: the Discord bot
     :param user_id: the user ID to look up
     :param guild: optional guild to check for a member first"""
-    if guild:
-        return guild.get_member(user_id) or await guild.fetch_member(user_id)
-    return bot.get_user(user_id) or await bot.fetch_user(user_id)
+    try:
+        if guild:
+            return guild.get_member(user_id) or await guild.fetch_member(user_id)
+        return bot.get_user(user_id) or await bot.fetch_user(user_id)
+    except discord.HTTPException:
+        return None

--- a/tests/util/users/get_user_test.py
+++ b/tests/util/users/get_user_test.py
@@ -1,3 +1,7 @@
+from unittest import mock
+
+import discord
+
 from duckbot.util.users import get_user
 
 
@@ -29,3 +33,15 @@ async def test_get_user_no_guild_user_not_in_cache(bot, user):
     result = await get_user(bot, 123)
     assert result is user
     bot.fetch_user.assert_called_once_with(123)
+
+
+async def test_get_user_guild_member_left(bot, guild):
+    guild.get_member.return_value = None
+    guild.fetch_member.side_effect = discord.NotFound(mock.Mock(status=404), "unknown member")
+    assert await get_user(bot, 123, guild) is None
+
+
+async def test_get_user_no_guild_user_not_found(bot):
+    bot.get_user.return_value = None
+    bot.fetch_user.side_effect = discord.NotFound(mock.Mock(status=404), "unknown user")
+    assert await get_user(bot, 123) is None


### PR DESCRIPTION
##### Summary

Fixes #1359 — `/market balance` and `/market leaderboard` showed raw user ids instead of names. `_name` now resolves through the shared `get_user` util, which fetches via the API on a cache miss.

`get_user` also now catches `discord.HTTPException` and returns `None`, so a player who left the guild can't raise mid-render. The only other caller (`touch_grass`) already handled the `None` fallback.

##### Checklist

- [x] this is a source code change
  - [x] run `format` in the repository root
  - [x] run `pytest` in the repository root
  - [x] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [ ] update the wiki documentation if necessary
- [ ] or, this is **not** a source code change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
