### PR TITLE
:art: `/market leaderboard` embed, show cash available to bet

### DIFF
--- a/duckbot/cogs/playmarket/market.py
+++ b/duckbot/cogs/playmarket/market.py
@@ -16,6 +16,8 @@ from .models import LedgerEntry, Market, PlayerAccount, Position, Season, Season
 
 CENT = Decimal("0.000001")
 
+MEDALS = {1: "🥇", 2: "🥈", 3: "🥉"}
+
 
 def _down(value: float) -> Decimal:
     """Round a share count down to storage precision."""
@@ -101,12 +103,11 @@ class PlayMarket(commands.Cog):
 
     async def leaderboard(self, context: commands.Context):
         with self.db.session(Season) as session:
-            ranked = self._standings(session)
+            standings = self._standings(session)
             session.commit()
-        if not ranked:
+        if not standings:
             return await context.send("Nobody's played yet. Buncha cowards.")
-        lines = [f"{i}. {await self._name(context, uid)} — {_coins(worth)} coins" for i, (uid, worth) in enumerate(ranked, start=1)]
-        await context.send("**Leaderboard**\n" + "\n".join(lines))
+        await context.send(embed=await self._leaderboard_embed(context, standings))
 
     # --- market commands --------------------------------------------------
 
@@ -313,13 +314,14 @@ class PlayMarket(commands.Cog):
     # --- read helpers -----------------------------------------------------
 
     def _standings(self, session):
-        """(user_id, net worth) ranked high to low; net worth = balance + open position value."""
-        worth = {a.id: a.balance for a in session.query(PlayerAccount).all()}
+        """(user_id, cash, shares_value) ranked by net worth (cash + shares_value) high to low."""
+        cash = {a.id: a.balance for a in session.query(PlayerAccount).all()}
+        shares_value = {uid: Decimal(0) for uid in cash}
         rows = session.query(Position, Market).join(Market, Position.market_id == Market.id).filter(Market.status == "OPEN").all()
         for position, market in rows:
             yes_price = Decimal(str(self._price(market)))
-            worth[position.user_id] = worth.get(position.user_id, Decimal(0)) + position.yes_shares * yes_price + position.no_shares * (1 - yes_price)
-        return sorted(worth.items(), key=lambda kv: kv[1], reverse=True)
+            shares_value[position.user_id] = shares_value.get(position.user_id, Decimal(0)) + position.yes_shares * yes_price + position.no_shares * (1 - yes_price)
+        return sorted(((uid, cash[uid], shares_value[uid]) for uid in cash), key=lambda row: row[1] + row[2], reverse=True)
 
     def _lock_market(self, session, market_id) -> Optional[Market]:
         return session.query(Market).filter_by(id=market_id).with_for_update().first()
@@ -357,6 +359,13 @@ class PlayMarket(commands.Cog):
         if holders:
             embed.add_field(name="Holders", value="\n".join(holders), inline=False)
         return embed
+
+    async def _leaderboard_embed(self, context, standings) -> Embed:
+        lines = [
+            f"{MEDALS.get(i, f'{i}.')} {await self._name(context, uid)} — {_coins(cash + shares_value)} coins ({_coins(cash)} cash + {_coins(shares_value)} shares)"
+            for i, (uid, cash, shares_value) in enumerate(standings, start=1)
+        ]
+        return Embed(title="Leaderboard", description="\n".join(lines), color=Color.gold())
 
     async def _is_admin(self, context) -> bool:
         return await context.bot.is_owner(context.author) or context.author.id in config.ADMIN_IDS

--- a/duckbot/cogs/playmarket/market.py
+++ b/duckbot/cogs/playmarket/market.py
@@ -320,7 +320,7 @@ class PlayMarket(commands.Cog):
         rows = session.query(Position, Market).join(Market, Position.market_id == Market.id).filter(Market.status == "OPEN").all()
         for position, market in rows:
             yes_price = Decimal(str(self._price(market)))
-            shares_value[position.user_id] = shares_value.get(position.user_id, Decimal(0)) + position.yes_shares * yes_price + position.no_shares * (1 - yes_price)
+            shares_value[position.user_id] += position.yes_shares * yes_price + position.no_shares * (1 - yes_price)
         return sorted(((uid, cash[uid], shares_value[uid]) for uid in cash), key=lambda row: row[1] + row[2], reverse=True)
 
     def _lock_market(self, session, market_id) -> Optional[Market]:
@@ -361,11 +361,12 @@ class PlayMarket(commands.Cog):
         return embed
 
     async def _leaderboard_embed(self, context, standings) -> Embed:
-        lines = [
-            f"{MEDALS.get(i, f'{i}.')} {await self._name(context, uid)} — {_coins(cash + shares_value)} coins ({_coins(cash)} cash + {_coins(shares_value)} shares)"
-            for i, (uid, cash, shares_value) in enumerate(standings, start=1)
-        ]
+        lines = [await self._standing_line(context, i, uid, cash, shares_value) for i, (uid, cash, shares_value) in enumerate(standings, start=1)]
         return Embed(title="Leaderboard", description="\n".join(lines), color=Color.gold())
