### PR TITLE
:sparkles: add !timer command

### DIFF
--- a/duckbot/cogs/timer/__init__.py
+++ b/duckbot/cogs/timer/__init__.py
@@ -1,0 +1,5 @@
+from .timer import Timer
+
+
+async def setup(bot):
+    await bot.add_cog(Timer())

--- a/duckbot/cogs/timer/timer.py
+++ b/duckbot/cogs/timer/timer.py
@@ -40,4 +40,5 @@ class Timer(commands.Cog):
             else:
                 await context.send(f":timer: Timer set for {duration}.")
                 await asyncio.sleep(delta.total_seconds())
-                await context.channel.send(f":alarm_clock: {context.author.mention} {label or 'timer'} is up!")
+                name = f"{label} timer" if label else "timer"
+                await context.channel.send(f":alarm_clock: {context.author.mention} your {name} is up!")

--- a/duckbot/cogs/timer/timer.py
+++ b/duckbot/cogs/timer/timer.py
@@ -38,7 +38,7 @@ class Timer(commands.Cog):
             if now() + delta > bedtime:
                 await context.send("I'm asleep by then... screw flanders.")
             else:
-                await context.send(f":timer: Timer set for {duration}.")
+                await context.send(f":timer: Timer set for {duration}. If I die before then, you're on your own.")
                 await asyncio.sleep(delta.total_seconds())
                 name = f"{label} timer" if label else "timer"
                 await context.channel.send(f":alarm_clock: {context.author.mention} your {name} is up!")

--- a/duckbot/cogs/timer/timer.py
+++ b/duckbot/cogs/timer/timer.py
@@ -3,6 +3,7 @@ import datetime
 import re
 
 from discord.ext import commands
+from discord.utils import escape_mentions
 
 from duckbot.util.datetime import now
 
@@ -40,5 +41,5 @@ class Timer(commands.Cog):
             else:
                 await context.send(f":timer: Timer set for {duration}. If I die before then, you're on your own.")
                 await asyncio.sleep(delta.total_seconds())
-                name = f"{label} timer" if label else "timer"
+                name = f"{escape_mentions(label)} timer" if label else "timer"
                 await context.channel.send(f":alarm_clock: {context.author.mention} your {name} is up!")

--- a/duckbot/cogs/timer/timer.py
+++ b/duckbot/cogs/timer/timer.py
@@ -1,0 +1,43 @@
+import asyncio
+import datetime
+import re
+
+from discord.ext import commands
+
+from duckbot.util.datetime import now
+
+DURATION_PATTERN = re.compile(r"(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?")
+
+
+def parse_duration(duration: str) -> datetime.timedelta:
+    """Parses strings like 1h30m, 90s, or bare minutes into a timedelta; None if invalid."""
+    if duration.isdigit():
+        delta = datetime.timedelta(minutes=int(duration))
+    else:
+        match = DURATION_PATTERN.fullmatch(duration.lower())
+        if match and any(match.groups()):
+            hours, minutes, seconds = (int(g or 0) for g in match.groups())
+            delta = datetime.timedelta(hours=hours, minutes=minutes, seconds=seconds)
+        else:
+            delta = None
+    return delta
+
+
+class Timer(commands.Cog):
+    @commands.hybrid_command(name="timer", description="Set a timer; get pinged when it ends.")
+    async def timer(self, context: commands.Context, duration: str, *, label: str = None):
+        """
+        :param duration: How long, eg 10, 90s, 1h30m.
+        :param label: What the timer is for.
+        """
+        delta = parse_duration(duration)
+        if delta is None or delta.total_seconds() <= 0:
+            await context.send("I can't count that. Try something like `10`, `90s` or `1h30m`.")
+        else:
+            bedtime = now().replace(hour=23, minute=50, second=0, microsecond=0)
+            if now() + delta > bedtime:
+                await context.send("I'm asleep by then... screw flanders.")
+            else:
+                await context.send(f":timer: Timer set for {duration}.")
+                await asyncio.sleep(delta.total_seconds())
+                await context.channel.send(f":alarm_clock: {context.author.mention} {label or 'timer'} is up!")

--- a/tests/cogs/timer/timer_test.py
+++ b/tests/cogs/timer/timer_test.py
@@ -37,6 +37,14 @@ async def test_timer_pings_with_label(now, sleep, clazz, context):
     context.channel.send.assert_called_once_with(f":alarm_clock: {context.author.mention} your pizza timer is up!")
 
 
