### PR TITLE
:sparkles: `/market resolve` embed showing each holder's win/loss

### DIFF
--- a/duckbot/cogs/playmarket/market.py
+++ b/duckbot/cogs/playmarket/market.py
@@ -199,9 +199,15 @@ class PlayMarket(commands.Cog):
                 return await context.send("That one's already in the books, brother.")
             if context.author.id != market.creator_id and not await self._is_admin(context):
                 return await context.send("Not your market, not your call.")
+            results = []
+            for pos in session.query(Position).filter_by(market_id=market.id).all():
+                if not pos.yes_shares and not pos.no_shares:
+                    continue
+                invested = sum(e.delta for e in session.query(LedgerEntry).filter_by(user_id=pos.user_id, market_id=market.id).filter(LedgerEntry.reason.in_(("bet", "sell"))).all())
+                results.append((pos.user_id, pos.yes_shares, pos.no_shares, invested, self._payout(pos, outcome)))
             self._resolve_market(session, market, outcome)
             session.commit()
-            await context.send(f"Market {market_id} called **{outcome.upper()}**. Winners paid, losers weep.")
+            await context.send(embed=await self._resolve_embed(context, market, outcome, results))
 
     @market_group.autocomplete("status")
     @list_command.autocomplete("status")
@@ -326,6 +332,22 @@ class PlayMarket(commands.Cog):
 
     def _summary(self, market) -> str:
         return f"**{market.id}** [{market.status}] {market.question} — YES {_pct(self._price(market))}"
+
+    async def _resolve_embed(self, context, market, outcome: str, results) -> Embed:
+        color = Color.green() if outcome == "yes" else Color.red() if outcome == "no" else Color.greyple()
+        embed = Embed(title=f"Market {market.id} — {market.question}", description=f"Called **{outcome.upper()}**.", color=color)
+        lines = []
+        for user_id, yes_shares, no_shares, invested, payout in sorted(results, key=lambda r: r[3] + r[4], reverse=True):
+            name = await self._name(context, user_id)
+            net = payout + invested
+            side = "YES" if yes_shares >= no_shares else "NO"
+            if net > 0:
+                lines.append(f"{name} — {_coins(-invested)} on {side}, won {_coins(payout)} (+{_coins(net)})")
+            else:
+                lines.append(f"{name} — {_coins(-invested)} on {side}, lost {_coins(-net)}")
+        if lines:
+            embed.add_field(name="Results", value="\n".join(lines), inline=False)
+        return embed
 
     async def _trade_embed(self, context, session, market, action: str, side: str) -> Embed:
         embed = Embed(title=f"Market {market.id} — {market.question}", description=f"{action}\nYES is now {_pct(self._price(market))}.", color=Color.green() if side == "yes" else Color.red())

--- a/tests/cogs/playmarket/market_test.py
+++ b/tests/cogs/playmarket/market_test.py
@@ -351,7 +351,18 @@ async def test_creator_can_resolve_their_market(cog, alice, in_memory_db):
     market_id = await open_market(cog, alice)
     await cog.resolve(alice, market_id, "yes")
     assert market_row(in_memory_db, market_id).status == "RESOLVED"
-    assert alice.send.call_args.args[0] == f"Market {market_id} called **YES**. Winners paid, losers weep."
+    expected = discord.Embed(title=f"Market {market_id} — Will it happen?", description="Called **YES**.", color=discord.Color.green())
+    alice.send.assert_called_with(embed=expected)
+
+
+async def test_resolve_embed_shows_winners_and_losers(cog, alice, bob, carol, in_memory_db):
+    market_id = await open_market(cog, alice)
+    await cog.bet(bob, market_id, "yes", BET)
+    await cog.bet(carol, market_id, "no", BET)
+    await cog.resolve(alice, market_id, "yes")
+    expected = discord.Embed(title=f"Market {market_id} — Will it happen?", description="Called **YES**.", color=discord.Color.green())
+    expected.add_field(name="Results", value="user2 — 500 on YES, won 831 (+331)\nuser3 — 500 on NO, lost 500", inline=False)
+    alice.send.assert_called_with(embed=expected)
 
 
 async def test_a_non_creator_non_admin_cannot_resolve(cog, alice, bob, in_memory_db):


### PR DESCRIPTION
##### Summary

Replaces the plain-text `/market resolve` response with an embed showing each holder's result.

Closes #1363, relates to #1360.

<img width="333" height="218" alt="image" src="https://github.com/user-attachments/assets/7148c842-4e9e-41db-94a2-29e87628d835" />

##### Checklist

- [x] this is a source code change
  - [x] run `format` in the repository root
  - [x] run `pytest` in the repository root
  - [x] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [ ] update the wiki documentation if necessary
- [ ] or, this is **not** a source code change