### PR TITLE
:bug: mark 'needs reply' issues stale, not just pulls

### DIFF
--- a/.github/workflows/close-stale-pulls.yml
+++ b/.github/workflows/close-stale-pulls.yml
@@ -17,15 +17,11 @@ jobs:
       with:
         only-labels: needs reply  # only consider items which are manually labelled 'needs reply'
         labels-to-remove-when-unstale: needs reply
-        days-before-stale: -1  # default don't auto mark things as stale
-        days-before-close: -1  # default don't close things
+        days-before-stale: 30  # things go stale after a month
+        days-before-close: 30  # close stale things after another month
         stale-issue-label: stale
         stale-pr-label: stale
-        days-before-pr-stale: 30  # pulls go stale after a month
-        days-before-pr-close: 30  # close stale pulls after another month
         stale-pr-message: Yo dawg, get some traction on this or it'll be yeeted. Brother.
         close-pr-message: YEET
-        days-before-issue-stale: 30  # issues go stale after a month
-        days-before-issue-close: 30  # close stale issues after another month
         stale-issue-message: Yo dawg, get some traction on this or it'll be yeeted. Brother.
         close-issue-message: YEET

--- a/.github/workflows/close-stale-pulls.yml
+++ b/.github/workflows/close-stale-pulls.yml
@@ -25,3 +25,7 @@ jobs:
         days-before-pr-close: 30  # close stale pulls after another month
         stale-pr-message: Yo dawg, get some traction on this or it'll be yeeted. Brother.
         close-pr-message: YEET
+        days-before-issue-stale: 30  # issues go stale after a month
+        days-before-issue-close: 30  # close stale issues after another month
+        stale-issue-message: Yo dawg, get some traction on this or it'll be yeeted. Brother.
+        close-issue-message: YEET


### PR DESCRIPTION
##### Summary

The stale workflow only sets `days-before-pr-stale`/`days-before-pr-close`, so the issue timers stay at the `-1` default and issues labelled `needs reply` are never marked stale or closed. This adds the issue equivalents with the same 30/30 day timers and messages as pulls.

Fixes #1411

##### Checklist

- [ ] this is a source code change
  - [ ] run `format` in the repository root
  - [ ] run `pytest` in the repository root
  - [ ] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [ ] update the wiki documentation if necessary
- [x] or, this is **not** a source code change

🤖 Generated with [Claude Code](https://claude.com/claude-code)