+@mock.patch("asyncio.sleep", return_value=None)
+@mock.patch("duckbot.cogs.timer.timer.now", return_value=noon)
+async def test_timer_escapes_mentions_in_label(now, sleep, clazz, context):
+    await clazz.timer(context, duration="10", label="@everyone")
+    # expected string has a zero-width space after the @
+    context.channel.send.assert_called_once_with(f":alarm_clock: {context.author.mention} your @​everyone timer is up!")
+
+
 @pytest.mark.parametrize("duration", ["duck", "0", "1x", "m"])
 async def test_timer_invalid_duration(clazz, context, duration):
     await clazz.timer(context, duration=duration)

--- a/tests/cogs/timer/timer_test.py
+++ b/tests/cogs/timer/timer_test.py
@@ -1,0 +1,49 @@
+import datetime
+from unittest import mock
+
+import pytest
+
+from duckbot.cogs.timer import Timer
+from tests.discord_test_ext import bind_commands
+
+noon = datetime.datetime(2026, 7, 9, 12, 0, 0, tzinfo=datetime.timezone.utc)
+
+
+@pytest.fixture
+def clazz() -> Timer:
+    return bind_commands(Timer())
+
+
+@pytest.mark.parametrize("duration, seconds", [("10", 600), ("90s", 90), ("1h30m", 5400), ("2h", 7200)])
+@mock.patch("asyncio.sleep", return_value=None)
+@mock.patch("duckbot.cogs.timer.timer.now", return_value=noon)
+async def test_timer_waits_for_duration(now, sleep, clazz, context, duration, seconds):
+    await clazz.timer(context, duration=duration)
+    sleep.assert_called_once_with(seconds)
+    context.send.assert_called_once_with(f":timer: Timer set for {duration}.")
+
+
+@mock.patch("asyncio.sleep", return_value=None)
+@mock.patch("duckbot.cogs.timer.timer.now", return_value=noon)
+async def test_timer_pings_when_done(now, sleep, clazz, context):
+    await clazz.timer(context, duration="10")
+    context.channel.send.assert_called_once_with(f":alarm_clock: {context.author.mention} timer is up!")
+
+
+@mock.patch("asyncio.sleep", return_value=None)
+@mock.patch("duckbot.cogs.timer.timer.now", return_value=noon)
+async def test_timer_pings_with_label(now, sleep, clazz, context):
+    await clazz.timer(context, duration="10", label="pizza")
+    context.channel.send.assert_called_once_with(f":alarm_clock: {context.author.mention} pizza is up!")
+
+
+@pytest.mark.parametrize("duration", ["duck", "0", "1x", "m"])
+async def test_timer_invalid_duration(clazz, context, duration):
+    await clazz.timer(context, duration=duration)
+    context.send.assert_called_once_with("I can't count that. Try something like `10`, `90s` or `1h30m`.")
+
+
+@mock.patch("duckbot.cogs.timer.timer.now", return_value=noon.replace(hour=23))
+async def test_timer_ends_past_bedtime(now, clazz, context):
+    await clazz.timer(context, duration="1h")
+    context.send.assert_called_once_with("I'm asleep by then... screw flanders.")

--- a/tests/cogs/timer/timer_test.py
+++ b/tests/cogs/timer/timer_test.py
@@ -14,7 +14,7 @@ def clazz() -> Timer:
     return bind_commands(Timer())
 
 
-@pytest.mark.parametrize("duration, seconds", [("10", 600), ("90s", 90), ("1h30m", 5400), ("2h", 7200)])
+@pytest.mark.parametrize("duration, seconds", [("10", 600), ("90s", 90), ("2h", 7200), ("1h30m", 5400), ("1h30s", 3630), ("30m30s", 1830), ("1h30m30s", 5430)])
 @mock.patch("asyncio.sleep", return_value=None)
 @mock.patch("duckbot.cogs.timer.timer.now", return_value=noon)
 async def test_timer_waits_for_duration(now, sleep, clazz, context, duration, seconds):
