### PR TITLE
:recycle: Test cog commands via `Command.__call__` instead of a delegate method

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,10 +77,10 @@ setup_nltk
 
 - **Don't shadow shared fixtures.** The global `db` fixture is a *mocked* session. For logic worth testing against real rows (balances, ledgers, etc.), use the shared `in_memory_db` fixture (real in-memory SQLite, in `tests/fixtures/database.py`) — don't redefine `db` locally.
 
-- To test a `@commands.command` / `@commands.hybrid_command` (or a group subcommand), keep the command's logic **inline** in the decorated method — no separate wrapper/delegate — and invoke it directly through `Command.__call__`. Wire each command to its cog once in the fixture with `bind_commands` (`tests/discord_test_ext.py`) so `__call__` injects `self`, then call the command by name:
+- To test a `@commands.command` / `@commands.hybrid_command` (or a group subcommand), wire the cog's commands in the fixture with `bind_commands` (`tests/discord_test_ext.py`) so `Command.__call__` injects `self`, then call the command by name:
 
   ```python
-  # source — logic inline, no foo_command/foo split
+  # source
   class Foo(commands.Cog):
       @commands.hybrid_command(name="foo")
       async def foo(self, context): ...
@@ -92,16 +92,16 @@ setup_nltk
 
   @pytest.fixture
   def clazz(bot) -> Foo:
-      return bind_commands(Foo(bot))  # sets .cog so __call__ works
+      return bind_commands(Foo(bot))
 
 
   async def test_foo(clazz, context):
       await clazz.foo(context)
   ```
 
-  `bind_commands` walks nested group subcommands too, so `/foo bar` is tested with `await clazz.bar(context)`. Without the wiring a bare `Foo(bot)` leaves `command.cog` unset and `__call__` misbinds `self`.
+  `bind_commands` walks nested group subcommands too, so `/foo bar` is `await clazz.bar(context)`.
 
-- A `@tasks.loop` is a `tasks.Loop`, not a `Command`, so the `__call__` trick doesn't apply — keep delegating the loop's body to a plain method and test that method directly:
+- A `@tasks.loop` isn't a `Command`, so delegate its body to a plain method and test that:
 
   ```python
   @tasks.loop(hours=1)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,25 +77,40 @@ setup_nltk
 
 - **Don't shadow shared fixtures.** The global `db` fixture is a *mocked* session. For logic worth testing against real rows (balances, ledgers, etc.), use the shared `in_memory_db` fixture (real in-memory SQLite, in `tests/fixtures/database.py`) — don't redefine `db` locally.
 
-- To test a `@commands.command` or `@tasks.loop` method, delegate the logic to a separate method and test that directly, since the decorators change the method signature:
+- To test a `@commands.command` / `@commands.hybrid_command` (or a group subcommand), keep the command's logic **inline** in the decorated method — no separate wrapper/delegate — and invoke it directly through `Command.__call__`. Wire each command to its cog once in the fixture with `bind_commands` (`tests/discord_test_ext.py`) so `__call__` injects `self`, then call the command by name:
 
   ```python
-  # source
+  # source — logic inline, no foo_command/foo split
   class Foo(commands.Cog):
-      @command(name="foo")
-      async def foo_command(self, context):
-          await self.foo(context)
-
+      @commands.hybrid_command(name="foo")
       async def foo(self, context): ...
 
 
   # test
-  async def test_foo(bot, context):
-      clazz = Foo(bot)
+  from tests.discord_test_ext import bind_commands
+
+
+  @pytest.fixture
+  def clazz(bot) -> Foo:
+      return bind_commands(Foo(bot))  # sets .cog so __call__ works
+
+
+  async def test_foo(clazz, context):
       await clazz.foo(context)
   ```
 
-  If the delegate is a private `__foo`, call it name-mangled from the test: `await clazz._Foo__foo(context)`.
+  `bind_commands` walks nested group subcommands too, so `/foo bar` is tested with `await clazz.bar(context)`. Without the wiring a bare `Foo(bot)` leaves `command.cog` unset and `__call__` misbinds `self`.
+
+- A `@tasks.loop` is a `tasks.Loop`, not a `Command`, so the `__call__` trick doesn't apply — keep delegating the loop's body to a plain method and test that method directly:
+
+  ```python
+  @tasks.loop(hours=1)
+  async def foo_loop(self):
+      await self.foo()
+
+
+  async def foo(self): ...  # test: await clazz.foo()
+  ```
 
 ### Mocking Patterns
 
@@ -133,7 +148,7 @@ setup_nltk
   message.author.display_name = "TestUser"
   ```
 
-- Don't aim for 100% coverage — discord.py decorators make some methods hard to cover directly.
+- Don't aim for 100% coverage — some discord.py decorators (e.g. `@tasks.loop`, autocomplete/error handlers) still make certain methods hard to cover directly.
 
 ## Pull Requests
 

--- a/duckbot/cogs/announce_day/announce_day.py
+++ b/duckbot/cogs/announce_day/announce_day.py
@@ -76,7 +76,7 @@ class AnnounceDay(commands.Cog):
             await channel.send(random.choice(self.days[day]["gifs"]))
 
     @commands.command(name="day")
-    async def day_command(self, context):
+    async def day(self, context):
         await context.send(self.get_message())
 
     @tasks.loop(time=time(hour=10, minute=0, tzinfo=duckbot.util.datetime.timezone()))

--- a/duckbot/cogs/audio/who_can_it_be_now.py
+++ b/duckbot/cogs/audio/who_can_it_be_now.py
@@ -21,10 +21,14 @@ class WhoCanItBeNow(commands.Cog):
             return self.bot.loop.create_task(self.stop())
 
     @commands.hybrid_command(name="start", description='Start playing "music" in whatever voice channel you are currently in.')
-    async def start_command(self, context: commands.Context):
-        await self.start(context)
+    async def start(self, context: commands.Context):
+        """Starts the music loop if it is not already playing."""
+        await context.send(":musical_note: :saxophone:", delete_after=30)
+        if not self.streaming:
+            self.streaming = True
+            self.audio_task = self.bot.loop.create_task(self.stream_audio())
 
-    @start_command.before_invoke
+    @start.before_invoke
     async def connect_to_voice(self, context: commands.Context):
         if context.voice_client is None:
             if not hasattr(context.author, "voice"):
@@ -36,13 +40,6 @@ class WhoCanItBeNow(commands.Cog):
                 raise commands.CommandError("`start` invoked when author not in voice channel")
         else:
             context.voice_client.stop()
-
-    async def start(self, context: commands.Context):
-        """Starts the music loop if it is not already playing."""
-        await context.send(":musical_note: :saxophone:", delete_after=30)
-        if not self.streaming:
-            self.streaming = True
-            self.audio_task = self.bot.loop.create_task(self.stream_audio())
 
     async def stream_audio(self):
         """The music loop. Connect to channel and stream. We await on `self.stream` to block on the song being played."""
@@ -85,7 +82,7 @@ class WhoCanItBeNow(commands.Cog):
         elif context is not None:
             await context.send("Brother, no :musical_note: :saxophone: is active.", delete_after=30)
 
-    @start_command.after_invoke
+    @start.after_invoke
     @stop_command.after_invoke
     async def delete_command_message(self, context: commands.Context):
         await try_delete(context.message)

--- a/duckbot/cogs/dogs/dog_photos.py
+++ b/duckbot/cogs/dogs/dog_photos.py
@@ -6,13 +6,10 @@ from discord.ext import commands
 
 class DogPhotos(commands.Cog):
     @commands.hybrid_command(name="dog", aliases=["doge"], description="Show a random dog you probably don't know")
-    async def dog_command(self, context: commands.Context, *, breed: Optional[str] = None):
+    async def dog(self, context: commands.Context, *, breed: Optional[str] = None):
         """
         :param breed: The specific breed of dog to show. Defaults to any breed.
         """
-        await self.dog(context, breed)
-
-    async def dog(self, context: commands.Context, breed: Optional[str]):
         if breed and breed in self.get_breeds():
             await context.send(self.get_dog_image(breed))
         else:

--- a/duckbot/cogs/duck/duck.py
+++ b/duckbot/cogs/duck/duck.py
@@ -44,20 +44,14 @@ class Duck(commands.Cog):
                 await message.add_reaction(regional_indicator(c))
 
     @commands.command(name="duck")
-    async def duck_command(self, context):
-        await self.github(context)
-
     async def github(self, context):
         await context.send("https://github.com/duck-dynasty/duckbot")
 
     @commands.command(name="help", aliases=["wiki"])
-    async def wiki_command(self, context):
-        await self.wiki(context)
-
     async def wiki(self, context):
         await context.send("https://github.com/duck-dynasty/duckbot/wiki")
 
-    @duck_command.after_invoke
-    @wiki_command.after_invoke
+    @github.after_invoke
+    @wiki.after_invoke
     async def delete_command_message(self, context):
         await try_delete(context.message)

--- a/duckbot/cogs/fortune/eightball.py
+++ b/duckbot/cogs/fortune/eightball.py
@@ -9,13 +9,10 @@ from .eightball_phrases import joke_phrases, phrases
 
 class EightBall(commands.Cog):
     @commands.hybrid_command(name="eightball", aliases=["8ball"], description="Ask the magic 8 ball a question!")
-    async def eightball_command(self, context: commands.Context, *, question: str = None):
+    async def eightball(self, context: commands.Context, *, question: str = None):
         """
         :param question: The question to ask the magic 8 ball.
         """
-        await self.eightball(context, question)
-
-    async def eightball(self, context: commands.Context, question: str):
         if question is None:
             await context.send("You need to ask a question to get an answer. :unamused:")
         elif len(question.replace("?", "")) == 0:

--- a/duckbot/cogs/games/coin_flip.py
+++ b/duckbot/cogs/games/coin_flip.py
@@ -5,9 +5,6 @@ from discord.ext import commands
 
 class CoinFlip(commands.Cog):
     @commands.command(name="coin", aliases=["flip", "toss"])
-    async def coin_command(self, context):
-        await self.coin_flip(context)
-
     async def coin_flip(self, context):
         if random.random() < 1.0 / 6_000.0:
             await context.send(":coin: :coin: The Side! :coin: :coin:")

--- a/duckbot/cogs/games/dice.py
+++ b/duckbot/cogs/games/dice.py
@@ -11,13 +11,10 @@ CRIT_FAIL_FLAVOUR = ":skull: **Critical fail!**"
 
 class Dice(commands.Cog):
     @commands.hybrid_command(name="roll", aliases=["r"], description="Roll some Dungeons & Dragons style dice!")
-    async def roll_command(self, context: commands.Context, *, expression: str = "1d20"):
+    async def roll(self, context: commands.Context, *, expression: str = "1d20"):
         """
         :param expression: The number and type of dice to roll. Default is 1d20
         """
-        await self.roll(context, expression)
-
-    async def roll(self, context: commands.Context, expression: str):
         max_length = MAX_MESSAGE_LENGTH - 50  # max-50 as a buffer for the added text
         try:
             roller = self.make_roller(100_000)

--- a/duckbot/cogs/games/pokemon.py
+++ b/duckbot/cogs/games/pokemon.py
@@ -56,13 +56,10 @@ class Pokemon(commands.Cog):
         return self._pokemon_names
 
     @commands.hybrid_command(name="pokemon", description="Show a Pokemon by name or ID. No args gives the Pokemon of the Day.")
-    async def pokemon_command(self, context: commands.Context, *, name_or_id: Optional[str] = None):
+    async def pokemon(self, context: commands.Context, *, name_or_id: Optional[str] = None):
         """
         :param name_or_id: The name or ID of the Pokemon to show.
         """
-        await self.pokemon(context, name_or_id)
-
-    async def pokemon(self, context: commands.Context, name_or_id: Optional[str]):
         async with context.typing():
             try:
                 if name_or_id is not None:
@@ -156,7 +153,7 @@ class Pokemon(commands.Cog):
 
         return embed
 
-    @pokemon_command.autocomplete("name_or_id")
+    @pokemon.autocomplete("name_or_id")
     async def pokemon_name_autocomplete(self, interaction: Interaction, current: str) -> List[Choice[str]]:
         if len(current) < 3:
             return []

--- a/duckbot/cogs/github/yolo_merge.py
+++ b/duckbot/cogs/github/yolo_merge.py
@@ -39,16 +39,13 @@ class YoloMerge(commands.Cog):
 
     @commands.command(name="yolo")
     @commands.check(is_repository_admin)
-    async def yolo_command(self, context: commands.Context, pr_id: Optional[int] = None):
+    async def yolo(self, context: commands.Context, pr_id: Optional[int] = None):
         async with context.typing():
-            await self.yolo(context, pr_id)
-
-    async def yolo(self, context: commands.Context, pr_id: Optional[int]):
-        repo = self.github.get_repo("duck-dynasty/duckbot")
-        if pr_id is None:
-            await self.list(context, repo)
-        else:
-            await self.merge(context, repo, pr_id)
+            repo = self.github.get_repo("duck-dynasty/duckbot")
+            if pr_id is None:
+                await self.list(context, repo)
+            else:
+                await self.merge(context, repo, pr_id)
 
     async def list(self, context: commands.Context, repo: Repository):
         pulls = repo.get_pulls()

--- a/duckbot/cogs/google/let_me_google_that.py
+++ b/duckbot/cogs/google/let_me_google_that.py
@@ -8,10 +8,7 @@ from duckbot.util.messages import try_delete
 
 class LetMeGoogleThat(commands.Cog):
     @commands.command(name="lmgt")
-    async def let_me_google_that_command(self, context: commands.Context, *, query: str):
-        await self.let_me_google_that(context, query)
-
-    async def let_me_google_that(self, context: commands.Context, query: str):
+    async def let_me_google_that(self, context: commands.Context, *, query: str):
         text = f"https://google.com/search?q={urllib.parse.quote_plus(query)}"
         link = f"https://letmegooglethat.com/?q={urllib.parse.quote_plus(query)}"
         embed = discord.Embed().add_field(name=query, value=f"[{text}]({link})")

--- a/duckbot/cogs/insights/insights.py
+++ b/duckbot/cogs/insights/insights.py
@@ -43,8 +43,5 @@ class Insights(commands.Cog):
         await self.bot.wait_until_ready()
 
     @commands.command(name="insight")
-    async def insight_command(self, context):
-        await self.insight(context)
-
     async def insight(self, context):
         await context.send(random.choice(responses))

--- a/duckbot/cogs/math/wolfram_alpha.py
+++ b/duckbot/cogs/math/wolfram_alpha.py
@@ -21,14 +21,11 @@ class WolframAlpha(commands.Cog):
         return self._wolfram
 
     @commands.command(name="calc")
-    async def calc_command(self, context: commands.Context, *, query: str = "charizard curve"):
+    async def calc(self, context: commands.Context, *, query: str = "charizard curve"):
         async with context.typing():
-            await self.calc(context, query)
-
-    async def calc(self, context: commands.Context, query: str):
-        result = await self.wolfram.aquery(query)
-        embeds = [self.as_embed(pod) for pod in itertools.islice(result.pods, 5)]
-        await context.send(f"https://www.wolframalpha.com/input/?i={urllib.parse.quote_plus(query)}", embeds=embeds)
+            result = await self.wolfram.aquery(query)
+            embeds = [self.as_embed(pod) for pod in itertools.islice(result.pods, 5)]
+            await context.send(f"https://www.wolframalpha.com/input/?i={urllib.parse.quote_plus(query)}", embeds=embeds)
 
     # see embed limits duckbot.util.embeds; some values are shorter here for legibility
     def as_embed(self, pod) -> discord.Embed:

--- a/duckbot/cogs/messages/touch_grass.py
+++ b/duckbot/cogs/messages/touch_grass.py
@@ -74,11 +74,7 @@ class TouchGrass(commands.Cog):
         await message.channel.send(phrase)
 
     @commands.hybrid_command(name="grass-stats", description="Show activity leaderboard for all tracked users.")
-    async def grass_stats_command(self, context: commands.Context):
-        """Show activity leaderboard for all tracked users."""
-        await self.show_activity_stats(context)
-
-    async def show_activity_stats(self, context):
+    async def show_activity_stats(self, context: commands.Context):
         """Show activity leaderboard with current message counts."""
         now = utcnow()
 

--- a/duckbot/cogs/playmarket/market.py
+++ b/duckbot/cogs/playmarket/market.py
@@ -65,53 +65,44 @@ class PlayMarket(commands.Cog):
     # --- economy commands -------------------------------------------------
 
     @market_group.command(name="balance", description="Show your coin balance and active bets.")
-    async def balance_command(self, context: commands.Context):
-        async with context.typing():
-            await self.balance(context)
-
     async def balance(self, context: commands.Context):
-        with self.db.session(Season) as session:
-            season = self.active_season(session)
-            account = self.account(session, season.id, context.author.id)
-            rows = session.query(Position, Market).join(Market, Position.market_id == Market.id).filter(Position.user_id == account.id, Market.status == "OPEN").order_by(Market.id.desc()).all()
-            session.commit()
-            lines = [f"**{await self._name(context, account.id)}** — {_coins(account.balance)} coins"]
-            lines += [f"**{m.id}** {m.question} — YES {_pct(self._price(m))} · you hold {_coins(p.yes_shares)} YES / {_coins(p.no_shares)} NO" for p, m in rows if p.yes_shares or p.no_shares]
-        await context.send("\n".join(lines))
+        async with context.typing():
+            with self.db.session(Season) as session:
+                season = self.active_season(session)
+                account = self.account(session, season.id, context.author.id)
+                rows = session.query(Position, Market).join(Market, Position.market_id == Market.id).filter(Position.user_id == account.id, Market.status == "OPEN").order_by(Market.id.desc()).all()
+                session.commit()
+                lines = [f"**{await self._name(context, account.id)}** — {_coins(account.balance)} coins"]
+                lines += [f"**{m.id}** {m.question} — YES {_pct(self._price(m))} · you hold {_coins(p.yes_shares)} YES / {_coins(p.no_shares)} NO" for p, m in rows if p.yes_shares or p.no_shares]
+            await context.send("\n".join(lines))
 
     @market_group.command(name="claim", description="Get a coin top-up when you're low and have no active bets.")
