### PR TITLE
:bug: Void markets refund each player's net stake

### DIFF
--- a/duckbot/cogs/playmarket/market.py
+++ b/duckbot/cogs/playmarket/market.py
@@ -204,8 +204,8 @@ class PlayMarket(commands.Cog):
             for pos in session.query(Position).filter_by(market_id=market.id).all():
                 if not pos.yes_shares and not pos.no_shares:
                     continue
-                invested = sum(e.delta for e in session.query(LedgerEntry).filter_by(user_id=pos.user_id, market_id=market.id).filter(LedgerEntry.reason.in_(("bet", "sell"))).all())
-                results.append((pos.user_id, pos.yes_shares, pos.no_shares, invested, self._payout(pos, outcome)))
+                invested = self._invested(session, pos.user_id, market.id)
+                results.append((pos.user_id, pos.yes_shares, pos.no_shares, invested, self._payout(pos, outcome, invested)))
             self._resolve_market(session, market, outcome)
             session.commit()
             await context.send(embed=await self._resolve_embed(context, market, outcome, results))
@@ -278,9 +278,9 @@ class PlayMarket(commands.Cog):
         session.add(LedgerEntry(season_id=season_id, user_id=account.id, market_id=market_id, delta=delta, reason=reason))
 
     def _resolve_market(self, session, market, outcome):
-        """Pay out winning shares (0.5 each on void), close positions, finalise."""
+        """Pay out winning shares (net stake back on void), close positions, finalise."""
         for position in session.query(Position).filter_by(market_id=market.id).all():
-            payout = self._payout(position, outcome)
+            payout = self._payout(position, outcome, self._invested(session, position.user_id, market.id))
             if payout > 0:
                 account = self._lock_account(session, position.user_id)
                 self._credit(session, market.season_id, account, market.id, payout, "refund" if outcome == "void" else "payout")
@@ -288,12 +288,14 @@ class PlayMarket(commands.Cog):
         market.status = "VOID" if outcome == "void" else "RESOLVED"
         market.outcome = outcome
 
-    def _payout(self, position, outcome) -> int:
+    def _invested(self, session, user_id, market_id) -> int:
+        """Net of the player's bets and sells on a market; negative while coins are in."""
+        return sum(e.delta for e in session.query(LedgerEntry).filter_by(user_id=user_id, market_id=market_id).filter(LedgerEntry.reason.in_(("bet", "sell"))).all())
+
+    def _payout(self, position, outcome, invested) -> int:
         if outcome == "void":
-            shares = (position.yes_shares + position.no_shares) / 2
-        else:
-            shares = position.yes_shares if outcome == "yes" else position.no_shares
-        return _whole(shares)
+            return max(0, -invested)
+        return _whole(position.yes_shares if outcome == "yes" else position.no_shares)
 
     def _add_shares(self, session, market, user_id, side, delta):
         position = session.get(Position, (user_id, market.id)) or Position(user_id=user_id, market_id=market.id, yes_shares=Decimal(0), no_shares=Decimal(0))
@@ -345,8 +347,10 @@ class PlayMarket(commands.Cog):
             side = "YES" if yes_shares >= no_shares else "NO"
             if net > 0:
                 lines.append(f"{name} — {_coins(-invested)} on {side}, won {_coins(payout)} (+{_coins(net)})")
-            else:
+            elif net < 0:
                 lines.append(f"{name} — {_coins(-invested)} on {side}, lost {_coins(-net)}")
+            else:
+                lines.append(f"{name} — {_coins(-invested)} on {side}, refunded")
         if lines:
             embed.add_field(name="Results", value="\n".join(lines), inline=False)
         return embed

