### PR TITLE
:speaker: ping position holders when a market resolves

### DIFF
--- a/duckbot/cogs/playmarket/market.py
+++ b/duckbot/cogs/playmarket/market.py
@@ -208,7 +208,8 @@ class PlayMarket(commands.Cog):
                 results.append((pos.user_id, pos.yes_shares, pos.no_shares, invested, self._payout(pos, outcome, invested)))
             self._resolve_market(session, market, outcome)
             session.commit()
-            await context.send(embed=await self._resolve_embed(context, market, outcome, results))
+            mentions = " ".join([await self._name(context, r[0], mention=True) for r in results])
+            await context.send(mentions or None, embed=await self._resolve_embed(context, market, outcome, results))
 
     @market_group.autocomplete("status")
     @list_command.autocomplete("status")
@@ -375,9 +376,9 @@ class PlayMarket(commands.Cog):
     async def _is_admin(self, context) -> bool:
         return await context.bot.is_owner(context.author) or context.author.id in config.ADMIN_IDS
 
-    async def _name(self, context, user_id) -> str:
+    async def _name(self, context, user_id, mention=False) -> str:
         user = await get_user(self.bot, user_id, context.guild)
-        return user.display_name if user else str(user_id)
+        return (user.mention if mention else user.display_name) if user else str(user_id)
 
 
 def _coins(value) -> str:

--- a/tests/cogs/playmarket/market_test.py
+++ b/tests/cogs/playmarket/market_test.py
@@ -51,7 +51,7 @@ def cog(bot, in_memory_db, clock):
 def make_context(user_id):
     ctx = mock.Mock()
     ctx.author = mock.Mock(id=user_id, display_name=f"user{user_id}")
-    ctx.guild.get_member = lambda uid: mock.Mock(id=uid, display_name=f"user{uid}")
+    ctx.guild.get_member = lambda uid: mock.Mock(id=uid, display_name=f"user{uid}", mention=f"<@{uid}>")
     ctx.send = mock.AsyncMock()
     ctx.bot.is_owner = mock.AsyncMock(return_value=False)
     return ctx
@@ -352,7 +352,7 @@ async def test_creator_can_resolve_their_market(cog, alice, in_memory_db):
     await cog.resolve(alice, market_id, "yes")
     assert market_row(in_memory_db, market_id).status == "RESOLVED"
     expected = discord.Embed(title=f"Market {market_id} — Will it happen?", description="Called **YES**.", color=discord.Color.green())
-    alice.send.assert_called_with(embed=expected)
+    alice.send.assert_called_with(None, embed=expected)
 
 
 async def test_resolve_embed_shows_winners_and_losers(cog, alice, bob, carol, in_memory_db):
@@ -362,7 +362,7 @@ async def test_resolve_embed_shows_winners_and_losers(cog, alice, bob, carol, in
     await cog.resolve(alice, market_id, "yes")
     expected = discord.Embed(title=f"Market {market_id} — Will it happen?", description="Called **YES**.", color=discord.Color.green())
     expected.add_field(name="Results", value="user2 — 500 on YES, won 831 (+331)\nuser3 — 500 on NO, lost 500", inline=False)
-    alice.send.assert_called_with(embed=expected)
+    alice.send.assert_called_with("<@2> <@3>", embed=expected)
 
 
 async def test_a_non_creator_non_admin_cannot_resolve(cog, alice, bob, in_memory_db):
@@ -423,7 +423,7 @@ async def test_resolve_embed_shows_void_refunds(cog, alice, bob, in_memory_db):
     await cog.resolve(alice, market_id, "void")
     expected = discord.Embed(title=f"Market {market_id} — Will it happen?", description="Called **VOID**.", color=discord.Color.greyple())
     expected.add_field(name="Results", value="user2 — 300 on YES, refunded", inline=False)
-    alice.send.assert_called_with(embed=expected)
+    alice.send.assert_called_with("<@2>", embed=expected)
 
 
 async def test_resolving_clears_all_positions(cog, alice, bob, in_memory_db):

--- a/wiki/Prediction-Market.md
+++ b/wiki/Prediction-Market.md
@@ -131,6 +131,8 @@ There's no close time and no scheduler — the person who **created** the market
 - **yes / no** — every winning share is paid 1 coin; losing shares pay 0.
 - **void** — if the question became unanswerable, every share (YES and NO) redeems at 0.5 coins. Nobody wins, nobody gets robbed.
 
+Everyone holding a position is pinged with the results, so you'll know how your bet went even if you miss the resolve.
+
 Only the creator can resolve their own market — it's a friends-trust-friends "prop bet" model. If a creator never resolves (or leaves the server), the market is automatically voided when the season ends, so no coins stay stranded.
 
 ## Economy at a glance


### PR DESCRIPTION
##### Summary

Fixes #1372 -- went with just a mention for now.

<img width="524" height="517" alt="image" src="https://github.com/user-attachments/assets/bfea5ac4-fe9c-40ac-a5fc-0cba00f07a0b" />



##### Checklist

- [x] this is a source code change
  - [x] run `format` in the repository root
  - [x] run `pytest` in the repository root
  - [x] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [x] update the wiki documentation if necessary
- [ ] or, this is **not** a source code change

🤖 Generated with [Claude Code](https://claude.com/claude-code)