-    async def claim_command(self, context: commands.Context):
-        async with context.typing():
-            await self.claim(context)
-
     async def claim(self, context: commands.Context):
-        with self.db.session(Season) as session:
-            season = self.active_season(session)
-            account = self.account(session, season.id, context.author.id)
-            if account.balance >= config.TOPUP_THRESHOLD:
-                return await context.send("Quit begging, you're not even broke.")
-            if session.query(Position).filter_by(user_id=account.id).filter((Position.yes_shares > 0) | (Position.no_shares > 0)).first():
-                return await context.send("You've got open bets, brother. No charity for gamblers.")
-            if account.last_topup_at and now() < account.last_topup_at + config.TOPUP_COOLDOWN:
-                return await context.send("Already milked that cow this week, greedy.")
-            grant = config.TOPUP_TARGET - account.balance
-            account.last_topup_at = now()
-            self._credit(session, season.id, account, None, grant, "topup")
-            session.commit()
-            await context.send(f"Pity money granted. You're sitting on {_coins(account.balance)} coins now, you charity case.")
+        async with context.typing():
+            with self.db.session(Season) as session:
+                season = self.active_season(session)
+                account = self.account(session, season.id, context.author.id)
+                if account.balance >= config.TOPUP_THRESHOLD:
+                    return await context.send("Quit begging, you're not even broke.")
+                if session.query(Position).filter_by(user_id=account.id).filter((Position.yes_shares > 0) | (Position.no_shares > 0)).first():
+                    return await context.send("You've got open bets, brother. No charity for gamblers.")
+                if account.last_topup_at and now() < account.last_topup_at + config.TOPUP_COOLDOWN:
+                    return await context.send("Already milked that cow this week, greedy.")
+                grant = config.TOPUP_TARGET - account.balance
+                account.last_topup_at = now()
+                self._credit(session, season.id, account, None, grant, "topup")
+                session.commit()
+                await context.send(f"Pity money granted. You're sitting on {_coins(account.balance)} coins now, you charity case.")
 
     @market_group.command(name="leaderboard", description="See who's winning this season.")
-    async def leaderboard_command(self, context: commands.Context):
-        async with context.typing():
-            await self.leaderboard(context)
-
     async def leaderboard(self, context: commands.Context):
-        with self.db.session(Season) as session:
-            standings = self._standings(session)
-            session.commit()
-        if not standings:
-            return await context.send("Nobody's played yet. Buncha cowards.")
-        await context.send(embed=await self._leaderboard_embed(context, standings))
+        async with context.typing():
+            with self.db.session(Season) as session:
+                standings = self._standings(session)
+                session.commit()
+            if not standings:
+                return await context.send("Nobody's played yet. Buncha cowards.")
+            await context.send(embed=await self._leaderboard_embed(context, standings))
 
     # --- market commands --------------------------------------------------
 
@@ -133,105 +124,93 @@ class PlayMarket(commands.Cog):
         await context.send(embed=embed)
 
     @market_group.command(name="create", description="Open a new question for people to bet on.")
-    async def create_command(self, context: commands.Context, question: str, liquidity: Literal["low", "med", "high"] = "med"):
+    async def create(self, context: commands.Context, question: str, liquidity: Literal["low", "med", "high"] = "med"):
         async with context.typing():
-            await self.create(context, question, liquidity)
-
-    async def create(self, context: commands.Context, question: str, liquidity: str):
-        b = config.LIQUIDITY[liquidity]
-        with self.db.session(Season) as session:
-            season = self.active_season(session)
-            if season.status != "active":
-                return await context.send("Season's wrapping up, no new markets. Pump the brakes.")
-            self.account(session, season.id, context.author.id)  # ensure creator has an account
-            market = Market(season_id=season.id, creator_id=context.author.id, question=question, b=b, subsidy=_whole(lmsr.subsidy(b)))
-            session.add(market)
-            session.commit()
-            await context.send(f"Market **{market.id}** is live: _{question}_ — YES 50%. Place your bets, degenerates.")
+            b = config.LIQUIDITY[liquidity]
+            with self.db.session(Season) as session:
+                season = self.active_season(session)
+                if season.status != "active":
+                    return await context.send("Season's wrapping up, no new markets. Pump the brakes.")
+                self.account(session, season.id, context.author.id)  # ensure creator has an account
+                market = Market(season_id=season.id, creator_id=context.author.id, question=question, b=b, subsidy=_whole(lmsr.subsidy(b)))
+                session.add(market)
+                session.commit()
+                await context.send(f"Market **{market.id}** is live: _{question}_ — YES 50%. Place your bets, degenerates.")
 
     @market_group.command(name="bet", description="Bet coins on a market resolving YES or NO.")
-    async def bet_command(self, context: commands.Context, market: int, side: Literal["yes", "no"], amount: int):
+    async def bet(self, context: commands.Context, market: int, side: Literal["yes", "no"], amount: int):
         async with context.typing():
-            await self.bet(context, market, side, amount)
-
-    async def bet(self, context: commands.Context, market_id: int, side: str, amount: int):
-        cost = int(amount)
-        if cost < config.MIN_BET:
-            return await context.send(f"{_coins(config.MIN_BET)} coins minimum, you cheapskate.")
-        with self.db.session(Market) as session:
-            market = self._lock_market(session, market_id)
-            if market is None:
-                return await context.send("No such market, brother.")
-            if market.status != "OPEN":
-                return await context.send("That market's done. Ship's sailed, brother.")
-            account = self.account(session, market.season_id, context.author.id)
-            if account.balance < cost:
-                return await context.send(f"Broke boy. You've only got {_coins(account.balance)} coins.")
-            shares = _down(lmsr.shares_for_budget(float(market.q_yes), float(market.q_no), float(market.b), side, amount))
-            self._credit(session, market.season_id, account, market.id, -cost, "bet")
-            self._add_shares(session, market, context.author.id, side, shares)
-            session.commit()
-            action = f"{context.author.display_name} bought {_coins(shares)} {side.upper()} shares for {_coins(cost)} coins."
-            await context.send(embed=await self._trade_embed(context, session, market, action, side))
+            cost = int(amount)
+            if cost < config.MIN_BET:
+                return await context.send(f"{_coins(config.MIN_BET)} coins minimum, you cheapskate.")
+            with self.db.session(Market) as session:
+                market = self._lock_market(session, market)
+                if market is None:
+                    return await context.send("No such market, brother.")
+                if market.status != "OPEN":
+                    return await context.send("That market's done. Ship's sailed, brother.")
+                account = self.account(session, market.season_id, context.author.id)
+                if account.balance < cost:
+                    return await context.send(f"Broke boy. You've only got {_coins(account.balance)} coins.")
+                shares = _down(lmsr.shares_for_budget(float(market.q_yes), float(market.q_no), float(market.b), side, amount))
+                self._credit(session, market.season_id, account, market.id, -cost, "bet")
+                self._add_shares(session, market, context.author.id, side, shares)
+                session.commit()
+                action = f"{context.author.display_name} bought {_coins(shares)} {side.upper()} shares for {_coins(cost)} coins."
+                await context.send(embed=await self._trade_embed(context, session, market, action, side))
 
     @market_group.command(name="sell", description="Cash out some or all of your position in a market.")
-    async def sell_command(self, context: commands.Context, market: int, side: Literal["yes", "no"], shares: str):
+    async def sell(self, context: commands.Context, market: int, side: Literal["yes", "no"], shares: str):
         async with context.typing():
-            await self.sell(context, market, side, shares)
-
-    async def sell(self, context: commands.Context, market_id: int, side: str, shares: str):
-        with self.db.session(Market) as session:
-            market = self._lock_market(session, market_id)
-            if market is None:
-                return await context.send("No such market, brother.")
-            if market.status != "OPEN":
-                return await context.send("That market's done. Ship's sailed, brother.")
-            position = session.get(Position, (context.author.id, market_id))
-            held = (position.yes_shares if side == "yes" else position.no_shares) if position else Decimal(0)
-            amount = held if shares == "all" else Decimal(str(shares))
-            if amount <= 0 or amount > held:
-                return await context.send(f"You've only got {_coins(held)} {side.upper()} shares, brother.")
-            account = self.account(session, market.season_id, context.author.id)
-            proceeds = self._sell_proceeds(market, side, amount)
-            self._add_shares(session, market, context.author.id, side, -amount)
-            self._credit(session, market.season_id, account, market.id, proceeds, "sell")
-            session.commit()
-            action = f"{context.author.display_name} sold {_coins(amount)} {side.upper()} shares for {_coins(proceeds)} coins."
-            await context.send(embed=await self._trade_embed(context, session, market, action, side))
+            with self.db.session(Market) as session:
+                market = self._lock_market(session, market)
+                if market is None:
+                    return await context.send("No such market, brother.")
+                if market.status != "OPEN":
+                    return await context.send("That market's done. Ship's sailed, brother.")
+                position = session.get(Position, (context.author.id, market.id))
+                held = (position.yes_shares if side == "yes" else position.no_shares) if position else Decimal(0)
+                amount = held if shares == "all" else Decimal(str(shares))
+                if amount <= 0 or amount > held:
+                    return await context.send(f"You've only got {_coins(held)} {side.upper()} shares, brother.")
+                account = self.account(session, market.season_id, context.author.id)
+                proceeds = self._sell_proceeds(market, side, amount)
+                self._add_shares(session, market, context.author.id, side, -amount)
+                self._credit(session, market.season_id, account, market.id, proceeds, "sell")
+                session.commit()
+                action = f"{context.author.display_name} sold {_coins(amount)} {side.upper()} shares for {_coins(proceeds)} coins."
+                await context.send(embed=await self._trade_embed(context, session, market, action, side))
 
     @market_group.command(name="resolve", description="Close your market with an outcome and pay out winners.")
-    async def resolve_command(self, context: commands.Context, market: int, outcome: Literal["yes", "no", "void"]):
+    async def resolve(self, context: commands.Context, market: int, outcome: Literal["yes", "no", "void"]):
         async with context.typing():
-            await self.resolve(context, market, outcome)
-
-    async def resolve(self, context: commands.Context, market_id: int, outcome: str):
-        with self.db.session(Market) as session:
-            market = self._lock_market(session, market_id)
-            if market is None:
-                return await context.send("No such market, brother.")
-            if market.status != "OPEN":
-                return await context.send("That one's already in the books, brother.")
-            if context.author.id != market.creator_id and not await self._is_admin(context):
-                return await context.send("Not your market, not your call.")
-            results = []
-            for pos in session.query(Position).filter_by(market_id=market.id).all():
-                if not pos.yes_shares and not pos.no_shares:
-                    continue
-                invested = self._invested(session, pos.user_id, market.id)
-                results.append((pos.user_id, pos.yes_shares, pos.no_shares, invested, self._payout(pos, outcome, invested)))
-            self._resolve_market(session, market, outcome)
-            session.commit()
-            mentions = " ".join([await self._name(context, r[0], mention=True) for r in results])
-            await context.send(mentions or None, embed=await self._resolve_embed(context, market, outcome, results))
+            with self.db.session(Market) as session:
+                market = self._lock_market(session, market)
+                if market is None:
+                    return await context.send("No such market, brother.")
+                if market.status != "OPEN":
+                    return await context.send("That one's already in the books, brother.")
+                if context.author.id != market.creator_id and not await self._is_admin(context):
+                    return await context.send("Not your market, not your call.")
+                results = []
+                for pos in session.query(Position).filter_by(market_id=market.id).all():
+                    if not pos.yes_shares and not pos.no_shares:
+                        continue
+                    invested = self._invested(session, pos.user_id, market.id)
+                    results.append((pos.user_id, pos.yes_shares, pos.no_shares, invested, self._payout(pos, outcome, invested)))
+                self._resolve_market(session, market, outcome)
+                session.commit()
+                mentions = " ".join([await self._name(context, r[0], mention=True) for r in results])
+                await context.send(mentions or None, embed=await self._resolve_embed(context, market, outcome, results))
 
     @market_group.autocomplete("status")
     @list_command.autocomplete("status")
     async def status_autocomplete(self, interaction: Interaction, current: str) -> List[Choice[str]]:
         return [Choice(name=s.title(), value=s) for s in ("OPEN", "RESOLVED", "VOID") if current.upper() in s]
 
-    @bet_command.autocomplete("market")
-    @sell_command.autocomplete("market")
-    @resolve_command.autocomplete("market")
+    @bet.autocomplete("market")
+    @sell.autocomplete("market")
+    @resolve.autocomplete("market")
     async def market_autocomplete(self, interaction: Interaction, current: str) -> List[Choice[int]]:
         needle = f"%{current}%"
         with self.db.session(Market) as session:

--- a/duckbot/cogs/recipe/recipe.py
+++ b/duckbot/cogs/recipe/recipe.py
@@ -49,31 +49,28 @@ class Recipe(commands.Cog):
 
         return html_content
 
-    async def recipe(self, context: commands.Context, search_term: str):
-        # clean up the arguments to make a valid recipe search
-        search_term = re.sub(r"[^\w\s]", "", search_term)
-
-        try:
-            # search for recipes on allrecipes.com
-            html_content = self.search_recipes(search_term)
-
-            # parse the html to get all recipes from the search
-            recipe_list = self.parse_recipes(html_content)
-
-            if len(recipe_list) == 0:
-                response = f"I am terribly sorry. There doesn't seem to be any recipes for {search_term}."
-            else:
-                recipe = self.select_recipe(recipe_list)
-                response = f"How about a nice {recipe['name']}. {recipe['description']} This recipe has a {recipe['rating']}/5 rating! {recipe['url']}"
-        except Exception:
-            response = "I am terribly sorry. I am having problems reading All Recipes for you."
-
-        await context.send(response)
-
     @commands.hybrid_command(name="recipe", description="Get a random recipe for something.")
-    async def recipe_command(self, context: commands.Context, *, search_term: str = ""):
+    async def recipe(self, context: commands.Context, *, search_term: str = ""):
         """
         :param search_term: Search terms for the recipe
         """
         async with context.typing():
-            await self.recipe(context, search_term)
+            # clean up the arguments to make a valid recipe search
+            search_term = re.sub(r"[^\w\s]", "", search_term)
+
+            try:
+                # search for recipes on allrecipes.com
+                html_content = self.search_recipes(search_term)
+
+                # parse the html to get all recipes from the search
+                recipe_list = self.parse_recipes(html_content)
+
+                if len(recipe_list) == 0:
+                    response = f"I am terribly sorry. There doesn't seem to be any recipes for {search_term}."
+                else:
+                    recipe = self.select_recipe(recipe_list)
+                    response = f"How about a nice {recipe['name']}. {recipe['description']} This recipe has a {recipe['rating']}/5 rating! {recipe['url']}"
+            except Exception:
+                response = "I am terribly sorry. I am having problems reading All Recipes for you."
+
+            await context.send(response)

--- a/duckbot/cogs/text/ascii_art.py
+++ b/duckbot/cogs/text/ascii_art.py
@@ -6,10 +6,7 @@ from duckbot.util.messages import MAX_MESSAGE_LENGTH
 
 class AsciiArt(commands.Cog):
     @commands.command(name="ascii")
-    async def ascii_command(self, context, *, text: str = "I need text, brother."):
-        await self.ascii(context, text)
-
-    async def ascii(self, context, text: str):
+    async def ascii(self, context, *, text: str = "I need text, brother."):
         art = str(pyfiglet.figlet_format(text.strip()))
         if len(art) < MAX_MESSAGE_LENGTH - 6:  # max-6 for the ``` characters
             await context.send(f"```{art}```")

--- a/duckbot/cogs/text/mock_text.py
+++ b/duckbot/cogs/text/mock_text.py
@@ -9,10 +9,7 @@ WRAPPERS = ["**", "*", "`"]
 
 class MockText(commands.Cog):
     @commands.command(name="mock")
-    async def mock_text_command(self, context: commands.Context, *, text: str = ""):
-        await self.mock_text(context, text)
-
-    async def mock_text(self, context: commands.Context, text: str):
+    async def mock_text(self, context: commands.Context, *, text: str = ""):
         if text == "":
             mocked_text = self.mockify(f"{context.message.author.display_name}, based on this, I should mock you... I need text dude.")
         else:
@@ -56,6 +53,6 @@ class MockText(commands.Cog):
 
         return "".join(parts)
 
-    @mock_text_command.after_invoke
+    @mock_text.after_invoke
     async def delete_command_message(self, context: commands.Context):
         await try_delete(context.message)

--- a/duckbot/cogs/text/wordnik.py
+++ b/duckbot/cogs/text/wordnik.py
@@ -19,19 +19,16 @@ class Wordnik(commands.Cog):
         self.api_key = os.getenv("WORDNIK_KEY")
 
     @commands.hybrid_command(name="define", description="Define a brother, word.")
-    async def define_command(self, context: commands.Context, *, word: str = "taco"):
+    async def define(self, context: commands.Context, *, word: str = "taco"):
         """
         :param word: The word to define.
         """
         async with context.typing():