@@ -27,14 +27,14 @@ async def test_timer_waits_for_duration(now, sleep, clazz, context, duration, se
 @mock.patch("duckbot.cogs.timer.timer.now", return_value=noon)
 async def test_timer_pings_when_done(now, sleep, clazz, context):
     await clazz.timer(context, duration="10")
-    context.channel.send.assert_called_once_with(f":alarm_clock: {context.author.mention} timer is up!")
+    context.channel.send.assert_called_once_with(f":alarm_clock: {context.author.mention} your timer is up!")
 
 
 @mock.patch("asyncio.sleep", return_value=None)
 @mock.patch("duckbot.cogs.timer.timer.now", return_value=noon)
 async def test_timer_pings_with_label(now, sleep, clazz, context):
     await clazz.timer(context, duration="10", label="pizza")
-    context.channel.send.assert_called_once_with(f":alarm_clock: {context.author.mention} pizza is up!")
+    context.channel.send.assert_called_once_with(f":alarm_clock: {context.author.mention} your pizza timer is up!")
 
 
 @pytest.mark.parametrize("duration", ["duck", "0", "1x", "m"])

--- a/tests/cogs/timer/timer_test.py
+++ b/tests/cogs/timer/timer_test.py
@@ -20,7 +20,7 @@ def clazz() -> Timer:
 async def test_timer_waits_for_duration(now, sleep, clazz, context, duration, seconds):
     await clazz.timer(context, duration=duration)
     sleep.assert_called_once_with(seconds)
-    context.send.assert_called_once_with(f":timer: Timer set for {duration}.")
+    context.send.assert_called_once_with(f":timer: Timer set for {duration}. If I die before then, you're on your own.")
 
 
 @mock.patch("asyncio.sleep", return_value=None)

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -47,6 +47,7 @@ def assert_extensions_loaded(bot_spy, additional_extensions=[]):
         "duckbot.cogs.recipe",
         "duckbot.cogs.robot",
         "duckbot.cogs.text",
+        "duckbot.cogs.timer",
         "duckbot.cogs.tito",
         "duckbot.cogs.weather",
     ]

--- a/wiki/Commands.md
+++ b/wiki/Commands.md
@@ -19,6 +19,7 @@
 |    [`!recipe`](#recipe-search)    | search for a random recipe                         |
 |         [`!roll`](#dice)          | rolls Dungeons and Dragons style dice              |
 |    [`!start`, `!stop`](#music)    | start or stop playing music                        |
+|        [`!timer`](#timer)         | set a timer, get pinged when it ends               |
 |        [`!truth`](#truth)         | fact checks a message when used in a reply         |
 |      [`!weather`](#weather)       | retrieve weather information                       |
 | [`/satisfy`](Satisfactory-Solver) | produce a factory for _Satisfactory_               |
@@ -63,6 +64,16 @@ DuckBot can provide information about Pokémon, because that matters. The comman
 ```
 /pokemon [name-or-id]
 ```
+
+## Timer
+
+DuckBot will set a timer for you and ping you when it's done. Durations can be plain minutes, or short forms like `90s` or `1h30m`. An optional label is echoed back in the ping.
+
+```
+!timer 10m pizza
+```
+
+Timers cannot run past DuckBot's bedtime, since the bot sleeps overnight.
 
 ## Truth
 


### PR DESCRIPTION
##### Summary

Adds a `!timer` / `/timer` command, fixes #1402. Set a timer with a duration like `10` (minutes), `90s`, or `1h30m`, plus an optional label; DuckBot pings you in the channel when it elapses.

Notes on the "ai bullshit" constraints:

- The completion ping is sent via `channel.send` (a fresh message, like `announce_day` does), not the interaction followup — so slash timers happily exceed the 15-minute interaction token limit.
- Timers ending after 23:50 Eastern are rejected. The shutdown schedule is not UTC: both the CDK code and the live ASG (`aws autoscaling describe-scheduled-actions`) scale down at 23:55 `America/Toronto`, so 23:50 leaves a 5-minute buffer.
- screw flanders: it's the rejection message for timers that cross bedtime.

Testing beyond unit tests: exercised the real command path in a script — durations parse (including uppercase forms), a 1s timer sleeps and pings with the label, and a timer crossing 23:50 gets the bedtime rejection.

##### Checklist

- [x] this is a source code change
  - [x] run `format` in the repository root
  - [x] run `pytest` in the repository root
  - [x] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [x] update the wiki documentation if necessary
- [ ] or, this is **not** a source code change

🤖 Generated with [Claude Code](https://claude.com/claude-code)