### PR TITLE
:arrow_up: bump aws-actions/configure-aws-credentials from 6.1.3 to v6.2.1

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -99,7 +99,7 @@ jobs:
       uses: ./.github/actions/setup-aws-cdk
 
     - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@6.1.3
+      uses: aws-actions/configure-aws-credentials@v6.2.1
       with:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
##### Summary

Bumps `aws-actions/configure-aws-credentials` from `6.1.3` to `v6.2.1` to fix failing deploys. The `6.1.3` tag appears to have become unresolvable. Other tags are all `vX.Y.Z` so I think they deleted the old tag.

##### Checklist

- [ ] this is a source code change
  - [ ] run `format` in the repository root
  - [ ] run `pytest` in the repository root
  - [ ] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [ ] update the wiki documentation if necessary
- [x] or, this is **not** a source code change

🤖 Generated with [Claude Code](https://claude.com/claude-code)