-            await self.define(context, word)
-
-    async def define(self, context: commands.Context, word: str):
-        definitions = self.get_definitions(word.lower()) or self.get_definitions("why")
-        if definitions:
-            await context.send(embed=self.get_embed(definitions))
-        else:
-            await context.send("wordnik is all worded out, give it a minute")
+            definitions = self.get_definitions(word.lower()) or self.get_definitions("why")
+            if definitions:
+                await context.send(embed=self.get_embed(definitions))
+            else:
+                await context.send("wordnik is all worded out, give it a minute")
 
     def get_definitions(self, word: str) -> List[dict]:
         """Returns definitions from the most preferred source dictionary that has any; inflections resolve to their root word."""

--- a/duckbot/cogs/weather/weather.py
+++ b/duckbot/cogs/weather/weather.py
@@ -36,18 +36,15 @@ class Weather(commands.Cog):
 
     @commands.hybrid_group(name="weather", invoke_without_command=True)
     async def weather_command(self, context: commands.Context, city: Optional[str] = None, country: Optional[str] = None, index: Optional[int] = None):
-        await self.weather_get_command(context, city, country, index)
+        await self.weather(context, city, country, index)
 
     @weather_command.command(name="get", description="Gives weather information for your default location or the provided city.")
-    async def weather_get_command(self, context: commands.Context, city: Optional[str] = None, country: Optional[str] = None, index: Optional[int] = None):
+    async def weather(self, context: commands.Context, city: Optional[str] = None, country: Optional[str] = None, index: Optional[int] = None) -> None:
         """
         :param city: The city name to get the weather for.
         :param country: The two letter country code (eg CA for Canada), or two letter US state code.
         :param index: Index to disambiguate city when city/country are not enough.
         """
-        await self.weather(context, city, country, index)
-
-    async def weather(self, context: commands.Context, city: Optional[str], country: Optional[str], index: Optional[int]) -> None:
         async with context.typing():
             try:
                 return await self.send_weather(context, city, country, index)
@@ -56,15 +53,12 @@ class Weather(commands.Cog):
                 raise e
 
     @weather_command.command(name="set", description="Updates your default location for /weather get")
-    async def weather_set_command(self, context: commands.Context, city: Optional[str] = None, country: Optional[str] = None, index: Optional[int] = None):
+    async def set_default_location(self, context: commands.Context, city: Optional[str] = None, country: Optional[str] = None, index: Optional[int] = None) -> None:
         """
         :param city: The city name to get the weather for.
         :param country: The two letter country code (eg CA for Canada), or two letter US state code.
         :param index: Index to disambiguate city when city/country are not enough.
         """
-        await self.set_default_location(context, city, country, index)
-
-    async def set_default_location(self, context: commands.Context, city: Optional[str], country: Optional[str], index: Optional[int]) -> None:
         location = await self.search_location(context, city, country, index)
         if location is not None:
             saved_location = SavedLocation(id=context.author.id, name=location.name, country=location.country, latitude=location.lat, longitude=location.lon)

--- a/tests/cogs/ai/test_truth.py
+++ b/tests/cogs/ai/test_truth.py
@@ -6,6 +6,7 @@ import pytest
 from discord.ext import commands
 
 from duckbot.cogs.ai import Truth
+from tests.discord_test_ext import bind_commands
 
 
 @pytest.fixture
@@ -18,7 +19,7 @@ def mock_ai_client(mock_groq):
 
 @pytest.fixture
 def truth(bot, mock_ai_client):
-    clazz = Truth(bot)
+    clazz = bind_commands(Truth(bot))
     clazz._ai_client = mock_ai_client
     return clazz
 
@@ -89,7 +90,7 @@ async def test_fact_check_exception(truth, message):
 
 
 async def test_truth_no_reference(truth, ctx):
-    await truth.truth.callback(truth, ctx)
+    await truth.truth(ctx)
     ctx.send.assert_called_once_with("⚠️ Please use this command as a reply to the message you want to fact-check. For example:\n`Reply to a message → !truth`")
 
 
@@ -104,7 +105,7 @@ async def test_truth_with_reference(truth, ctx):
 
     # Mock get_message_reference directly with the referenced message
     with mock.patch("duckbot.cogs.ai.truth.get_message_reference", new=mock.AsyncMock(return_value=referenced_message)):
-        await truth.truth.callback(truth, ctx)
+        await truth.truth(ctx)
 
     # Verify only that the referenced message got the reply
     referenced_message.reply.assert_called_once_with("Fact-checked response.")

--- a/tests/cogs/announce_day/announce_day_test.py
+++ b/tests/cogs/announce_day/announce_day_test.py
@@ -4,12 +4,18 @@ from unittest import mock
 import pytest
 
 from duckbot.cogs.announce_day import AnnounceDay
+from tests.discord_test_ext import bind_commands
 
 
 @pytest.fixture
 @mock.patch("duckbot.cogs.dogs.DogPhotos")
 def dog_photos(d):
     return d
+
+
+@pytest.fixture
+def clazz(bot, dog_photos) -> AnnounceDay:
+    return bind_commands(AnnounceDay(bot, dog_photos))
 
 
 async def test_before_loop_waits_for_bot(bot, dog_photos):
