### PR TITLE
:sparkles: allow admins to void resolved markets

### DIFF
--- a/duckbot/cogs/playmarket/market.py
+++ b/duckbot/cogs/playmarket/market.py
@@ -209,6 +209,8 @@ class PlayMarket(commands.Cog):
             market = self._lock_market(session, market_id)
             if market is None:
                 return await context.send("No such market, brother.")
+            if market.status == "RESOLVED" and outcome == "void":
+                return await self.void_resolved(context, session, market)
             if market.status != "OPEN":
                 return await context.send("That one's already in the books, brother.")
             if context.author.id != market.creator_id and not await self._is_admin(context):
@@ -223,6 +225,41 @@ class PlayMarket(commands.Cog):
             session.commit()
             mentions = " ".join([await self._name(context, r[0], mention=True) for r in results])
             await context.send(mentions or None, embed=await self._resolve_embed(context, market, outcome, results))
+
+    async def void_resolved(self, context: commands.Context, session, market):
+        """Admin correction: reverse a bad resolution, clawing back payouts and refunding stakes."""
+        if not await self._is_admin(context):
+            return await context.send("Reversing a resolution is above your pay grade, brother.")
+        if session.get(Season, market.season_id).status == "archived":
+            return await context.send("That season's ancient history, brother.")
+        results = self._void_resolved(session, market)
+        session.commit()
+        mentions = " ".join([await self._name(context, r[0], mention=True) for r in results])
+        await context.send(mentions or None, embed=await self._void_resolved_embed(context, market, results))
+
+    def _void_resolved(self, session, market):
+        """Positions are gone post-resolution; rebuild each user's stake and payout from the ledger."""
+        results = []
+        user_ids = [uid for (uid,) in session.query(LedgerEntry.user_id).filter_by(market_id=market.id).distinct().all()]
+        for user_id in user_ids:
+            clawback = sum(e.delta for e in session.query(LedgerEntry).filter_by(user_id=user_id, market_id=market.id, reason="payout").all())
+            refund = max(0, -self._invested(session, user_id, market.id))
+            if refund - clawback != 0:
+                self._credit(session, market.season_id, self._lock_account(session, user_id), market.id, refund - clawback, "void")
+            if clawback or refund:
+                results.append((user_id, clawback, refund))
+        market.status = "VOID"
+        market.outcome = "void"
+        return results
+
+    async def _void_resolved_embed(self, context, market, results) -> Embed:
+        embed = Embed(title=f"Market {market.id} — {market.question}", description="Resolution reversed — market **VOIDED** by an admin.", color=Color.greyple())
+        lines = []
+        for user_id, clawback, refund in sorted(results, key=lambda r: r[2] - r[1], reverse=True):
+            lines.append(f"{await self._name(context, user_id)} — clawed back {_coins(clawback)}, refunded {_coins(refund)} ({refund - clawback:+,})")
+        if lines:
+            embed.add_field(name="Corrections", value="\n".join(lines), inline=False)
+        return embed
 
     @market_group.autocomplete("status")
     @list_command.autocomplete("status")