+
+    async def _standing_line(self, context, rank, uid, cash, shares_value) -> str:
+        name = await self._name(context, uid)
+        return f"{MEDALS.get(rank, f'{rank}.')} {name} — {_coins(cash + shares_value)} coins ({_coins(cash)} available)"
 
     async def _is_admin(self, context) -> bool:
         return await context.bot.is_owner(context.author) or context.author.id in config.ADMIN_IDS

--- a/tests/cogs/playmarket/market_test.py
+++ b/tests/cogs/playmarket/market_test.py
@@ -479,7 +479,7 @@ async def test_leaderboard_ranks_by_net_worth(cog, alice, bob, in_memory_db):
     market_id = await open_market(cog, bob)
     await cog.bet(bob, market_id, "yes", BET)  # bob's position is worth more than his spent coins
     await cog.leaderboard(alice)
-    expected = discord.Embed(title="Leaderboard", description="🥇 user2 — 10,080 coins (9,500 cash + 580 shares)\n🥈 user1 — 10,000 coins (10,000 cash + 0 shares)", color=discord.Color.gold())
+    expected = discord.Embed(title="Leaderboard", description="🥇 user2 — 10,080 coins (9,500 available)\n🥈 user1 — 10,000 coins (10,000 available)", color=discord.Color.gold())
     alice.send.assert_called_with(embed=expected)
 
 
@@ -487,10 +487,10 @@ async def test_leaderboard_medals_the_top_three_then_falls_back_to_numbers(cog, 
     standings = [(1, 100, 0), (2, 90, 0), (3, 80, 0), (4, 70, 0)]
     embed = await cog._leaderboard_embed(alice, standings)
     assert embed.description.splitlines() == [
-        "🥇 user1 — 100 coins (100 cash + 0 shares)",
-        "🥈 user2 — 90 coins (90 cash + 0 shares)",
-        "🥉 user3 — 80 coins (80 cash + 0 shares)",
-        "4. user4 — 70 coins (70 cash + 0 shares)",
+        "🥇 user1 — 100 coins (100 available)",
+        "🥈 user2 — 90 coins (90 available)",
+        "🥉 user3 — 80 coins (80 available)",
+        "4. user4 — 70 coins (70 available)",
     ]
 
 

--- a/tests/cogs/playmarket/market_test.py
+++ b/tests/cogs/playmarket/market_test.py
@@ -479,8 +479,27 @@ async def test_leaderboard_ranks_by_net_worth(cog, alice, bob, in_memory_db):
     market_id = await open_market(cog, bob)
     await cog.bet(bob, market_id, "yes", BET)  # bob's position is worth more than his spent coins
     await cog.leaderboard(alice)
-    message = alice.send.call_args.args[0]
-    assert message.index("user2") < message.index("user1")
+    expected = discord.Embed(title="Leaderboard", description="🥇 user2 — 10,080 coins (9,500 cash + 580 shares)\n🥈 user1 — 10,000 coins (10,000 cash + 0 shares)", color=discord.Color.gold())
+    alice.send.assert_called_with(embed=expected)
+
+
+async def test_leaderboard_medals_the_top_three_then_falls_back_to_numbers(cog, alice):
+    standings = [(1, 100, 0), (2, 90, 0), (3, 80, 0), (4, 70, 0)]
+    embed = await cog._leaderboard_embed(alice, standings)
+    assert embed.description.splitlines() == [
+        "🥇 user1 — 100 coins (100 cash + 0 shares)",
+        "🥈 user2 — 90 coins (90 cash + 0 shares)",
+        "🥉 user3 — 80 coins (80 cash + 0 shares)",
+        "4. user4 — 70 coins (70 cash + 0 shares)",
+    ]
+
+
+async def test_standings_splits_cash_and_shares_value(cog, bob, in_memory_db):
+    market_id = await open_market(cog, bob)
+    await cog.bet(bob, market_id, "yes", BET)
+    with in_memory_db.session(Season) as session:
+        cash, shares_value = next((c, s) for uid, c, s in cog._standings(session) if uid == 2)
+    assert cash == STARTING - BET and shares_value > 0
 
 
 # --- season rollover -----------------------------------------------------


### PR DESCRIPTION
##### Summary

Fixes #1371
<img width="442" height="173" alt="image" src="https://github.com/user-attachments/assets/bff1eae0-e64e-4528-a2ec-a928c9fdadb7" />




##### Checklist

- [x] this is a source code change
  - [x] run `format` in the repository root
  - [x] run `pytest` in the repository root
  - [x] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [ ] update the wiki documentation if necessary
- [ ] or, this is **not** a source code change