@@ -102,3 +108,10 @@ async def test_on_gandalf_not_oct24_does_nothing(now, bot, dog_photos, general_c
     clazz = AnnounceDay(bot, dog_photos)
     await clazz.on_gandalf()
     general_channel.send.assert_not_called()
+
+
+@mock.patch("random.choice", side_effect=["today", "tomorrow", "yesterday", "{today} {tomorrow} {yesterday}"])
+@mock.patch("duckbot.util.datetime.now", return_value=datetime.datetime(2002, 1, 21, hour=7))
+async def test_day_sends_message(now, choice, clazz, context):
+    await clazz.day(context)
+    context.send.assert_called_once_with("today tomorrow yesterday")

--- a/tests/cogs/audio/who_can_it_be_now_test.py
+++ b/tests/cogs/audio/who_can_it_be_now_test.py
@@ -6,6 +6,12 @@ from discord.ext.commands import CommandError
 
 from duckbot.cogs.audio import WhoCanItBeNow
 from tests import async_value
+from tests.discord_test_ext import bind_commands
+
+
+@pytest.fixture
+def clazz(bot) -> WhoCanItBeNow:
+    return bind_commands(WhoCanItBeNow(bot))
 
 
 def play(*args, **kwargs):
@@ -18,7 +24,7 @@ async def test_task_loop_once(ffmpeg, vol, bot_spy, context, voice_client, skip_
     context.voice_client = None
     context.author.voice.channel.connect.return_value = async_value(voice_client)
     voice_client.play.side_effect = play
-    clazz = WhoCanItBeNow(bot_spy)
+    clazz = bind_commands(WhoCanItBeNow(bot_spy))
     await clazz.connect_to_voice(context)
     assert clazz.voice_client is not None
     await clazz.start(context)
@@ -44,7 +50,7 @@ async def test_task_loop_repeats(ffmpeg, vol, bot_spy, context, voice_client, sk
         play(*args, **kwargs)
 
     voice_client.play.side_effect = loop_first
-    clazz = WhoCanItBeNow(bot_spy)
+    clazz = bind_commands(WhoCanItBeNow(bot_spy))
     await clazz.connect_to_voice(context)
     assert clazz.voice_client is not None
     await clazz.start(context)
@@ -67,7 +73,7 @@ async def test_task_loop_repeats_max_times(ffmpeg, vol, bot_spy, context, voice_
     context.voice_client = None
     context.author.voice.channel.connect.return_value = async_value(voice_client)
     voice_client.play.side_effect = play
-    clazz = WhoCanItBeNow(bot_spy)
+    clazz = bind_commands(WhoCanItBeNow(bot_spy))
     await clazz.connect_to_voice(context)
     assert clazz.voice_client is not None
     await clazz.start(context)
@@ -84,40 +90,35 @@ async def test_task_loop_repeats_max_times(ffmpeg, vol, bot_spy, context, voice_
     context.send.assert_called_once_with(":musical_note: :saxophone:", delete_after=30)
 
 
-async def test_connect_to_voice_no_voice(bot, context):
+async def test_connect_to_voice_no_voice(clazz, context):
     context.voice_client = None
     delattr(context.author, "voice")
-    clazz = WhoCanItBeNow(bot)
     await clazz.connect_to_voice(context)
     context.send.assert_called_once_with("Music can only be played in a discord server, not a private channel.", delete_after=30)
 
 
-async def test_connect_to_voice_author_in_channel(bot, context, voice_client, skip_if_private_channel):
+async def test_connect_to_voice_author_in_channel(clazz, context, voice_client, skip_if_private_channel):
     context.voice_client = None
     context.author.voice.channel.connect.return_value = async_value(voice_client)
-    clazz = WhoCanItBeNow(bot)
     await clazz.connect_to_voice(context)
     assert clazz.voice_client == voice_client
 
 
-async def test_connect_to_voice_author_not_in_channel(bot, context):
+async def test_connect_to_voice_author_not_in_channel(clazz, context):
     context.voice_client = None
     context.author.voice = None
-    clazz = WhoCanItBeNow(bot)
     with pytest.raises(CommandError):
         await clazz.connect_to_voice(context)
     context.send.assert_called_once_with("Connect to a voice channel so I know where to `!start`.", delete_after=30)
 
 
-async def test_connect_to_voice_already_connected(bot, context, voice_client):
+async def test_connect_to_voice_already_connected(clazz, context, voice_client):
     context.voice_client = voice_client
-    clazz = WhoCanItBeNow(bot)
     await clazz.connect_to_voice(context)
     voice_client.stop.assert_called()
 
 
-async def test_start_already_started(bot, context):
-    clazz = WhoCanItBeNow(bot)
+async def test_start_already_started(clazz, bot, context):
     clazz.streaming = True
     await clazz.start(context)
     context.send.assert_called_once_with(":musical_note: :saxophone:", delete_after=30)
@@ -126,8 +127,7 @@ async def test_start_already_started(bot, context):
 
 @mock.patch("duckbot.cogs.audio.who_can_it_be_now.PCMVolumeTransformer", autospec=True)
 @mock.patch("duckbot.cogs.audio.who_can_it_be_now.FFmpegPCMAudio", autospec=True)
-async def test_stop_disconnects(ffmpeg, vol, bot, context, voice_client):
-    clazz = WhoCanItBeNow(bot)
+async def test_stop_disconnects(ffmpeg, vol, clazz, context, voice_client):
     clazz.streaming = True
     clazz.audio_task = asyncio.create_task(clazz.stream_audio())
     clazz.voice_client = voice_client
@@ -139,24 +139,27 @@ async def test_stop_disconnects(ffmpeg, vol, bot, context, voice_client):
     context.send.assert_called_once_with(":disappointed_relieved:", delete_after=30)
 
 
-async def test_stop_not_streaming(bot, context):
-    clazz = WhoCanItBeNow(bot)
+async def test_stop_not_streaming(clazz, context):
     clazz.streaming = False
     await clazz.stop(context)
     context.send.assert_called_once_with("Brother, no :musical_note: :saxophone: is active.", delete_after=30)
 
 
-async def test_stop_null_context_not_streaming(bot):
-    clazz = WhoCanItBeNow(bot)
+async def test_stop_command_not_streaming(clazz, context):
+    clazz.streaming = False
+    await clazz.stop_command(context)
+    context.send.assert_called_once_with("Brother, no :musical_note: :saxophone: is active.", delete_after=30)
+
+
+async def test_stop_null_context_not_streaming(clazz):
     clazz.streaming = False
     await clazz.stop()
 
 
 @mock.patch("duckbot.cogs.audio.who_can_it_be_now.PCMVolumeTransformer", autospec=True)
 @mock.patch("duckbot.cogs.audio.who_can_it_be_now.FFmpegPCMAudio", autospec=True)
-async def test_cog_unload_stops_streaming(ffmpeg, vol, bot, voice_client):
+async def test_cog_unload_stops_streaming(ffmpeg, vol, clazz, bot, voice_client):
     bot.loop = asyncio.get_event_loop()
-    clazz = WhoCanItBeNow(bot)
     clazz.voice_client = voice_client
     clazz.audio_task = bot.loop.create_task(clazz.stream_audio())
     clazz.streaming = True
@@ -167,7 +170,6 @@ async def test_cog_unload_stops_streaming(ffmpeg, vol, bot, voice_client):
     assert clazz.audio_task is None
 
 
-async def test_delete_command_message(bot, context):
-    clazz = WhoCanItBeNow(bot)
+async def test_delete_command_message(clazz, context):
     await clazz.delete_command_message(context)
     context.message.delete.assert_called()

--- a/tests/cogs/dogs/dog_photos_test.py
+++ b/tests/cogs/dogs/dog_photos_test.py
@@ -1,14 +1,19 @@
 import pytest
 
 from duckbot.cogs.dogs import DogPhotos
+from tests.discord_test_ext import bind_commands
 
 RANDOM_IMAGE_URI = "https://dog.ceo/api/breeds/image/random"
 LIST_BREEDS_URI = "https://dog.ceo/api/breeds/list/all"
 
 
-def test_get_dog_image_any_breed_success(responses):
+@pytest.fixture
+def clazz() -> DogPhotos:
+    return bind_commands(DogPhotos())
+
+
+def test_get_dog_image_any_breed_success(clazz, responses):
     responses.add(responses.GET, RANDOM_IMAGE_URI, json=build_dog("dog", success=True))
-    clazz = DogPhotos()
     response = clazz.get_dog_image()
     assert response == "dog"
     assert len(responses.calls) == 1
@@ -16,76 +21,68 @@ def test_get_dog_image_any_breed_success(responses):
 
 
 @pytest.mark.parametrize("breed,path", [("collie", "collie"), ("border collie", "collie/border"), ("dog", "dog")])
-def test_get_dog_image_given_breed_success(responses, breed, path):
+def test_get_dog_image_given_breed_success(clazz, responses, breed, path):
     responses.add(responses.GET, f"https://dog.ceo/api/breed/{path}/images/random", json=build_dog(f"{breed} result", success=True))
-    clazz = DogPhotos()
     response = clazz.get_dog_image(breed)
     assert response == f"{breed} result"
     assert len(responses.calls) == 1
     assert responses.calls[0].request.url == f"https://dog.ceo/api/breed/{path}/images/random"
 
 
-def test_get_dog_image_failure(responses):
+def test_get_dog_image_failure(clazz, responses):
     responses.add(responses.GET, RANDOM_IMAGE_URI, json=build_dog("dog", success=False))
-    clazz = DogPhotos()
     with pytest.raises(RuntimeError):
         clazz.get_dog_image()
     assert len(responses.calls) == 1
     assert responses.calls[0].request.url == RANDOM_IMAGE_URI
 
 
-def test_get_dog_image_no_message(responses):
+def test_get_dog_image_no_message(clazz, responses):
     responses.add(responses.GET, RANDOM_IMAGE_URI, json=build_dog("", success=True))
-    clazz = DogPhotos()
     with pytest.raises(RuntimeError):
         clazz.get_dog_image()
     assert len(responses.calls) == 1
     assert responses.calls[0].request.url == RANDOM_IMAGE_URI
 
 
-def test_get_breeds_success(responses):
+def test_get_breeds_success(clazz, responses):
     responses.add(responses.GET, LIST_BREEDS_URI, json=build_breeds(success=True))
-    clazz = DogPhotos()
     response = clazz.get_breeds()
     assert response == ["collie", "border collie", "dog"]
     assert len(responses.calls) == 1
     assert responses.calls[0].request.url == LIST_BREEDS_URI
 
 
-def test_get_breeds_failure(responses):
+def test_get_breeds_failure(clazz, responses):
     responses.add(responses.GET, LIST_BREEDS_URI, json=build_breeds(success=False))
-    clazz = DogPhotos()
     with pytest.raises(RuntimeError):
         clazz.get_breeds()
     assert len(responses.calls) == 1
     assert responses.calls[0].request.url == LIST_BREEDS_URI
 
 
-async def test_dog_no_breed(context, responses):
+async def test_dog_no_breed(clazz, context, responses):
     responses.add(responses.GET, RANDOM_IMAGE_URI, json=build_dog("result", success=True))
-    clazz = DogPhotos()
-    await clazz.dog(context, None)
+    await clazz.dog(context, breed=None)
     context.send.assert_called_once_with("result")
     assert len(responses.calls) == 1
     assert responses.calls[0].request.url == RANDOM_IMAGE_URI
 
 
-async def test_dog_known_breed(context, responses):
+async def test_dog_known_breed(clazz, context, responses):
     responses.add(responses.GET, LIST_BREEDS_URI, json=build_breeds(success=True))
     responses.add(responses.GET, "https://dog.ceo/api/breed/collie/images/random", json=build_dog("pup", success=True))
-    clazz = DogPhotos()
-    await clazz.dog(context, "collie")
+    await clazz.dog(context, breed="collie")
     context.send.assert_called_once_with("pup")
     assert len(responses.calls) == 2
     assert responses.calls[0].request.url == LIST_BREEDS_URI
     assert responses.calls[1].request.url == "https://dog.ceo/api/breed/collie/images/random"
 
 
-async def test_dog_unknown_breed(context, responses):
+async def test_dog_unknown_breed(clazz, context, responses):
     responses.add(responses.GET, LIST_BREEDS_URI, json=build_breeds(success=True))
     responses.add(responses.GET, RANDOM_IMAGE_URI, json=build_dog("flup", success=True))
-    clazz = DogPhotos()
-    await clazz.dog(context, "who?")
+    await clazz.dog(context, breed="who?")
     context.send.assert_called_once_with("flup")
     assert len(responses.calls) == 2
     assert responses.calls[0].request.url == LIST_BREEDS_URI

--- a/tests/cogs/duck/duck_test.py
+++ b/tests/cogs/duck/duck_test.py
@@ -1,37 +1,40 @@
 from unittest import mock
 
 import discord
+import pytest
 
 from duckbot.cogs.duck import Duck
 from duckbot.util.emojis import regional_indicator
+from tests.discord_test_ext import bind_commands
+
+
+@pytest.fixture
+def clazz(bot) -> Duck:
+    return bind_commands(Duck(bot))
 
 
 @mock.patch("random.random", return_value=0.0001)
-async def test_react_duck_random_fails(random, bot, message):
-    clazz = Duck(bot)
+async def test_react_duck_random_fails(random, clazz, message):
     await clazz.react_duck(message)
     message.add_reaction.assert_not_called()
 
 
 @mock.patch("random.random", return_value=0)
-async def test_react_with_duckbot_not_bot_author(random, bot, message):
-    clazz = Duck(bot)
+async def test_react_with_duckbot_not_bot_author(random, clazz, message):
     await clazz.react_with_duckbot(message)
     message.add_reaction.assert_not_called()
 
 
 @mock.patch("random.random", return_value=0.01)
-async def test_react_with_duckbot_random_fails(random, bot, message):
+async def test_react_with_duckbot_random_fails(random, clazz, bot, message):
     message.author = bot.user
-    clazz = Duck(bot)
     await clazz.react_with_duckbot(message)
     message.add_reaction.assert_not_called()
 
 
 @mock.patch("random.random", return_value=0.009)
-async def test_react_with_duckbot_random_passes(random, bot, message):
+async def test_react_with_duckbot_random_passes(random, clazz, bot, message):
     message.author = bot.user
-    clazz = Duck(bot)
     await clazz.react_with_duckbot(message)
     calls = [
         mock.call(regional_indicator("i")),
@@ -48,42 +51,37 @@ async def test_react_with_duckbot_random_passes(random, bot, message):
     message.add_reaction.assert_has_calls(calls, any_order=False)
 
 
-async def test_github(bot, context):
-    clazz = Duck(bot)
+async def test_github(clazz, context):
     await clazz.github(context)
     context.send.assert_called_once_with("https://github.com/duck-dynasty/duckbot")
 
 
-async def test_wiki(bot, context):
-    clazz = Duck(bot)
+async def test_wiki(clazz, context):
     await clazz.wiki(context)
     context.send.assert_called_once_with("https://github.com/duck-dynasty/duckbot/wiki")
 
 
-async def test_delete_command_message(bot, context):
-    clazz = Duck(bot)
+async def test_delete_command_message(clazz, context):
     await clazz.delete_command_message(context)
     context.message.delete.assert_called()
 
 
 @mock.patch("duckbot.cogs.duck.duck.discord.utils.get")
-async def test_post_to_duckboard_no_guild(mock_get, bot, raw_message):
+async def test_post_to_duckboard_no_guild(mock_get, clazz, raw_message):
     raw_message.guild = None
-    clazz = Duck(bot)
     await clazz.post_to_duckboard(raw_message)
     mock_get.assert_not_called()
 
 
 @mock.patch("duckbot.cogs.duck.duck.discord.utils.get", return_value=None)
-async def test_post_to_duckboard_no_duckboard_channel(mock_get, bot, message, skip_if_private_channel):
-    clazz = Duck(bot)
+async def test_post_to_duckboard_no_duckboard_channel(mock_get, clazz, message, skip_if_private_channel):
     await clazz.post_to_duckboard(message)
 
 
 @mock.patch("duckbot.cogs.duck.duck.discord.utils.get")
 @mock.patch("random.choice", return_value=0x3B7A57)
 @mock.patch("random.random", return_value=0.000009)
-async def test_react_duck_sends_to_duckboard(random, mock_choice, mock_get, bot, message, skip_if_private_channel, autospec):
+async def test_react_duck_sends_to_duckboard(random, mock_choice, mock_get, clazz, message, skip_if_private_channel, autospec):
     duckboard_channel = autospec.of(discord.TextChannel)
     mock_get.return_value = duckboard_channel
     message.content = "hello world"
@@ -91,7 +89,6 @@ async def test_react_duck_sends_to_duckboard(random, mock_choice, mock_get, bot,
     message.author.display_name = "TestUser"
     message.author.display_avatar.url = "https://example.com/avatar.png"
     message.channel.mention = "<#456>"
-    clazz = Duck(bot)
     await clazz.react_duck(message)
     message.add_reaction.assert_called_once_with("\U0001f986")
     mock_get.assert_called_once_with(message.guild.text_channels, name="duckboard")

--- a/tests/cogs/fortune/eightball_test.py
+++ b/tests/cogs/fortune/eightball_test.py
@@ -4,33 +4,35 @@ import pytest
 from discord import Colour, Embed
 
 from duckbot.cogs.fortune import EightBall
+from tests.discord_test_ext import bind_commands
 
 
-async def test_eightball_no_text(context):
-    clazz = EightBall()
-    await clazz.eightball(context, None)
+@pytest.fixture
+def clazz() -> EightBall:
+    return bind_commands(EightBall())
+
+
+async def test_eightball_no_text(clazz, context):
+    await clazz.eightball(context, question=None)
     context.send.assert_called_once_with("You need to ask a question to get an answer. :unamused:")
 
 
-async def test_eightball_not_given_question(context):
-    clazz = EightBall()
-    await clazz.eightball(context, "not a question")
+async def test_eightball_not_given_question(clazz, context):
+    await clazz.eightball(context, question="not a question")
     context.send.assert_called_once_with("I can't tell if that's a question, brother.")
 
 
 @pytest.mark.parametrize("question", ["?", "???"])
-async def test_eightball_only_question_marks(context, question):
-    clazz = EightBall()
-    await clazz.eightball(context, question)
+async def test_eightball_only_question_marks(clazz, context, question):
+    await clazz.eightball(context, question=question)
     context.send.assert_called_once_with("Who do you think you are? I AM!\nhttps://youtu.be/gKQOXYB2cd8?t=10")
 
 
 @mock.patch("random.random", return_value=0.5)
 @mock.patch("random.choice", return_value="8ball")
 @mock.patch("asyncio.sleep", return_value=None)
-async def test_eightball_gives_response(sleep, choice, random, context):
-    clazz = EightBall()
-    await clazz.eightball(context, "will this test pass?")
+async def test_eightball_gives_response(sleep, choice, random, clazz, context):
+    await clazz.eightball(context, question="will this test pass?")
     embed = Embed(colour=Colour.purple()).add_field(name=f"{context.author.display_name}, my :crystal_ball: says:", value="_8ball_")
     context.send.assert_called_once_with(embed=embed)
 
@@ -38,9 +40,8 @@ async def test_eightball_gives_response(sleep, choice, random, context):
 @mock.patch("random.random", return_value=0.29)
 @mock.patch("random.choice", side_effect=["joke", "fortune"])
 @mock.patch("asyncio.sleep", return_value=None)
-async def test_eightball_gives_joke_response(sleep, choice, random, context):
-    clazz = EightBall()
-    await clazz.eightball(context, "will this test pass?")
+async def test_eightball_gives_joke_response(sleep, choice, random, clazz, context):
+    await clazz.eightball(context, question="will this test pass?")
     context.send.assert_any_call("joke")
     embed = Embed(colour=Colour.purple()).add_field(name=f"{context.author.display_name}, my :crystal_ball: says:", value="_fortune_")
     context.send.assert_any_call(embed=embed)

--- a/tests/cogs/fortune/fortune_test.py
+++ b/tests/cogs/fortune/fortune_test.py
@@ -1,23 +1,34 @@
 from subprocess import CompletedProcess
 from unittest import mock
 
+import pytest
+
 from duckbot.cogs.fortune import Fortune
 from duckbot.util.messages import MAX_MESSAGE_LENGTH
+from tests.discord_test_ext import bind_commands
+
+
+@pytest.fixture
+def clazz() -> Fortune:
+    return bind_commands(Fortune())
 
 
 @mock.patch("subprocess.run")
-def test_get_fortune_short(run):
+async def test_fortune_sends_fortune(run, clazz, context):
     run.return_value = CompletedProcess([], 0, b"fortune")
-    clazz = Fortune()
-    message = clazz.get_fortune()
-    assert message == "```fortune```"
+    await clazz.fortune(context)
+    context.send.assert_called_once_with("```fortune```")
 
 
 @mock.patch("subprocess.run")
-def test_get_fortune_first_is_long(run):
+def test_get_fortune_short(run, clazz):
+    run.return_value = CompletedProcess([], 0, b"fortune")
+    assert clazz.get_fortune() == "```fortune```"
+
+
+@mock.patch("subprocess.run")
+def test_get_fortune_first_is_long(run, clazz):
     long_message = "f" * MAX_MESSAGE_LENGTH
     short_message = "f"
     run.side_effect = [CompletedProcess([], 0, long_message.encode()), CompletedProcess([], 0, short_message.encode())]
-    clazz = Fortune()
-    message = clazz.get_fortune()
-    assert message == "```f```"
+    assert clazz.get_fortune() == "```f```"

--- a/tests/cogs/games/coin_flip_test.py
+++ b/tests/cogs/games/coin_flip_test.py
@@ -1,19 +1,25 @@
 from unittest import mock
 
+import pytest
+
 from duckbot.cogs.games import CoinFlip
+from tests.discord_test_ext import bind_commands
+
+
+@pytest.fixture
+def clazz() -> CoinFlip:
+    return bind_commands(CoinFlip())
 
 
 @mock.patch("random.random", return_value=0.5)
 @mock.patch("random.choice", return_value="some coin flip result")
-async def test_coin_flip_sends_result(choice, random, context):
-    clazz = CoinFlip()
+async def test_coin_flip_sends_result(choice, random, clazz, context):
     await clazz.coin_flip(context)
     context.send.assert_called_once_with(":coin: :coin: some coin flip result :coin: :coin:")
 
 
 @mock.patch("random.random", return_value=0.9 / 6000.0)
-async def test_coin_flip_lands_on_side(random, context):
-    clazz = CoinFlip()
+async def test_coin_flip_lands_on_side(random, clazz, context):
     await clazz.coin_flip(context)
     context.send.assert_any_call(":coin: :coin: The Side! :coin: :coin:")
     context.send.assert_any_call("1v1 me bro: https://journals.aps.org/pre/abstract/10.1103/PhysRevE.48.2547")

--- a/tests/cogs/games/dice_test.py
+++ b/tests/cogs/games/dice_test.py
@@ -6,36 +6,38 @@ import pytest
 from duckbot.cogs.games import Dice
 from duckbot.cogs.games.dice import CRIT_FAIL_FLAVOUR, CRIT_HIT_FLAVOUR
 from duckbot.util.messages import MAX_MESSAGE_LENGTH
+from tests.discord_test_ext import bind_commands
+
+
+@pytest.fixture
+def clazz() -> Dice:
+    return bind_commands(Dice())
 
 
 @mock.patch("d20.Roller.roll", side_effect=[d20.RollValueError("ded")])
-async def test_roll_dice_error(roller, context):
-    clazz = Dice()
-    await clazz.roll(context, "1d-20")
+async def test_roll_dice_error(roller, clazz, context):
+    await clazz.roll(context, expression="1d-20")
     context.send.assert_called_once_with("Oh... :nauseated_face: I don't feel so good... :face_vomiting:\n```ded```", delete_after=30)
 
 
-async def test_roll_dice_too_many_dice(context):
-    clazz = Dice()
-    await clazz.roll(context, "100001d20")
+async def test_roll_dice_too_many_dice(clazz, context):
+    await clazz.roll(context, expression="100001d20")
     context.send.assert_called_once_with("I can only roll up to 100000 dice.", delete_after=30)
 
 
 @mock.patch("d20.Roller")
-async def test_roll_result_too_long_for_message(roller, context):
+async def test_roll_result_too_long_for_message(roller, clazz, context):
     roller.return_value.roll.return_value.result = "x" * MAX_MESSAGE_LENGTH
     roller.return_value.roll.return_value.total = 100
-    clazz = Dice()
-    await clazz.roll(context, "1d20")
+    await clazz.roll(context, expression="1d20")
     context.send.assert_called_once_with(f"**Rolls**: {'x' * (MAX_MESSAGE_LENGTH - 50)}...\n**Total**: 100")
 
 
 @mock.patch("d20.Roller")
-async def test_roll_sends_result(roller, context):
+async def test_roll_sends_result(roller, clazz, context):
     roller.return_value.roll.return_value.result = "results"
     roller.return_value.roll.return_value.total = 1
-    clazz = Dice()
-    await clazz.roll(context, "1d20")
+    await clazz.roll(context, expression="1d20")
     context.send.assert_called_once_with("**Rolls**: results\n**Total**: 1")
 
 
@@ -48,12 +50,11 @@ async def test_roll_sends_result(roller, context):
 )
 @mock.patch("duckbot.cogs.games.dice.Dice._crit_flavour")
 @mock.patch("d20.Roller")
-async def test_roll_includes_crit_flavour(roller, crit_flavour, flavour, expected_message, context):
+async def test_roll_includes_crit_flavour(roller, crit_flavour, flavour, expected_message, clazz, context):
     roller.return_value.roll.return_value.result = "results"
     roller.return_value.roll.return_value.total = 20
     crit_flavour.return_value = flavour
-    clazz = Dice()
-    await clazz.roll(context, "1d20")
+    await clazz.roll(context, expression="1d20")
     context.send.assert_called_once_with(expected_message)
 
 

--- a/tests/cogs/games/pokemon_test.py
+++ b/tests/cogs/games/pokemon_test.py
@@ -2,33 +2,39 @@ import random
 from datetime import date
 from unittest.mock import patch
 
+import pytest
+
 from duckbot.cogs.games.pokemon import ANCHOR_DATE, POTD_SEED, Pokemon
+from tests.discord_test_ext import bind_commands
 
 POKEMON_API = "https://pokeapi.co/api/v2/pokemon"
 SPECIES_API = "https://pokeapi.co/api/v2/pokemon-species"
 
 
-async def test_pokemon_by_name(bot, context, responses):
+@pytest.fixture
+def clazz(bot) -> Pokemon:
+    return bind_commands(Pokemon(bot))
+
+
+async def test_pokemon_by_name(clazz, context, responses):
     responses.add(responses.GET, f"{POKEMON_API}/pikachu", json=build_pokemon_data())
     responses.add(responses.GET, f"{SPECIES_API}/25/", json=build_species_data())
-    clazz = Pokemon(bot)
-    await clazz.pokemon(context, "pikachu")
+    await clazz.pokemon(context, name_or_id="pikachu")
     context.send.assert_called_once()
     embed = context.send.call_args.kwargs["embed"]
-    assert embed.title == "#25 \u2014 Pikachu"
+    assert embed.title == "#25 — Pikachu"
 
 
-async def test_pokemon_by_id(bot, context, responses):
+async def test_pokemon_by_id(clazz, context, responses):
     responses.add(responses.GET, f"{POKEMON_API}/25", json=build_pokemon_data())
     responses.add(responses.GET, f"{SPECIES_API}/25/", json=build_species_data())
-    clazz = Pokemon(bot)
-    await clazz.pokemon(context, "25")
+    await clazz.pokemon(context, name_or_id="25")
     context.send.assert_called_once()
     embed = context.send.call_args.kwargs["embed"]
-    assert embed.title == "#25 \u2014 Pikachu"
+    assert embed.title == "#25 — Pikachu"
 
 
-async def test_pokemon_no_args_shows_potd(bot, context, responses):
+async def test_pokemon_no_args_shows_potd(clazz, context, responses):
     n = 10
     ids = list(range(1, n + 1))
     random.Random(POTD_SEED).shuffle(ids)
@@ -36,28 +42,25 @@ async def test_pokemon_no_args_shows_potd(bot, context, responses):
     responses.add(responses.GET, f"{SPECIES_API}?limit=1", json={"count": n})
     responses.add(responses.GET, f"{POKEMON_API}/{potd_id}", json=build_pokemon_data(name="testmon", pokemon_id=potd_id))
     responses.add(responses.GET, f"{SPECIES_API}/{potd_id}/", json=build_species_data(pokemon_id=potd_id))
-    clazz = Pokemon(bot)
     with patch("duckbot.cogs.games.pokemon.now") as mock_now:
         mock_now.return_value.date.return_value = ANCHOR_DATE
-        await clazz.pokemon(context, None)
+        await clazz.pokemon(context, name_or_id=None)
     context.send.assert_called_once()
     embed = context.send.call_args.kwargs["embed"]
     assert "Pokemon of the Day:" in embed.title
 
 
-async def test_pokemon_not_found(bot, context, responses):
+async def test_pokemon_not_found(clazz, context, responses):
     responses.add(responses.GET, f"{POKEMON_API}/fakemon", status=404)
-    clazz = Pokemon(bot)
-    await clazz.pokemon(context, "fakemon")
+    await clazz.pokemon(context, name_or_id="fakemon")
     context.send.assert_called_once_with("Could not find a Pokemon named 'fakemon'.")
 
 
-def test_build_embed_has_correct_fields(bot):
-    clazz = Pokemon(bot)
+def test_build_embed_has_correct_fields(clazz):
     data = build_pokemon_data()
     species = build_species_data()
     embed = clazz.build_embed(data, species)
-    assert embed.title == "#25 \u2014 Pikachu"
+    assert embed.title == "#25 — Pikachu"
     assert "Mouse Pokemon" in embed.description
     assert "A Pokemon. It is cool." in embed.description
     assert len(embed.fields) == 3
@@ -70,16 +73,14 @@ def test_build_embed_has_correct_fields(bot):
     assert embed.thumbnail.url == "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/25.png"
 
 
-def test_build_embed_potd_title(bot):
-    clazz = Pokemon(bot)
+def test_build_embed_potd_title(clazz):
     data = build_pokemon_data()
     species = build_species_data()
     embed = clazz.build_embed(data, species, is_potd=True)
-    assert embed.title == "Pokemon of the Day: #25 \u2014 Pikachu"
+    assert embed.title == "Pokemon of the Day: #25 — Pikachu"
 
 
-def test_build_embed_dual_type(bot):
-    clazz = Pokemon(bot)
+def test_build_embed_dual_type(clazz):
     types = [{"slot": 1, "type": {"name": "fire"}}, {"slot": 2, "type": {"name": "flying"}}]
     data = build_pokemon_data(name="charizard", pokemon_id=6, types=types)
     species = build_species_data(pokemon_id=6)
@@ -88,8 +89,7 @@ def test_build_embed_dual_type(bot):
     assert embed.color.value == 0xEE8130
 
 
-def test_build_embed_color_from_primary_type(bot):
-    clazz = Pokemon(bot)
+def test_build_embed_color_from_primary_type(clazz):
     data = build_pokemon_data()
     species = build_species_data()
     embed = clazz.build_embed(data, species)
@@ -133,8 +133,7 @@ def test_get_genus_no_english_returns_empty():
     assert result == ""
 
 
-def test_potd_deterministic(bot):
-    clazz = Pokemon(bot)
+def test_potd_deterministic(clazz):
     clazz._pokemon_count = 1025
     with patch("duckbot.cogs.games.pokemon.now") as mock_now:
         mock_now.return_value.date.return_value = date(2025, 6, 15)
@@ -144,8 +143,7 @@ def test_potd_deterministic(bot):
     assert 1 <= id1 <= 1025
 
 
-def test_potd_different_days_give_different_pokemon(bot):
-    clazz = Pokemon(bot)
+def test_potd_different_days_give_different_pokemon(clazz):
     clazz._pokemon_count = 1025
     with patch("duckbot.cogs.games.pokemon.now") as mock_now:
         mock_now.return_value.date.return_value = date(2025, 6, 15)
@@ -155,45 +153,40 @@ def test_potd_different_days_give_different_pokemon(bot):
     assert id1 != id2
 
 
-def test_pokemon_count_cached(bot, responses):
+def test_pokemon_count_cached(clazz, responses):
     responses.add(responses.GET, f"{SPECIES_API}?limit=1", json={"count": 1025})
-    clazz = Pokemon(bot)
     count1 = clazz.pokemon_count
     count2 = clazz.pokemon_count
     assert count1 == count2 == 1025
     assert len(responses.calls) == 1
 
 
-def test_pokemon_names_cached(bot, responses):
+def test_pokemon_names_cached(clazz, responses):
     responses.add(responses.GET, f"{SPECIES_API}?limit=1", json={"count": 3})
     responses.add(responses.GET, f"{SPECIES_API}?limit=3", json={"results": [{"name": "bulbasaur"}, {"name": "ivysaur"}, {"name": "venusaur"}]})
-    clazz = Pokemon(bot)
     names1 = clazz.pokemon_names
     names2 = clazz.pokemon_names
     assert names1 == names2 == ["bulbasaur", "ivysaur", "venusaur"]
     assert len(responses.calls) == 2  # one for count, one for names
 
 
-async def test_autocomplete_returns_matches(bot, responses):
+async def test_autocomplete_returns_matches(clazz, responses):
     responses.add(responses.GET, f"{SPECIES_API}?limit=1", json={"count": 3})
     responses.add(responses.GET, f"{SPECIES_API}?limit=3", json={"results": [{"name": "pikachu"}, {"name": "pichu"}, {"name": "bulbasaur"}]})
-    clazz = Pokemon(bot)
     results = await clazz.pokemon_name_autocomplete(None, "pik")
     assert len(results) == 1
     assert results[0].name == "pikachu"
 
 
-async def test_autocomplete_short_input_returns_empty(bot):
-    clazz = Pokemon(bot)
+async def test_autocomplete_short_input_returns_empty(clazz):
     results = await clazz.pokemon_name_autocomplete(None, "pi")
     assert results == []
 
 
-async def test_autocomplete_max_25_results(bot, responses):
+async def test_autocomplete_max_25_results(clazz, responses):
     responses.add(responses.GET, f"{SPECIES_API}?limit=1", json={"count": 30})
     names = [{"name": f"pokemon{i}"} for i in range(30)]
     responses.add(responses.GET, f"{SPECIES_API}?limit=30", json={"results": names})
-    clazz = Pokemon(bot)
     results = await clazz.pokemon_name_autocomplete(None, "pok")
     assert len(results) == 25
 

--- a/tests/cogs/games/satisfy/satisfy_test.py
+++ b/tests/cogs/games/satisfy/satisfy_test.py
@@ -10,11 +10,12 @@ from duckbot.cogs.games.satisfy.factory import Factory
 from duckbot.cogs.games.satisfy.item import Item
 from duckbot.cogs.games.satisfy.rates import Rates
 from duckbot.cogs.games.satisfy.recipe import ModifiedRecipe, all, as_slooped, default
+from tests.discord_test_ext import bind_commands
 
 
 @pytest.fixture
 def clazz(bot) -> Satisfy:
-    return Satisfy(bot)
+    return bind_commands(Satisfy(bot))
 
 
 @pytest.fixture
@@ -25,92 +26,92 @@ def default_factory(clazz, context) -> Factory:
 async def test_reset_destroys_factory(clazz, context):
     empty_factory = Factory(Rates(), [], Rates(), set())
     clazz.save(context, empty_factory)
-    await clazz.reset.callback(clazz, context)
+    await clazz.reset(context)
     assert clazz.factory_cache == {}
     context.send.assert_called_once_with(f":factory: :fire: Factory for {context.author.display_name} cleared. Bitch. :fire: :factory:", delete_after=60)
 
 
 async def test_factory_state_sends_something_i_guess(clazz, context):
-    await clazz.factory_state.callback(clazz, context)
+    await clazz.factory_state(context)
     context.send.assert_called_once()
 
 
 async def test_add_input_stores_input_rate(clazz, context, default_factory):
-    await clazz.add_input.callback(clazz, context, str(Item.IronOre), 30)
+    await clazz.add_input(context, str(Item.IronOre), 30)
     default_factory.inputs = Item.IronOre * 30
     assert clazz.factory(context) == default_factory
 
-    await clazz.add_input.callback(clazz, context, str(Item.IronIngot), 30)
+    await clazz.add_input(context, str(Item.IronIngot), 30)
     default_factory.inputs = Item.IronOre * 30 + Item.IronIngot * 30
     assert clazz.factory(context) == default_factory
 
 
 async def test_add_target_stores_output_rate(clazz, context, default_factory):
-    await clazz.add_target.callback(clazz, context, str(Item.IronOre), 30)
+    await clazz.add_target(context, str(Item.IronOre), 30)
     default_factory.targets = Item.IronOre * 30
     assert clazz.factory(context) == default_factory
 
-    await clazz.add_target.callback(clazz, context, str(Item.IronIngot), 30)
+    await clazz.add_target(context, str(Item.IronIngot), 30)
     default_factory.targets = Item.IronOre * 30 + Item.IronIngot * 30
     assert clazz.factory(context) == default_factory
 
 
 async def test_toggle_maximize_stores_maximizer(clazz, context, default_factory):
-    await clazz.toggle_maximize.callback(clazz, context, str(Item.IronOre))
+    await clazz.toggle_maximize(context, str(Item.IronOre))
     default_factory.maximize = {Item.IronOre}
     assert clazz.factory(context) == default_factory
 
-    await clazz.toggle_maximize.callback(clazz, context, str(Item.IronIngot))
+    await clazz.toggle_maximize(context, str(Item.IronIngot))
     default_factory.maximize = {Item.IronOre, Item.IronIngot}
     assert clazz.factory(context) == default_factory
 
 
 async def test_toggle_maximize_removes_already_maximized_item(clazz, context, default_factory):
-    await clazz.toggle_maximize.callback(clazz, context, str(Item.IronOre))
-    await clazz.toggle_maximize.callback(clazz, context, str(Item.IronOre))
+    await clazz.toggle_maximize(context, str(Item.IronOre))
+    await clazz.toggle_maximize(context, str(Item.IronOre))
     default_factory.maximize = set()
     assert clazz.factory(context) == default_factory
 
 
 async def test_toggle_maximize_removes_toggled_only(clazz, context, default_factory):
-    await clazz.toggle_maximize.callback(clazz, context, str(Item.IronOre))
-    await clazz.toggle_maximize.callback(clazz, context, str(Item.IronIngot))
-    await clazz.toggle_maximize.callback(clazz, context, str(Item.CopperOre))
-    await clazz.toggle_maximize.callback(clazz, context, str(Item.IronIngot))
+    await clazz.toggle_maximize(context, str(Item.IronOre))
+    await clazz.toggle_maximize(context, str(Item.IronIngot))
+    await clazz.toggle_maximize(context, str(Item.CopperOre))
+    await clazz.toggle_maximize(context, str(Item.IronIngot))
     default_factory.maximize = {Item.IronOre, Item.CopperOre}
     assert clazz.factory(context) == default_factory
 
 
 async def test_add_booster_power_shard(clazz, context, default_factory):
-    await clazz.add_booster.callback(clazz, context, str(Item.PowerShard), 10)
+    await clazz.add_booster(context, str(Item.PowerShard), 10)
     default_factory.power_shards = 10
     assert clazz.factory(context) == default_factory
 
 
 async def test_add_booster_sloops(clazz, context, default_factory):
-    await clazz.add_booster.callback(clazz, context, str(Item.Somersloop), 10)
+    await clazz.add_booster(context, str(Item.Somersloop), 10)
     default_factory.sloops = 10
     assert clazz.factory(context) == default_factory
 
 
 async def test_recipe_bank_stores_bank(clazz, context):
-    await clazz.recipe_bank.callback(clazz, context, "Default")
+    await clazz.recipe_bank(context, "Default")
     assert clazz.factory(context).recipe_bank == "Default"
 
 
 async def test_include_recipe_adds_include_no_boost(clazz, context):
-    await clazz.include_recipe.callback(clazz, context, str(Item.IronOre))
+    await clazz.include_recipe(context, str(Item.IronOre))
     assert clazz.factory(context).include_recipes == {r.name for r in sloop([r for r in all() if r.name in ["IronOre"]])}
 
-    await clazz.include_recipe.callback(clazz, context, str(Item.IronIngot))
+    await clazz.include_recipe(context, str(Item.IronIngot))
     assert clazz.factory(context).include_recipes == {r.name for r in sloop([r for r in all() if r.name in ["IronOre", "IronIngot"]])}
 
 
 async def test_include_recipe_adds_include_with_boost(clazz, context):
-    await clazz.include_recipe.callback(clazz, context, str(Item.IronIngot), 3, 1)
+    await clazz.include_recipe(context, str(Item.IronIngot), 3, 1)
     assert clazz.factory(context).include_recipes == {r.name for r in sloop(all()) if r.original_recipe.name == "IronIngot" and r.sloops == 1 and r.power_shards == 3}
 
-    await clazz.include_recipe.callback(clazz, context, str(Item.CopperIngot), 2, 0)
+    await clazz.include_recipe(context, str(Item.CopperIngot), 2, 0)
     assert clazz.factory(context).include_recipes == {
         r.name
         for r in sloop(all())
@@ -119,15 +120,15 @@ async def test_include_recipe_adds_include_with_boost(clazz, context):
 
 
 async def test_include_recipe_removes_exclusion(clazz, context):
-    await clazz.exclude_recipe.callback(clazz, context, str(Item.IronOre))
-    await clazz.include_recipe.callback(clazz, context, str(Item.IronOre))
+    await clazz.exclude_recipe(context, str(Item.IronOre))
+    await clazz.include_recipe(context, str(Item.IronOre))
     assert clazz.factory(context).include_recipes == set()
     assert clazz.factory(context).exclude_recipes == set()
 
 
 async def test_include_recipe_removes_boosted_exclusion(clazz, context):
-    await clazz.exclude_recipe.callback(clazz, context, str(Item.IronIngot), 3, 1)
-    await clazz.include_recipe.callback(clazz, context, str(Item.IronIngot))
+    await clazz.exclude_recipe(context, str(Item.IronIngot), 3, 1)
+    await clazz.include_recipe(context, str(Item.IronIngot))
     assert clazz.factory(context).include_recipes == set()
     assert clazz.factory(context).exclude_recipes == set()
 
@@ -135,22 +136,22 @@ async def test_include_recipe_removes_boosted_exclusion(clazz, context):
 @pytest.mark.parametrize("shards,sloops", [(None, 0), (0, None)])
 async def test_include_recipe_invalid_args(clazz, context, shards, sloops):
     with pytest.raises(ValueError):
-        await clazz.include_recipe.callback(clazz, context, str(Item.IronIngot), shards, sloops)
+        await clazz.include_recipe(context, str(Item.IronIngot), shards, sloops)
 
 
 async def test_exclude_recipe_adds_exclude_no_boost(clazz, context):
-    await clazz.exclude_recipe.callback(clazz, context, str(Item.IronOre))
+    await clazz.exclude_recipe(context, str(Item.IronOre))
     assert clazz.factory(context).exclude_recipes == {r.name for r in sloop([r for r in all() if r.name in ["IronOre"]])}
 
-    await clazz.exclude_recipe.callback(clazz, context, str(Item.IronIngot))
+    await clazz.exclude_recipe(context, str(Item.IronIngot))
     assert clazz.factory(context).exclude_recipes == {r.name for r in sloop([r for r in all() if r.name in ["IronOre", "IronIngot"]])}
 
 
 async def test_exclude_recipe_adds_include_with_boost(clazz, context):
-    await clazz.exclude_recipe.callback(clazz, context, str(Item.IronIngot), 3, 1)
+    await clazz.exclude_recipe(context, str(Item.IronIngot), 3, 1)
     assert clazz.factory(context).exclude_recipes == {r.name for r in sloop(all()) if r.original_recipe.name == "IronIngot" and r.sloops == 1 and r.power_shards == 3}
 
-    await clazz.exclude_recipe.callback(clazz, context, str(Item.CopperIngot), 2, 0)
+    await clazz.exclude_recipe(context, str(Item.CopperIngot), 2, 0)
     assert clazz.factory(context).exclude_recipes == {
         r.name
         for r in sloop(all())
@@ -159,15 +160,15 @@ async def test_exclude_recipe_adds_include_with_boost(clazz, context):
 
 
 async def test_exclude_recipe_removes_inclusion(clazz, context):
-    await clazz.include_recipe.callback(clazz, context, str(Item.IronOre))
-    await clazz.exclude_recipe.callback(clazz, context, str(Item.IronOre))
+    await clazz.include_recipe(context, str(Item.IronOre))
+    await clazz.exclude_recipe(context, str(Item.IronOre))
     assert clazz.factory(context).exclude_recipes == set()
     assert clazz.factory(context).include_recipes == set()
 
 
 async def test_exclude_recipe_removes_boosted_inclusion(clazz, context):
-    await clazz.include_recipe.callback(clazz, context, str(Item.IronIngot), 3, 1)
-    await clazz.exclude_recipe.callback(clazz, context, str(Item.IronIngot))
+    await clazz.include_recipe(context, str(Item.IronIngot), 3, 1)
+    await clazz.exclude_recipe(context, str(Item.IronIngot))
     assert clazz.factory(context).exclude_recipes == set()
     assert clazz.factory(context).include_recipes == set()
 
@@ -175,22 +176,22 @@ async def test_exclude_recipe_removes_boosted_inclusion(clazz, context):
 @pytest.mark.parametrize("shards,sloops", [(None, 0), (0, None)])
 async def test_exclude_recipe_invalid_args(clazz, context, shards, sloops):
     with pytest.raises(ValueError):
-        await clazz.exclude_recipe.callback(clazz, context, str(Item.IronIngot), shards, sloops)
+        await clazz.exclude_recipe(context, str(Item.IronIngot), shards, sloops)
 
 
 async def test_limit_recipe_adds_limit_no_boost(clazz, context, default_factory):
-    await clazz.limit_recipe.callback(clazz, context, str(Item.IronOre), 30)
+    await clazz.limit_recipe(context, str(Item.IronOre), 30)
     assert clazz.factory(context).limits == {x: 30 for x in sloop([r for r in all() if r.name in ["IronOre"]])}
 
-    await clazz.limit_recipe.callback(clazz, context, str(Item.IronIngot), 30)
+    await clazz.limit_recipe(context, str(Item.IronIngot), 30)
     assert clazz.factory(context).limits == {x: 30 for x in sloop([r for r in all() if r.name in ["IronOre", "IronIngot"]])}
 
 
 async def test_limit_recipe_adds_include_with_boost(clazz, context):
-    await clazz.limit_recipe.callback(clazz, context, str(Item.IronIngot), 30, 3, 1)
+    await clazz.limit_recipe(context, str(Item.IronIngot), 30, 3, 1)
     assert clazz.factory(context).limits == {r: 30 for r in sloop(all()) if r.original_recipe.name == "IronIngot" and r.sloops == 1 and r.power_shards == 3}
 
-    await clazz.limit_recipe.callback(clazz, context, str(Item.CopperIngot), 30, 2, 0)
+    await clazz.limit_recipe(context, str(Item.CopperIngot), 30, 2, 0)
     assert clazz.factory(context).limits == {
         r: 30
         for r in sloop(all())
@@ -199,26 +200,26 @@ async def test_limit_recipe_adds_include_with_boost(clazz, context):
 
 
 async def test_limit_recipe_adds_limit_with_boost(clazz, context, default_factory):
-    await clazz.limit_recipe.callback(clazz, context, str(Item.IronOre), 30)
+    await clazz.limit_recipe(context, str(Item.IronOre), 30)
     assert clazz.factory(context).limits == {x: 30 for x in sloop([r for r in all() if r.name in ["IronOre"]])}
 
-    await clazz.limit_recipe.callback(clazz, context, str(Item.IronIngot), 30)
+    await clazz.limit_recipe(context, str(Item.IronIngot), 30)
     assert clazz.factory(context).limits == {x: 30 for x in sloop([r for r in all() if r.name in ["IronOre", "IronIngot"]])}
 
 
 @pytest.mark.parametrize("shards,sloops", [(None, 0), (0, None)])
 async def test_limit_recipe_invalid_args(clazz, context, shards, sloops):
     with pytest.raises(ValueError):
-        await clazz.limit_recipe.callback(clazz, context, str(Item.IronIngot), 30, shards, sloops)
+        await clazz.limit_recipe(context, str(Item.IronIngot), 30, shards, sloops)
 
 
 async def test_solve_no_factory_rejects(clazz, context):
-    await clazz.solve.callback(clazz, context)
+    await clazz.solve(context)
     context.send.assert_called_once_with("No.", delete_after=60)
 
 
 async def test_solve_no_in_or_out(clazz, context, default_factory):
-    await clazz.solve.callback(clazz, context)
+    await clazz.solve(context)
     context.send.assert_called_once_with("No.", delete_after=60)
 
 
@@ -230,7 +231,7 @@ async def test_solve_all_defaults(opt, clazz, context, default_factory):
     expected.recipes = sloop(default())
 
     clazz.save(context, default_factory)
-    await clazz.solve.callback(clazz, context)
+    await clazz.solve(context)
     opt.assert_called_once_with(expected)
 
 
@@ -243,7 +244,7 @@ async def test_solve_different_recipe_bank(opt, clazz, context, default_factory)
     expected.recipes = sloop(all())
 
     clazz.save(context, default_factory)
-    await clazz.solve.callback(clazz, context)
+    await clazz.solve(context)
     opt.assert_called_once_with(expected)
 
 
@@ -257,7 +258,7 @@ async def test_solve_recipe_includes(opt, clazz, context, default_factory):
     expected.recipes = sloop(default() + [r for r in all() if r.name == "DilutedPackagedFuel"])
 
     clazz.save(context, default_factory)
-    await clazz.solve.callback(clazz, context)
+    await clazz.solve(context)
     opt.assert_called_once_with(expected)
 
 
@@ -270,7 +271,7 @@ async def test_solve_recipe_excludes(opt, clazz, context, default_factory):
     expected.recipes = sloop([r for r in default() if r.name == "IronIngot"])
 
     clazz.save(context, default_factory)
-    await clazz.solve.callback(clazz, context)
+    await clazz.solve(context)
     opt.assert_called_once_with(expected)
 
 
@@ -280,7 +281,7 @@ async def test_solve_sends_graph_file(mock_opt, mock_graph, clazz, context, defa
     default_factory.inputs = Item.IronOre * 30
     default_factory.maximize = {Item.IronIngot}
     clazz.save(context, default_factory)
-    await clazz.solve.callback(clazz, context)
+    await clazz.solve(context)
     last_call_kwargs = context.send.call_args_list[-1].kwargs
     assert "file" in last_call_kwargs
     assert isinstance(last_call_kwargs["file"], discord.File)

--- a/tests/cogs/github/yolo_merge_test.py
+++ b/tests/cogs/github/yolo_merge_test.py
@@ -14,6 +14,7 @@ from github.GithubException import UnknownObjectException
 
 from duckbot.cogs.github import YoloMerge
 from duckbot.cogs.github.yolo_merge import MergeConfirmation
+from tests.discord_test_ext import bind_commands
 
 
 @pytest.fixture
@@ -28,7 +29,7 @@ def gh(autospec) -> github.Github:
 
 @pytest.fixture
 def yolo(bot, gh) -> YoloMerge:
-    clazz = YoloMerge(bot)
+    clazz = bind_commands(YoloMerge(bot))
     clazz._github = gh
     return clazz
 

--- a/tests/cogs/google/let_me_google_that_test.py
+++ b/tests/cogs/google/let_me_google_that_test.py
@@ -1,10 +1,16 @@
 import discord
+import pytest
 
 from duckbot.cogs.google import LetMeGoogleThat
+from tests.discord_test_ext import bind_commands
 
 
-async def test_let_me_google_that_generates_link(context):
-    clazz = LetMeGoogleThat()
-    await clazz.let_me_google_that(context, "search thing")
+@pytest.fixture
+def clazz() -> LetMeGoogleThat:
+    return bind_commands(LetMeGoogleThat())
+
+
+async def test_let_me_google_that_generates_link(clazz, context):
+    await clazz.let_me_google_that(context, query="search thing")
     context.send.assert_called_once_with(embed=discord.Embed().add_field(name="search thing", value="[https://google.com/search?q=search+thing](https://letmegooglethat.com/?q=search+thing)"))
     context.message.delete.assert_called()

--- a/tests/cogs/insights/insights_test.py
+++ b/tests/cogs/insights/insights_test.py
@@ -1,60 +1,61 @@
 import datetime
 from unittest import mock
 
+import pytest
+
 from duckbot.cogs.insights import Insights
 from tests import list_as_async_generator
+from tests.discord_test_ext import bind_commands
 
 
-async def test_before_loop_waits_for_bot(bot):
-    clazz = Insights(bot)
+@pytest.fixture
+def clazz(bot) -> Insights:
+    return bind_commands(Insights(bot))
+
+
+async def test_before_loop_waits_for_bot(clazz, bot):
     await clazz.before_loop()
     bot.wait_until_ready.assert_called()
 
 
-async def test_cog_unload_cancels_task(bot):
-    clazz = Insights(bot)
+async def test_cog_unload_cancels_task(clazz):
     clazz.cog_unload()
     clazz.check_should_respond_loop.cancel.assert_called()
 
 
-async def test_check_should_respond_no_history(bot, general_channel):
+async def test_check_should_respond_no_history(clazz, general_channel):
     general_channel.history.return_value = list_as_async_generator([])
-    clazz = Insights(bot)
     await clazz.check_should_respond()
     general_channel.send.assert_not_called()
 
 
 @mock.patch("duckbot.cogs.insights.insights.utcnow", return_value=datetime.datetime(2000, 1, 1, hour=12, minute=00, tzinfo=datetime.timezone.utc))
-async def test_check_should_respond_new_message(utcnow, bot, raw_message, general_channel):
+async def test_check_should_respond_new_message(utcnow, clazz, raw_message, general_channel):
     raw_message.created_at = datetime.datetime(2000, 1, 1, hour=11, minute=38, tzinfo=datetime.timezone.utc)
     raw_message.author.id = 244629273191645184
     general_channel.history.return_value = list_as_async_generator([raw_message])
-    clazz = Insights(bot)
     await clazz.check_should_respond()
     general_channel.send.assert_not_called()
 
 
 @mock.patch("duckbot.cogs.insights.insights.utcnow", return_value=datetime.datetime(2000, 1, 1, hour=12, minute=00, tzinfo=datetime.timezone.utc))
-async def test_check_should_respond_not_special_user(utcnow, bot, raw_message, general_channel):
+async def test_check_should_respond_not_special_user(utcnow, clazz, raw_message, general_channel):
     raw_message.created_at = datetime.datetime(2000, 1, 1, hour=11, minute=00, tzinfo=datetime.timezone.utc)
     raw_message.author.id = 0
     general_channel.history.return_value = list_as_async_generator([raw_message])
-    clazz = Insights(bot)
     await clazz.check_should_respond()
     general_channel.send.assert_not_called()
 
 
 @mock.patch("duckbot.cogs.insights.insights.utcnow", return_value=datetime.datetime(2000, 1, 1, hour=12, minute=00, tzinfo=datetime.timezone.utc))
-async def test_check_should_respond_old_message_sent_by_special_user(utcnow, bot, raw_message, general_channel):
+async def test_check_should_respond_old_message_sent_by_special_user(utcnow, clazz, raw_message, general_channel):
     raw_message.created_at = datetime.datetime(2000, 1, 1, hour=11, minute=00, tzinfo=datetime.timezone.utc)
     raw_message.author.id = 244629273191645184
     general_channel.history.return_value = list_as_async_generator([raw_message])
-    clazz = Insights(bot)
     await clazz.check_should_respond()
     general_channel.send.assert_called()
 
 
-async def test_insight_command_sends_message(bot, context):
-    clazz = Insights(bot)
+async def test_insight_sends_message(clazz, context):
     await clazz.insight(context)
     context.send.assert_called()

--- a/tests/cogs/math/wolfram_alpha_test.py
+++ b/tests/cogs/math/wolfram_alpha_test.py
@@ -4,6 +4,7 @@ import wolframalpha
 
 from duckbot.cogs.math import WolframAlpha
 from duckbot.util.embeds import MAX_EMBED_LENGTH, MAX_TITLE_LENGTH
+from tests.discord_test_ext import bind_commands
 
 
 @pytest.fixture
@@ -13,7 +14,7 @@ def wra_client(autospec) -> wolframalpha.Client:
 
 @pytest.fixture
 def wolfram(bot, wra_client) -> WolframAlpha:
-    clazz = WolframAlpha(bot)
+    clazz = bind_commands(WolframAlpha(bot))
     clazz._wolfram = wra_client
     return clazz
 
@@ -31,14 +32,14 @@ def test_wolfram_returns_cached_instance(wolfram, wra_client):
 
 async def test_calc_single_pod(wolfram, context, wra_client):
     wra_client.aquery.return_value = result([pod(subpods=[subpod(img=image())])])
-    await wolfram.calc(context, "query")
+    await wolfram.calc(context, query="query")
     embed = discord.Embed(title="title").set_image(url="src").add_field(name="subtitle", value="plaintext")
     context.send.assert_called_once_with("https://www.wolframalpha.com/input/?i=query", embeds=[embed])
 
 
 async def test_calc_single_pod_large_embed(wolfram, context, wra_client):
     wra_client.aquery.return_value = result([pod(title="p" * MAX_EMBED_LENGTH, subpods=[subpod(title="s" * MAX_EMBED_LENGTH, plaintext="t" * MAX_EMBED_LENGTH, img=image())])])
-    await wolfram.calc(context, "query")
+    await wolfram.calc(context, query="query")
     embed = discord.Embed(title="p" * MAX_TITLE_LENGTH).set_image(url="src").add_field(name="s" * 64, value="t" * 512)
     context.send.assert_called_once_with("https://www.wolframalpha.com/input/?i=query", embeds=[embed])
 
@@ -51,7 +52,7 @@ async def test_calc_multiple_pods_and_subpods(wolfram, context, wra_client):
             pod(title="pod3", subpods=[subpod(title=None, img=image(title="img", src="pod3.img"))]),
         ]
     )
-    await wolfram.calc(context, "query things")
+    await wolfram.calc(context, query="query things")
     embed1 = discord.Embed(title="pod1").set_image(url="2.img").add_field(name="1", value="plaintext").add_field(name="2", value="plaintext")
     embed2 = discord.Embed(title="pod2").add_field(name="3", value="plaintext")
     embed3 = discord.Embed(title="pod3").set_image(url="pod3.img").add_field(name="img", value="plaintext")

--- a/tests/cogs/messages/touch_grass_test.py
+++ b/tests/cogs/messages/touch_grass_test.py
@@ -1,19 +1,26 @@
 import datetime
 from unittest import mock
 
+import pytest
+
 from duckbot.cogs.messages.touch_grass import TouchGrass
+from tests.discord_test_ext import bind_commands
 
 MONDAY_NOON = datetime.datetime(2024, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc)  # Mon, work hours
 SATURDAY_NOON = datetime.datetime(2024, 1, 6, 12, 0, 0, tzinfo=datetime.timezone.utc)  # Sat, off hours
 
 
+@pytest.fixture
+def clazz(bot) -> TouchGrass:
+    return bind_commands(TouchGrass(bot))
+
+
 @mock.patch("duckbot.cogs.messages.touch_grass.utcnow")
-async def test_bot_messages_are_ignored(mock_utcnow, bot, bot_message):
+async def test_bot_messages_are_ignored(mock_utcnow, clazz, bot_message):
     """Bot messages should not be tracked."""
     base_time = datetime.datetime(2024, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc)
     mock_utcnow.return_value = base_time
 
-    clazz = TouchGrass(bot)
     await clazz.on_message_activity(bot_message)
 
     # Should not have tracked anything
@@ -22,12 +29,11 @@ async def test_bot_messages_are_ignored(mock_utcnow, bot, bot_message):
 
 
 @mock.patch("duckbot.cogs.messages.touch_grass.utcnow")
-async def test_tracks_user_messages(mock_utcnow, bot, message):
+async def test_tracks_user_messages(mock_utcnow, clazz, message):
     """User messages should be tracked with timestamps."""
     base_time = datetime.datetime(2024, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc)
     mock_utcnow.return_value = base_time
 
-    clazz = TouchGrass(bot)
     await clazz.track_activity(message)
     await clazz.track_activity(message)
     await clazz.track_activity(message)
@@ -38,12 +44,10 @@ async def test_tracks_user_messages(mock_utcnow, bot, message):
 
 
 @mock.patch("duckbot.cogs.messages.touch_grass.utcnow")
-async def test_threshold_not_reached_no_notification(mock_utcnow, bot, message):
+async def test_threshold_not_reached_no_notification(mock_utcnow, clazz, message):
     """Sending 39 messages should not trigger notification."""
     base_time = datetime.datetime(2024, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc)
     mock_utcnow.return_value = base_time
-
-    clazz = TouchGrass(bot)
 
     # Send 39 messages
     for i in range(39):
@@ -55,13 +59,11 @@ async def test_threshold_not_reached_no_notification(mock_utcnow, bot, message):
 
 
 @mock.patch("duckbot.cogs.messages.touch_grass.utcnow")
-async def test_threshold_reached_sends_notification(mock_utcnow, bot, message):
+async def test_threshold_reached_sends_notification(mock_utcnow, clazz, message):
     """Sending 40 messages should trigger notification."""
     base_time = datetime.datetime(2024, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc)
     mock_utcnow.return_value = base_time
     message.author.display_name = "TestUser"
-
-    clazz = TouchGrass(bot)
 
     # Send 40 messages
     for i in range(40):
@@ -77,12 +79,10 @@ async def test_threshold_reached_sends_notification(mock_utcnow, bot, message):
 
 
 @mock.patch("duckbot.cogs.messages.touch_grass.utcnow")
-async def test_cooldown_prevents_duplicate_notifications(mock_utcnow, bot, message):
+async def test_cooldown_prevents_duplicate_notifications(mock_utcnow, clazz, message):
     """Cooldown should prevent multiple notifications within 1 hour."""
     base_time = datetime.datetime(2024, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc)
     mock_utcnow.return_value = base_time
-
-    clazz = TouchGrass(bot)
 
     # Send 40 messages to trigger first notification
     for i in range(40):
@@ -99,12 +99,10 @@ async def test_cooldown_prevents_duplicate_notifications(mock_utcnow, bot, messa
 
 
 @mock.patch("duckbot.cogs.messages.touch_grass.utcnow")
-async def test_cooldown_expires_allows_new_notification(mock_utcnow, bot, message):
+async def test_cooldown_expires_allows_new_notification(mock_utcnow, clazz, message):
     """After 1 hour cooldown, should be able to notify again."""
     base_time = datetime.datetime(2024, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc)
     mock_utcnow.return_value = base_time
-
-    clazz = TouchGrass(bot)
 
     # Send 40 messages at T=0 to trigger first notification
     for _ in range(40):
@@ -122,12 +120,10 @@ async def test_cooldown_expires_allows_new_notification(mock_utcnow, bot, messag
 
 
 @mock.patch("duckbot.cogs.messages.touch_grass.utcnow")
-async def test_sliding_window_removes_old_messages(mock_utcnow, bot, message):
+async def test_sliding_window_removes_old_messages(mock_utcnow, clazz, message):
     """Messages older than 60 minutes should be removed from tracking."""
     base_time = datetime.datetime(2024, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc)
     mock_utcnow.return_value = base_time
-
-    clazz = TouchGrass(bot)
 
     # Send 20 messages at T=0
     for _ in range(20):
@@ -144,12 +140,10 @@ async def test_sliding_window_removes_old_messages(mock_utcnow, bot, message):
 
 
 @mock.patch("duckbot.cogs.messages.touch_grass.utcnow")
-async def test_multiple_users_tracked_separately(mock_utcnow, bot, message):
+async def test_multiple_users_tracked_separately(mock_utcnow, clazz, message):
     """Different users should have separate tracking."""
     base_time = datetime.datetime(2024, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc)
     mock_utcnow.return_value = base_time
-
-    clazz = TouchGrass(bot)
 
     # User 1 sends 40 messages
     message.author.id = 12345
@@ -170,12 +164,10 @@ async def test_multiple_users_tracked_separately(mock_utcnow, bot, message):
 
 
 @mock.patch("duckbot.cogs.messages.touch_grass.utcnow")
-async def test_clean_old_messages_preserves_recent(mock_utcnow, bot, message):
+async def test_clean_old_messages_preserves_recent(mock_utcnow, clazz, message):
     """Cleanup should only remove old messages, not recent ones."""
     base_time = datetime.datetime(2024, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc)
     mock_utcnow.return_value = base_time
-
-    clazz = TouchGrass(bot)
 
     # Send 20 messages at T=0
     for _ in range(20):
@@ -195,36 +187,33 @@ async def test_clean_old_messages_preserves_recent(mock_utcnow, bot, message):
 
 
 @mock.patch("duckbot.cogs.messages.touch_grass.utcnow")
-async def test_should_notify_returns_true_for_new_user(mock_utcnow, bot, message):
+async def test_should_notify_returns_true_for_new_user(mock_utcnow, clazz, message):
     """First notification for a user should be allowed."""
     base_time = datetime.datetime(2024, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc)
     mock_utcnow.return_value = base_time
 
-    clazz = TouchGrass(bot)
     clazz.activity[message.author.id] = {"messages": [], "last_notification": None}
 
     assert clazz.should_notify(message.author.id, base_time) is True
 
 
 @mock.patch("duckbot.cogs.messages.touch_grass.utcnow")
-async def test_should_notify_returns_false_within_cooldown(mock_utcnow, bot, message):
+async def test_should_notify_returns_false_within_cooldown(mock_utcnow, clazz, message):
     """Notification within cooldown period should be blocked."""
     base_time = datetime.datetime(2024, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc)
     last_notification = base_time - datetime.timedelta(minutes=30)
 
-    clazz = TouchGrass(bot)
     clazz.activity[message.author.id] = {"messages": [], "last_notification": last_notification}
 
     assert clazz.should_notify(message.author.id, base_time) is False
 
 
 @mock.patch("duckbot.cogs.messages.touch_grass.utcnow")
-async def test_should_notify_returns_true_after_cooldown(mock_utcnow, bot, message):
+async def test_should_notify_returns_true_after_cooldown(mock_utcnow, clazz, message):
     """Notification after cooldown expires should be allowed."""
     base_time = datetime.datetime(2024, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc)
     last_notification = base_time - datetime.timedelta(hours=1, minutes=1)
 
-    clazz = TouchGrass(bot)
     clazz.activity[message.author.id] = {"messages": [], "last_notification": last_notification}
 
     assert clazz.should_notify(message.author.id, base_time) is True
@@ -232,13 +221,12 @@ async def test_should_notify_returns_true_after_cooldown(mock_utcnow, bot, messa
 
 @mock.patch("random.choice")
 @mock.patch("duckbot.cogs.messages.touch_grass.utcnow")
-async def test_send_notification_uses_random_grass_phrase_off_hours(mock_utcnow, mock_random, bot, message):
+async def test_send_notification_uses_random_grass_phrase_off_hours(mock_utcnow, mock_random, clazz, message):
     """Off-hours notification should select from touch grass phrases."""
     mock_random.return_value = "Test message with {name} and {count}"
     mock_utcnow.return_value = SATURDAY_NOON
     message.author.display_name = "TestUser"
 
-    clazz = TouchGrass(bot)
     await clazz.send_notification(message, 42, work_hours=False)
 
     message.channel.send.assert_called_once()
@@ -249,13 +237,12 @@ async def test_send_notification_uses_random_grass_phrase_off_hours(mock_utcnow,
 
 @mock.patch("random.choice")
 @mock.patch("duckbot.cogs.messages.touch_grass.utcnow")
-async def test_send_notification_uses_work_phrase_during_work_hours(mock_utcnow, mock_random, bot, message):
+async def test_send_notification_uses_work_phrase_during_work_hours(mock_utcnow, mock_random, clazz, message):
     """Work-hours notification should select from work phrases."""
     mock_random.return_value = "Get back to work {name}! {count} messages."
     mock_utcnow.return_value = MONDAY_NOON
     message.author.display_name = "TestUser"
 
-    clazz = TouchGrass(bot)
     await clazz.send_notification(message, 42, work_hours=True)
 
     from duckbot.cogs.messages.touch_grass_phrases import work_phrases
@@ -267,12 +254,11 @@ async def test_send_notification_uses_work_phrase_during_work_hours(mock_utcnow,
 
 
 @mock.patch("duckbot.cogs.messages.touch_grass.utcnow")
-async def test_show_activity_stats_no_activity(mock_utcnow, bot, context):
+async def test_show_activity_stats_no_activity(mock_utcnow, clazz, context):
     """Stats command shows message when no recent activity."""
     base_time = datetime.datetime(2024, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc)
     mock_utcnow.return_value = base_time
 
-    clazz = TouchGrass(bot)
     await clazz.show_activity_stats(context)
 
     context.send.assert_called_once_with(
@@ -282,12 +268,10 @@ async def test_show_activity_stats_no_activity(mock_utcnow, bot, context):
 
 @mock.patch("duckbot.cogs.messages.touch_grass.get_user")
 @mock.patch("duckbot.cogs.messages.touch_grass.utcnow")
-async def test_show_activity_stats_with_activity(mock_utcnow, mock_get_user, bot, context, message):
+async def test_show_activity_stats_with_activity(mock_utcnow, mock_get_user, clazz, context, message):
     """Stats command shows leaderboard with user activity."""
     base_time = datetime.datetime(2024, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc)
     mock_utcnow.return_value = base_time
-
-    clazz = TouchGrass(bot)
 
     # Simulate activity for two users
     message.author.id = 123
@@ -320,12 +304,10 @@ async def test_show_activity_stats_with_activity(mock_utcnow, mock_get_user, bot
 
 @mock.patch("duckbot.cogs.messages.touch_grass.get_user")
 @mock.patch("duckbot.cogs.messages.touch_grass.utcnow")
-async def test_show_activity_stats_sorts_by_count(mock_utcnow, mock_get_user, bot, context, message):
+async def test_show_activity_stats_sorts_by_count(mock_utcnow, mock_get_user, clazz, context, message):
     """Stats command sorts users by message count descending."""
     base_time = datetime.datetime(2024, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc)
     mock_utcnow.return_value = base_time
-
-    clazz = TouchGrass(bot)
 
     # User 1: 3 messages
     message.author.id = 111
@@ -366,12 +348,10 @@ async def test_show_activity_stats_sorts_by_count(mock_utcnow, mock_get_user, bo
 
 
 @mock.patch("duckbot.cogs.messages.touch_grass.utcnow")
-async def test_show_activity_stats_excludes_old_messages(mock_utcnow, bot, context, message):
+async def test_show_activity_stats_excludes_old_messages(mock_utcnow, clazz, context, message):
     """Stats command only shows messages within 60-minute window."""
     base_time = datetime.datetime(2024, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc)
     mock_utcnow.return_value = base_time
-
-    clazz = TouchGrass(bot)
 
     # Send 10 messages at T=0
     message.author.id = 123
@@ -391,13 +371,11 @@ async def test_show_activity_stats_excludes_old_messages(mock_utcnow, bot, conte
 
 @mock.patch("duckbot.cogs.messages.touch_grass.get_user")
 @mock.patch("duckbot.cogs.messages.touch_grass.utcnow")
-async def test_show_activity_stats_unknown_user(mock_utcnow, mock_get_user, bot, context, message):
+async def test_show_activity_stats_unknown_user(mock_utcnow, mock_get_user, clazz, context, message):
     """Stats command shows User-{id} when get_user returns None."""
     base_time = datetime.datetime(2024, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc)
     mock_utcnow.return_value = base_time
     mock_get_user.return_value = None
-
-    clazz = TouchGrass(bot)
 
     message.author.id = 999
     for _ in range(5):
@@ -410,9 +388,8 @@ async def test_show_activity_stats_unknown_user(mock_utcnow, mock_get_user, bot,
     assert "5" in call_args
 
 
-async def test_is_work_hours_weekday_within_hours(bot):
+async def test_is_work_hours_weekday_within_hours(clazz):
     """Mon-Fri 8am-6pm EDT (12pm-10pm UTC) should be work hours."""
-    clazz = TouchGrass(bot)
     # Monday 12:00 UTC
     assert clazz.is_work_hours(MONDAY_NOON) is True
     # Monday 12:00 UTC (boundary start)
@@ -421,9 +398,8 @@ async def test_is_work_hours_weekday_within_hours(bot):
     assert clazz.is_work_hours(datetime.datetime(2024, 1, 1, 21, 59, 0, tzinfo=datetime.timezone.utc)) is True
 
 
-async def test_is_work_hours_weekday_outside_hours(bot):
+async def test_is_work_hours_weekday_outside_hours(clazz):
     """Before 12pm and at/after 10pm UTC on weekdays should not be work hours."""
-    clazz = TouchGrass(bot)
     # Monday 11:59 UTC
     assert clazz.is_work_hours(datetime.datetime(2024, 1, 1, 11, 59, 0, tzinfo=datetime.timezone.utc)) is False
     # Monday 22:00 UTC
@@ -432,9 +408,8 @@ async def test_is_work_hours_weekday_outside_hours(bot):
     assert clazz.is_work_hours(datetime.datetime(2024, 1, 1, 23, 0, 0, tzinfo=datetime.timezone.utc)) is False
 
 
-async def test_is_work_hours_weekend(bot):
+async def test_is_work_hours_weekend(clazz):
     """Weekends should not be work hours regardless of time."""
-    clazz = TouchGrass(bot)
     # Saturday 12:00 UTC
     assert clazz.is_work_hours(SATURDAY_NOON) is False
     # Sunday 12:00 UTC
@@ -442,11 +417,9 @@ async def test_is_work_hours_weekend(bot):
 
 
 @mock.patch("duckbot.cogs.messages.touch_grass.utcnow")
-async def test_off_hours_threshold_119_no_notification(mock_utcnow, bot, message):
+async def test_off_hours_threshold_119_no_notification(mock_utcnow, clazz, message):
     """119 messages outside work hours should not trigger notification."""
     mock_utcnow.return_value = SATURDAY_NOON
-
-    clazz = TouchGrass(bot)
 
     for i in range(119):
         mock_utcnow.return_value = SATURDAY_NOON + datetime.timedelta(seconds=i * 30)
@@ -456,12 +429,10 @@ async def test_off_hours_threshold_119_no_notification(mock_utcnow, bot, message
 
 
 @mock.patch("duckbot.cogs.messages.touch_grass.utcnow")
-async def test_off_hours_threshold_120_sends_notification(mock_utcnow, bot, message):
+async def test_off_hours_threshold_120_sends_notification(mock_utcnow, clazz, message):
     """120 messages outside work hours should trigger notification."""
     mock_utcnow.return_value = SATURDAY_NOON
     message.author.display_name = "TestUser"
-
-    clazz = TouchGrass(bot)
 
     for i in range(120):
         mock_utcnow.return_value = SATURDAY_NOON + datetime.timedelta(seconds=i * 30)
@@ -471,11 +442,9 @@ async def test_off_hours_threshold_120_sends_notification(mock_utcnow, bot, mess
 
 
 @mock.patch("duckbot.cogs.messages.touch_grass.utcnow")
-async def test_off_hours_40_messages_no_notification(mock_utcnow, bot, message):
+async def test_off_hours_40_messages_no_notification(mock_utcnow, clazz, message):
     """40 messages outside work hours should not trigger (threshold is 120)."""
     mock_utcnow.return_value = SATURDAY_NOON
-
-    clazz = TouchGrass(bot)
 
     for _ in range(40):
         await clazz.track_activity(message)
@@ -485,11 +454,9 @@ async def test_off_hours_40_messages_no_notification(mock_utcnow, bot, message):
 
 @mock.patch("duckbot.cogs.messages.touch_grass.get_user")
 @mock.patch("duckbot.cogs.messages.touch_grass.utcnow")
-async def test_leaderboard_unaffected_by_time_of_day(mock_utcnow, mock_get_user, bot, context, message):
+async def test_leaderboard_unaffected_by_time_of_day(mock_utcnow, mock_get_user, clazz, context, message):
     """Leaderboard should show all activity regardless of work hours or thresholds."""
     mock_utcnow.return_value = SATURDAY_NOON
-
-    clazz = TouchGrass(bot)
 
     # Send 10 messages on a Saturday (well below 120 threshold)
     message.author.id = 123

--- a/tests/cogs/playmarket/market_test.py
+++ b/tests/cogs/playmarket/market_test.py
@@ -15,6 +15,7 @@ from duckbot.cogs.playmarket.models import (
     Season,
     SeasonResult,
 )
+from tests.discord_test_ext import bind_commands
 
 BET = 500
 STARTING = config.STARTING_BALANCE
@@ -43,9 +44,19 @@ def clock():
 
 @pytest.fixture
 def cog(bot, in_memory_db, clock):
-    market = PlayMarket(bot, in_memory_db)
+    market = bind_commands(PlayMarket(bot, in_memory_db))
     market.tick_loop.cancel()  # don't run the loop mid-test
     return market
+
+
+class _Typing:
+    """Async context manager stand-in for context.typing()."""
+
+    async def __aenter__(self):
+        return None
+
+    async def __aexit__(self, *exc):
+        return None
 
 
 def make_context(user_id):
@@ -54,6 +65,7 @@ def make_context(user_id):
     ctx.guild.get_member = lambda uid: mock.Mock(id=uid, display_name=f"user{uid}", mention=f"<@{uid}>")
     ctx.send = mock.AsyncMock()
     ctx.bot.is_owner = mock.AsyncMock(return_value=False)
+    ctx.typing.return_value = _Typing()
     return ctx
 
 
@@ -193,6 +205,19 @@ async def test_list_filters_by_status(cog, alice):
     expected = discord.Embed(title="Resolved Markets", color=discord.Color.blurple())
     expected.add_field(name=f"Market {market_id} — Will it happen?", value="YES 50%", inline=False)
     alice.send.assert_called_with(embed=expected)
+
+
+async def test_list_command_shows_markets(cog, alice):
+    market_id = await open_market(cog, alice)
+    await cog.list_command(alice, None)
+    expected = discord.Embed(title="Open Markets", color=discord.Color.blurple())
+    expected.add_field(name=f"Market {market_id} — Will it happen?", value="YES 50%", inline=False)
+    alice.send.assert_called_with(embed=expected)
+
+
+async def test_market_group_defaults_to_listing(cog, alice):
+    await cog.market_group(alice, None)
+    assert alice.send.call_args.args[0] == "No markets. What, you hate fun?"
 
 
 # --- create --------------------------------------------------------------

--- a/tests/cogs/recipe/recipe_test.py
+++ b/tests/cogs/recipe/recipe_test.py
@@ -1,88 +1,86 @@
 import json
 
+import pytest
 from responses import RequestsMock, matchers
 
 from duckbot.cogs.recipe import Recipe
+from tests.discord_test_ext import bind_commands
 
 RECIPE_SEARCH_URI = "https://www.allrecipes.com/element-api/content-proxy/faceted-searches-load-more"
 
 
-async def test_search_recipes_returns_scraped_html(responses):
+@pytest.fixture
+def clazz() -> Recipe:
+    return bind_commands(Recipe())
+
+
+async def test_search_recipes_returns_scraped_html(clazz, responses):
     search_term = "test1"
     mock_data = get_mock_data(search_term, 5)
     setup_responses(responses, search_term, with_articles(mock_data))
-    clazz = Recipe()
     response = clazz.search_recipes(search_term)
     assert response == json_articles(mock_data)
     assert_requests(responses, search_term)
 
 
-async def test_parse_recipes_returns_articles():
+async def test_parse_recipes_returns_articles(clazz):
     mock_data = get_mock_data("test1", 5)
     expected_response = [get_mock_data("test1", 5) for _ in range(5)]
     html = json_articles(mock_data)
-    clazz = Recipe()
     response = clazz.parse_recipes(html)
     assert response == expected_response
 
 
-async def test_parse_recipes_returns_empty():
+async def test_parse_recipes_returns_empty(clazz):
     expected_response = []
     html = without_articles()
-    clazz = Recipe()
     response = clazz.parse_recipes(html)
     assert response == expected_response
 
 
-async def test_parse_recipes_no_content_returns_empty():
+async def test_parse_recipes_no_content_returns_empty(clazz):
     expected_response = []
     html = without_content()
-    clazz = Recipe()
     response = clazz.parse_recipes(html)
     assert response == expected_response
 
 
-async def test_select_recipes_with_one_return_one():
+async def test_select_recipes_with_one_return_one(clazz):
     recipe_list = [get_mock_data("test1", 5)]
-    clazz = Recipe()
     response = clazz.select_recipe(recipe_list)
     assert response == recipe_list[0]
 
 
-async def test_select_recipes_with_many_return_one():
+async def test_select_recipes_with_many_return_one(clazz):
     recipe_list = [get_mock_data("test1", 5), get_mock_data("test2", 4)]
-    clazz = Recipe()
     response = clazz.select_recipe(recipe_list)
     assert response in recipe_list
 
 
-async def test_recipe_with_content_return_recipe(context, responses):
+async def test_recipe_with_content_return_recipe(clazz, context, responses):
     search_term = "test1"
     mock_data = get_mock_data(search_term, 5)
     expected_response = f"How about a nice {mock_data['name']}. {mock_data['description']} This recipe has a {mock_data['rating']}/5 rating! {mock_data['url']}"
     setup_responses(responses, search_term, with_articles(mock_data))
-    clazz = Recipe()
-    await clazz.recipe(context, search_term)
+    await clazz.recipe(context, search_term=search_term)
     context.send.assert_called_once_with(expected_response)
     assert_requests(responses, search_term)
 
 
-async def test_recipe_without_articles_return_sorry(context, responses):
+async def test_recipe_without_articles_return_sorry(clazz, context, responses):
     search_term = "test1"
     expected_response = f"I am terribly sorry. There doesn't seem to be any recipes for {search_term}."
     setup_responses(responses, search_term, without_articles(), num_pages=1)
-    clazz = Recipe()
-    await clazz.recipe(context, search_term)
+    await clazz.recipe(context, search_term=search_term)
     context.send.assert_called_once_with(expected_response)
     assert_requests(responses, search_term, num_pages=1)
 
 
-async def test_recipe_without_content_return_sorry(context, responses):
+async def test_recipe_without_content_return_sorry(clazz, context, responses):
     search_term = "test1"
     expected_response = "I am terribly sorry. I am having problems reading All Recipes for you."
     setup_responses(responses, search_term, without_content(), num_pages=1)
-    clazz = Recipe()
-    await clazz.recipe(context, search_term)
+    await clazz.recipe(context, search_term=search_term)
     context.send.assert_called_once_with(expected_response)
     assert_requests(responses, search_term, num_pages=1)
 

--- a/tests/cogs/text/ascii_art_test.py
+++ b/tests/cogs/text/ascii_art_test.py
@@ -1,20 +1,26 @@
 from unittest import mock
 
+import pytest
+
 from duckbot.cogs.text import AsciiArt
+from tests.discord_test_ext import bind_commands
+
+
+@pytest.fixture
+def clazz() -> AsciiArt:
+    return bind_commands(AsciiArt())
 
 
 @mock.patch("pyfiglet.figlet_format", return_value="ascii text")
-async def test_ascii_formats_message(figlet, context):
-    clazz = AsciiArt()
-    await clazz.ascii(context, "some text")
+async def test_ascii_formats_message(figlet, clazz, context):
+    await clazz.ascii(context, text="some text")
     context.send.assert_called_once_with("```ascii text```")
     figlet.assert_called_once_with("some text")
 
 
 @mock.patch("pyfiglet.figlet_format", side_effect=["x" * 2000, "happy birthday"])
-async def test_ascii_message_too_long(figlet, context):
-    clazz = AsciiArt()
-    await clazz.ascii(context, "it text")
+async def test_ascii_message_too_long(figlet, clazz, context):
+    await clazz.ascii(context, text="it text")
     context.send.assert_called_once_with("Discord won't let me send art with that much GUSTO, so here's a happy birthday.\n```happy birthday```")
     figlet.assert_any_call("it text")
     figlet.assert_any_call("Happy Birthday!")

--- a/tests/cogs/text/mock_text_test.py
+++ b/tests/cogs/text/mock_text_test.py
@@ -1,17 +1,23 @@
 from unittest import mock
 
 import discord
+import pytest
 
 from duckbot.cogs.text import MockText
 from duckbot.cogs.text.mock_text import WRAPPERS
+from tests.discord_test_ext import bind_commands
+
+
+@pytest.fixture
+def clazz() -> MockText:
+    return bind_commands(MockText())
 
 
 @mock.patch("duckbot.cogs.text.mock_text.random.randint", return_value=1)
 @mock.patch("duckbot.cogs.text.mock_text.random.choice", return_value="")
 @mock.patch("duckbot.cogs.text.mock_text.get_message_reference", return_value=None)
-async def test_mock_text_mocks_message_not_reply(get_message_reference, random_choice, random_randint, context):
-    clazz = MockText()
-    await clazz.mock_text(context, "some' message% asd")
+async def test_mock_text_mocks_message_not_reply(get_message_reference, random_choice, random_randint, clazz, context):
+    await clazz.mock_text(context, text="some' message% asd")
     context.send.assert_called_once_with("SoMe' MeSsAgE% aSd")
     get_message_reference.assert_called_once_with(context.message)
 
@@ -19,11 +25,10 @@ async def test_mock_text_mocks_message_not_reply(get_message_reference, random_c
 @mock.patch("duckbot.cogs.text.mock_text.random.randint", return_value=1)
 @mock.patch("duckbot.cogs.text.mock_text.random.choice", return_value="")
 @mock.patch("duckbot.cogs.text.mock_text.get_message_reference")
-async def test_mock_text_mocks_message_reply(get_message_reference, random_choice, random_randint, context, autospec):
+async def test_mock_text_mocks_message_reply(get_message_reference, random_choice, random_randint, clazz, context, autospec):
     reply = autospec.of(discord.Message)
     get_message_reference.return_value = reply
-    clazz = MockText()
-    await clazz.mock_text(context, "some' message% asd")
+    await clazz.mock_text(context, text="some' message% asd")
     reply.reply.assert_called_once_with("SoMe' MeSsAgE% aSd")
     get_message_reference.assert_called_once_with(context.message)
 
@@ -31,10 +36,9 @@ async def test_mock_text_mocks_message_reply(get_message_reference, random_choic
 @mock.patch("duckbot.cogs.text.mock_text.random.randint", return_value=1)
 @mock.patch("duckbot.cogs.text.mock_text.random.choice", return_value="")
 @mock.patch("duckbot.cogs.text.mock_text.get_message_reference", return_value=None)
-async def test_mock_text_no_message_not_reply(get_message_reference, random_choice, random_randint, context):
+async def test_mock_text_no_message_not_reply(get_message_reference, random_choice, random_randint, clazz, context):
     context.message.author.display_name = "bob"
-    clazz = MockText()
-    await clazz.mock_text(context, "")
+    await clazz.mock_text(context, text="")
     context.send.assert_called_once_with("BoB, bAsEd On ThIs, I sHoUlD mOcK yOu... I nEeD tExT dUdE.")
     get_message_reference.assert_called_once_with(context.message)
 
@@ -42,67 +46,58 @@ async def test_mock_text_no_message_not_reply(get_message_reference, random_choi
 @mock.patch("duckbot.cogs.text.mock_text.random.randint", return_value=1)
 @mock.patch("duckbot.cogs.text.mock_text.random.choice", return_value="")
 @mock.patch("duckbot.cogs.text.mock_text.get_message_reference")
-async def test_mock_text_no_message_reply(get_message_reference, random_choice, random_randint, context, autospec):
+async def test_mock_text_no_message_reply(get_message_reference, random_choice, random_randint, clazz, context, autospec):
     reply = autospec.of(discord.Message)
     get_message_reference.return_value = reply
     context.message.author.display_name = "bob"
-    clazz = MockText()
-    await clazz.mock_text(context, "")
+    await clazz.mock_text(context, text="")
     reply.reply.assert_called_once_with("BoB, bAsEd On ThIs, I sHoUlD mOcK yOu... I nEeD tExT dUdE.")
     get_message_reference.assert_called_once_with(context.message)
 
 
 @mock.patch("duckbot.cogs.text.mock_text.random.randint", return_value=1)
 @mock.patch("duckbot.cogs.text.mock_text.random.choice", return_value="**")
-async def test_mockify_wraps_emphasis_span_with_bold(random_choice, random_randint):
-    clazz = MockText()
+async def test_mockify_wraps_emphasis_span_with_bold(random_choice, random_randint, clazz):
     assert clazz.mockify("hi") == "**H**i"
 
 
 @mock.patch("duckbot.cogs.text.mock_text.random.randint", return_value=1)
 @mock.patch("duckbot.cogs.text.mock_text.random.choice", return_value="*")
-async def test_mockify_wraps_emphasis_span_with_italic(random_choice, random_randint):
-    clazz = MockText()
+async def test_mockify_wraps_emphasis_span_with_italic(random_choice, random_randint, clazz):
     assert clazz.mockify("hi") == "*H*i"
 
 
 @mock.patch("duckbot.cogs.text.mock_text.random.randint", return_value=1)
 @mock.patch("duckbot.cogs.text.mock_text.random.choice", return_value="`")
-async def test_mockify_wraps_emphasis_span_with_code(random_choice, random_randint):
-    clazz = MockText()
+async def test_mockify_wraps_emphasis_span_with_code(random_choice, random_randint, clazz):
     assert clazz.mockify("hi") == "`H`i"
 
 
 @mock.patch("duckbot.cogs.text.mock_text.random.randint", return_value=1)
 @mock.patch("duckbot.cogs.text.mock_text.random.choice", side_effect=["**", "*"])
-async def test_mockify_alternates_emphasis_and_plain(random_choice, random_randint):
-    clazz = MockText()
+async def test_mockify_alternates_emphasis_and_plain(random_choice, random_randint, clazz):
     assert clazz.mockify("abc") == "**A**b*C*"
 
 
 @mock.patch("duckbot.cogs.text.mock_text.random.randint", return_value=4)
 @mock.patch("duckbot.cogs.text.mock_text.random.choice", return_value="**")
-async def test_mockify_spans_multiple_characters(random_choice, random_randint):
-    clazz = MockText()
+async def test_mockify_spans_multiple_characters(random_choice, random_randint, clazz):
     assert clazz.mockify("hello") == "**HeLl**O"
 
 
 @mock.patch("duckbot.cogs.text.mock_text.random.randint", return_value=1)
 @mock.patch("duckbot.cogs.text.mock_text.random.choice", return_value="**")
-async def test_mockify_does_not_wrap_punctuation_or_whitespace(random_choice, random_randint):
-    clazz = MockText()
+async def test_mockify_does_not_wrap_punctuation_or_whitespace(random_choice, random_randint, clazz):
     assert clazz.mockify("hi ... bye") == "**H**i ... **B**y**E**"
 
 
 @mock.patch("duckbot.cogs.text.mock_text.random.randint", return_value=1)
 @mock.patch("duckbot.cogs.text.mock_text.random.choice", return_value="**")
-async def test_mockify_does_not_offer_previous_wrapper_as_choice(random_choice, random_randint):
-    clazz = MockText()
+async def test_mockify_does_not_offer_previous_wrapper_as_choice(random_choice, random_randint, clazz):
     clazz.mockify("abcde")
     assert set(random_choice.call_args_list[1][0][0]) == set(WRAPPERS) - {"**"}
 
 
-async def test_delete_command_message(context):
-    clazz = MockText()
+async def test_delete_command_message(clazz, context):
     await clazz.delete_command_message(context)
     context.message.delete.assert_called()

--- a/tests/cogs/text/wordnik_test.py
+++ b/tests/cogs/text/wordnik_test.py
@@ -3,6 +3,7 @@ import pytest
 
 from duckbot.cogs.text import Wordnik
 from duckbot.util.embeds import MAX_FIELD_VALUE_LENGTH
+from tests.discord_test_ext import bind_commands
 
 URL = "https://api.wordnik.com/v4/word.json"
 ATTRIBUTION = "from The American Heritage® Dictionary of the English Language, 5th Edition."
@@ -13,11 +14,15 @@ def set_wordnik_key_env(monkeypatch):
     monkeypatch.setenv("WORDNIK_KEY", "wordnik-key")
 
 
-async def test_define_inflected_word(bot, context, responses):
+@pytest.fixture
+def clazz(bot) -> Wordnik:
+    return bind_commands(Wordnik(bot))
+
+
+async def test_define_inflected_word(clazz, context, responses):
     responses.add(responses.GET, f"{URL}/cows/definitions", json=cow_definitions())
     responses.add(responses.GET, f"{URL}/cow/pronunciations", json=cow_pronunciations())
-    clazz = Wordnik(bot)
-    await clazz.define(context, "Cows")
+    await clazz.define(context, word="Cows")
     embed = discord.Embed(title="cow")
     noun_lines = [
         "1. The mature female of cattle of the genus Bos.\n_this is where I'd use cow in a sentence... IF I HAD ONE_",
@@ -35,12 +40,11 @@ async def test_define_inflected_word(bot, context, responses):
     context.send.assert_called_once_with(embed=embed)
 
 
-async def test_define_unknown_word(bot, context, responses):
+async def test_define_unknown_word(clazz, context, responses):
     responses.add(responses.GET, f"{URL}/nothing/definitions", json={"statusCode": 404, "error": "Not Found", "message": "Not found"})
     responses.add(responses.GET, f"{URL}/why/definitions", json=why_definitions())
     responses.add(responses.GET, f"{URL}/why/pronunciations", json=[{"raw": "/hwaɪ/", "rawType": "IPA"}])
-    clazz = Wordnik(bot)
-    await clazz.define(context, "nothing")
+    await clazz.define(context, word="nothing")
     embed = discord.Embed(title="why")
     adverb_lines = [
         "1. For what purpose, reason, or cause.\n_why did he do it?_",
@@ -51,39 +55,35 @@ async def test_define_unknown_word(bot, context, responses):
     context.send.assert_called_once_with(embed=embed)
 
 
-async def test_define_rate_limited(bot, context, responses):
+async def test_define_rate_limited(clazz, context, responses):
     error = {"statusCode": 429, "error": "Too Many Requests", "message": "API rate limit exceeded"}
     responses.add(responses.GET, f"{URL}/nothing/definitions", json=error)
     responses.add(responses.GET, f"{URL}/why/definitions", json=error)
-    clazz = Wordnik(bot)
-    await clazz.define(context, "nothing")
+    await clazz.define(context, word="nothing")
     context.send.assert_called_once_with("wordnik is all worded out, give it a minute")
 
 
-async def test_get_pronunciation_no_results(bot, responses):
+async def test_get_pronunciation_no_results(clazz, responses):
     responses.add(responses.GET, f"{URL}/cat/pronunciations", json={"statusCode": 404, "error": "Not Found", "message": "Not found"})
-    clazz = Wordnik(bot)
     assert clazz.get_pronunciation("cat") == "screw flanders"
 
 
-async def test_define_truncates_long_field_value(bot, context, responses):
+async def test_define_truncates_long_field_value(clazz, context, responses):
     long_text = "a" * 2000
     definitions = [{"sourceDictionary": "ahd-5", "attributionText": ATTRIBUTION, "word": "cow", "partOfSpeech": "noun", "text": long_text, "exampleUses": []}]
     responses.add(responses.GET, f"{URL}/cow/definitions", json=definitions)
     responses.add(responses.GET, f"{URL}/cow/pronunciations", json=cow_pronunciations())
-    clazz = Wordnik(bot)
-    await clazz.define(context, "cow")
+    await clazz.define(context, word="cow")
     sent_embed = context.send.call_args.kwargs["embed"]
     assert len(sent_embed.fields[0].value) == MAX_FIELD_VALUE_LENGTH
     assert sent_embed.fields[0].value.endswith("...")
 
 
-async def test_define_handles_null_example_uses(bot, context, responses):
+async def test_define_handles_null_example_uses(clazz, context, responses):
     definitions = [{"sourceDictionary": "ahd-5", "attributionText": ATTRIBUTION, "word": "cow", "partOfSpeech": "noun", "text": "A big animal.", "exampleUses": None}]
     responses.add(responses.GET, f"{URL}/cow/definitions", json=definitions)
     responses.add(responses.GET, f"{URL}/cow/pronunciations", json=cow_pronunciations())
-    clazz = Wordnik(bot)
-    await clazz.define(context, "cow")
+    await clazz.define(context, word="cow")
     embed = discord.Embed(title="cow")
     embed.add_field(name="noun: **cow**  /kou/", value="1. A big animal.\n_this is where I'd use cow in a sentence... IF I HAD ONE_\n", inline=False)
     embed.set_footer(text=ATTRIBUTION)

--- a/tests/cogs/weather/weather_test.py
+++ b/tests/cogs/weather/weather_test.py
@@ -7,6 +7,7 @@ from pyowm.weatherapi30.weather import Weather as pyowmWeather
 
 from duckbot.cogs.weather import Weather
 from duckbot.cogs.weather.saved_location import SavedLocation
+from tests.discord_test_ext import bind_commands
 
 
 @pytest.fixture
@@ -24,7 +25,7 @@ def owm(o, geocoding):
 
 @pytest.fixture
 def weather(bot, owm, db):
-    clazz = Weather(bot, db)
+    clazz = bind_commands(Weather(bot, db))
     clazz._owm = owm
     owm.weather_manager.return_value.one_call = mock.MagicMock()
     return clazz
@@ -50,6 +51,12 @@ async def test_weather_get_failure(weather, owm, context):
     with pytest.raises(Exception):
         await weather.weather(context, "city", None, None)
     context.send.assert_called_once_with("Iunno. Figure it out.\nded")
+
+
+async def test_weather_group_defaults_to_get(weather, context):
+    weather.send_weather = mock.AsyncMock()
+    await weather.weather_command(context, "city", None, None)
+    weather.send_weather.assert_awaited_once_with(context, "city", None, None)
 
 
 async def test_search_location_no_args(weather, context):
@@ -130,7 +137,7 @@ async def test_set_default_location_round_trip(bot, in_memory_db, context):
     async def mock_search_location(context, city, country, index):
         return Location(city, 1, 1, 1, country="CA")
 
-    clazz = Weather(bot, in_memory_db)
+    clazz = bind_commands(Weather(bot, in_memory_db))
     clazz.search_location = mock_search_location
     context.author.id = 123
     await clazz.set_default_location(context, "city", None, None)

--- a/tests/discord_test_ext.py
+++ b/tests/discord_test_ext.py
@@ -1,4 +1,11 @@
-from discord.ext.commands import Bot
+from discord.ext.commands import Bot, Cog
+
+
+def bind_commands(cog: Cog) -> Cog:
+    """Wire each command to its cog so Command.__call__ injects self in tests."""
+    for cmd in cog.walk_commands():
+        cmd.cog = cog
+    return cog
 
 
 def assert_cog_added_of_type(bot: Bot, cog_type):


### PR DESCRIPTION
##### Summary

Review claude.md first as it contains the new pattern used in the rest of the diff.

Making command functions a little easier to understand/test, allowing us to remove a bunch of kinda useless functions like `def thing_command(..): return self.thing(..)`

##### Checklist

- [x] this is a source code change
  - [x] run `format` in the repository root
  - [x] run `pytest` in the repository root
  - [ ] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [ ] update the wiki documentation if necessary
- [ ] or, this is **not** a source code change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