--- a/tests/cogs/playmarket/market_test.py
+++ b/tests/cogs/playmarket/market_test.py
@@ -400,13 +400,30 @@ async def test_resolving_yes_pays_the_yes_holders(cog, alice, bob, carol, in_mem
     assert account(in_memory_db, 3).balance == STARTING - BET  # carol held NO and got nothing
 
 
-async def test_resolving_void_pays_half_to_everyone(cog, alice, bob, in_memory_db):
+async def test_resolving_void_refunds_every_bet(cog, alice, bob, in_memory_db):
+    market_id = await open_market(cog, alice)
+    await cog.bet(bob, market_id, "no", 99)
+    await cog.bet(bob, market_id, "no", 1234)
+    await cog.resolve(alice, market_id, "void")
+    assert market_row(in_memory_db, market_id).status == "VOID"
+    assert account(in_memory_db, 2).balance == STARTING
+
+
+async def test_resolving_void_refunds_the_stake_net_of_sells(cog, alice, bob, in_memory_db):
+    market_id = await open_market(cog, alice)
+    await cog.bet(bob, market_id, "yes", BET)
+    await cog.sell(bob, market_id, "yes", "200")
+    await cog.resolve(alice, market_id, "void")
+    assert account(in_memory_db, 2).balance == STARTING
+
+
+async def test_resolve_embed_shows_void_refunds(cog, alice, bob, in_memory_db):
     market_id = await open_market(cog, alice)
     await cog.bet(bob, market_id, "yes", 300)
     await cog.resolve(alice, market_id, "void")
-    assert market_row(in_memory_db, market_id).status == "VOID"
-    # ~530 YES shares, each redeems at 0.5 on void
-    assert float(account(in_memory_db, 2).balance) == pytest.approx(9965, abs=1)
+    expected = discord.Embed(title=f"Market {market_id} — Will it happen?", description="Called **VOID**.", color=discord.Color.greyple())
+    expected.add_field(name="Results", value="user2 — 300 on YES, refunded", inline=False)
+    alice.send.assert_called_with(embed=expected)
 
 
 async def test_resolving_clears_all_positions(cog, alice, bob, in_memory_db):

--- a/tests/cogs/playmarket/market_unit_test.py
+++ b/tests/cogs/playmarket/market_unit_test.py
@@ -18,27 +18,27 @@ def cog(bot, db):
 
 def test_winning_yes_pays_one_coin_per_share(cog):
     holding = SimpleNamespace(yes_shares=Decimal(10), no_shares=Decimal(4))
-    assert cog._payout(holding, "yes") == 10
+    assert cog._payout(holding, "yes", -7) == 10
 
 
 def test_winning_no_pays_one_coin_per_share(cog):
     holding = SimpleNamespace(yes_shares=Decimal(10), no_shares=Decimal(4))
-    assert cog._payout(holding, "no") == 4
+    assert cog._payout(holding, "no", -7) == 4
 
 
-def test_void_pays_half_of_every_share(cog):
+def test_void_refunds_the_net_stake(cog):
     holding = SimpleNamespace(yes_shares=Decimal(10), no_shares=Decimal(4))
-    assert cog._payout(holding, "void") == 7
+    assert cog._payout(holding, "void", -99) == 99
+
+
+def test_void_never_claws_back_realised_profit(cog):
+    holding = SimpleNamespace(yes_shares=Decimal(10), no_shares=Decimal(0))
+    assert cog._payout(holding, "void", 25) == 0
 
 
 def test_payout_floors_fractional_shares_toward_the_house(cog):
     holding = SimpleNamespace(yes_shares=Decimal("10.9"), no_shares=Decimal(0))
-    assert cog._payout(holding, "yes") == 10
-
-
-def test_void_payout_floors_to_a_whole_coin(cog):
-    holding = SimpleNamespace(yes_shares=Decimal(3), no_shares=Decimal(0))  # 1.5 -> 1
-    assert cog._payout(holding, "void") == 1
+    assert cog._payout(holding, "yes", -7) == 10
 
 
 # --- rounding & formatting ----------------------------------------------


### PR DESCRIPTION
##### Summary

Voiding a market settled every share at 0.5 coins, so anyone who bought at a price above 50% lost money on a "void." Void now refunds each player's net stake (bets minus sells) from the ledger, never clawing back realised profit. The resolve embed shows "refunded" instead of "lost 0".

Fixes #1392

<img width="539" height="663" alt="image" src="https://github.com/user-attachments/assets/fd3a1b34-1ae6-462e-95ea-14ff56d29fc3" />


##### Checklist

- [x] this is a source code change
  - [x] run `format` in the repository root
  - [x] run `pytest` in the repository root
  - [x] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [ ] update the wiki documentation if necessary
- [ ] or, this is **not** a source code change

🤖 Generated with [Claude Code](https://claude.com/claude-code)