--- a/tests/cogs/playmarket/market_test.py
+++ b/tests/cogs/playmarket/market_test.py
@@ -462,6 +462,120 @@ async def test_resolving_keeps_the_ledger_reconciled(cog, alice, bob, carol, in_
     assert reconciles(in_memory_db)
 
 
+# --- void a resolved market (admin correction) ----------------------------
+
+
+async def test_admin_void_claws_back_payouts_and_refunds_stakes(cog, alice, bob, carol, in_memory_db):
+    admin = make_context(config.ADMIN_IDS[0])
+    market_id = await open_market(cog, alice)
+    await cog.bet(bob, market_id, "yes", BET)
+    await cog.bet(carol, market_id, "no", BET)
+    await cog.resolve(alice, market_id, "yes")
+    await cog.resolve(admin, market_id, "void")
+    market = market_row(in_memory_db, market_id)
+    assert market.status == "VOID" and market.outcome == "void"
+    assert account(in_memory_db, 2).balance == STARTING
+    assert account(in_memory_db, 3).balance == STARTING
+
+
+async def test_admin_void_writes_void_ledger_rows(cog, alice, bob, carol, in_memory_db):
+    admin = make_context(config.ADMIN_IDS[0])
+    market_id = await open_market(cog, alice)
+    await cog.bet(bob, market_id, "yes", BET)
+    await cog.bet(carol, market_id, "no", BET)
+    await cog.resolve(alice, market_id, "yes")
+    await cog.resolve(admin, market_id, "void")
+    assert reasons(in_memory_db, 2) == ["season_grant", "bet", "payout", "void"]
+    assert reasons(in_memory_db, 3) == ["season_grant", "bet", "void"]
+
+
+async def test_admin_void_keeps_the_ledger_reconciled(cog, alice, bob, carol, in_memory_db):
+    admin = make_context(config.ADMIN_IDS[0])
+    market_id = await open_market(cog, alice)
+    await cog.bet(bob, market_id, "yes", BET)
+    await cog.bet(carol, market_id, "no", BET)
+    await cog.resolve(alice, market_id, "yes")
+    await cog.resolve(admin, market_id, "void")
+    assert reconciles(in_memory_db)
+
+
+async def test_admin_void_announces_the_corrections(cog, alice, bob, in_memory_db):
+    admin = make_context(config.ADMIN_IDS[0])
+    market_id = await open_market(cog, alice)
+    await cog.bet(bob, market_id, "yes", BET)
+    await cog.resolve(alice, market_id, "yes")
+    await cog.resolve(admin, market_id, "void")
+    expected = discord.Embed(title=f"Market {market_id} — Will it happen?", description="Resolution reversed — market **VOIDED** by an admin.", color=discord.Color.greyple())
+    expected.add_field(name="Corrections", value="user2 — clawed back 831, refunded 500 (-331)", inline=False)
+    admin.send.assert_called_with("<@2>", embed=expected)
+
+
+async def test_admin_void_can_push_a_spender_negative(cog, alice, bob, in_memory_db):
+    admin = make_context(config.ADMIN_IDS[0])
+    market_id = await open_market(cog, alice)
+    await cog.bet(bob, market_id, "yes", BET)
+    await cog.resolve(alice, market_id, "yes")
+    set_balance(in_memory_db, 2, 100)  # bob spent his winnings
+    await cog.resolve(admin, market_id, "void")
+    assert account(in_memory_db, 2).balance == 100 + BET - 831
+
+
+async def test_admin_void_refunds_a_seller_their_rounding_loss(cog, alice, bob, in_memory_db):
+    admin = make_context(config.ADMIN_IDS[0])
+    market_id = await open_market(cog, alice)
+    await cog.bet(bob, market_id, "yes", BET)
+    await cog.sell(bob, market_id, "yes", "all")  # gets back 499, house keeps 1
+    await cog.resolve(alice, market_id, "yes")
+    await cog.resolve(admin, market_id, "void")
+    assert account(in_memory_db, 2).balance == STARTING
+    assert reconciles(in_memory_db)
+
+
+async def test_admin_void_with_no_bettors_just_flips_the_status(cog, alice, in_memory_db):
+    admin = make_context(config.ADMIN_IDS[0])
+    market_id = await open_market(cog, alice)
+    await cog.resolve(alice, market_id, "yes")
+    await cog.resolve(admin, market_id, "void")
+    assert market_row(in_memory_db, market_id).status == "VOID"
+
+
+async def test_creator_cannot_void_a_resolved_market(cog, alice, in_memory_db):
+    market_id = await open_market(cog, alice)
+    await cog.resolve(alice, market_id, "yes")
+    await cog.resolve(alice, market_id, "void")
+    assert alice.send.call_args.args[0] == "Reversing a resolution is above your pay grade, brother."
+    assert market_row(in_memory_db, market_id).status == "RESOLVED"
+
+
+async def test_admin_cannot_re_resolve_to_yes_or_no(cog, alice, in_memory_db):
+    admin = make_context(config.ADMIN_IDS[0])
+    market_id = await open_market(cog, alice)
+    await cog.resolve(alice, market_id, "yes")
+    await cog.resolve(admin, market_id, "no")
+    assert admin.send.call_args.args[0] == "That one's already in the books, brother."
+    assert market_row(in_memory_db, market_id).status == "RESOLVED"
+
+
+async def test_voiding_an_already_void_market_is_rejected(cog, alice, in_memory_db):
+    admin = make_context(config.ADMIN_IDS[0])
+    market_id = await open_market(cog, alice)
+    await cog.resolve(alice, market_id, "void")
+    await cog.resolve(admin, market_id, "void")
+    assert admin.send.call_args.args[0] == "That one's already in the books, brother."
+
+
+async def test_admin_void_is_rejected_once_the_season_is_archived(cog, alice, bob, clock, in_memory_db):
+    admin = make_context(config.ADMIN_IDS[0])
+    market_id = await open_market(cog, alice)
+    await cog.bet(bob, market_id, "yes", BET)
+    await cog.resolve(alice, market_id, "yes")
+    clock.advance(days=190)
+    await cog.tick()  # archives the season
+    await cog.resolve(admin, market_id, "void")
+    assert admin.send.call_args.args[0] == "That season's ancient history, brother."
+    assert market_row(in_memory_db, market_id).status == "RESOLVED"
+
+
 # --- claim (need-based top-up) ------------------------------------------
 
 

--- a/wiki/Prediction-Market.md
+++ b/wiki/Prediction-Market.md
@@ -135,6 +135,10 @@ Everyone holding a position is pinged with the results, so you'll know how your 
 
 Only the creator can resolve their own market — it's a friends-trust-friends "prop bet" model. If a creator never resolves (or leaves the server), the market is automatically voided when the season ends, so no coins stay stranded.
 
+### Fixing a bad resolution
+
+If a market gets resolved wrong (fat finger, disputed call), a bot admin can void it after the fact: run `/market resolve` again on the resolved market with `outcome:void`. Payouts are clawed back, everyone's stake is refunded as if the market had been voided in the first place, and affected players are pinged. This only works while the season is still running — once a season is archived, its results are final. Fair warning: if you already spent the winnings, the clawback can put your balance in the red.
+
 ## Economy at a glance
 
 | Thing             | Value                                                    |


### PR DESCRIPTION
##### Summary

So anyway, I tested here: https://discord.com/channels/845352633702809621/845356062474371122/1524914326903718078

Extends `/market resolve` so an admin can run it with `outcome:void` on an already-**RESOLVED** market to reverse a bad resolution — fixes #1405.

Positions are deleted at resolution, so the correction is rebuilt from the immutable `pm_ledger`: each participant's `payout` rows are clawed back and their net stake (`bet`/`sell` sum) refunded, written as a single compensating `void` ledger entry per user, keeping the balance == ledger-sum invariant. The market flips to `VOID` and affected players are pinged with a corrections embed.

Guard rails: admin-only (creators can't reverse paid money), rejected once the market's season is archived (season results are frozen), and `RESOLVED` markets still can't be re-resolved to yes/no. Clawbacks may push a spender's balance negative — it's play money, they'll earn it back.

No schema change: ledger `reason` is a free string, so no migration needed.

Testing: full `pytest` suite plus new integration tests covering clawback/refund math, ledger reconciliation, negative balances, seller rounding refunds, permission and season guards.

##### Checklist

- [x] this is a source code change
  - [x] run `format` in the repository root
  - [x] run `pytest` in the repository root
  - [x] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [x] update the wiki documentation if necessary
- [ ] or, this is **not** a source code change

🤖 Generated with [Claude Code](https://claude.com/claude-code)