### PR TITLE
:lipstick: render /satisfy solution graph with graphviz

### DIFF
--- a/.github/actions/setup-python-venv/action.yml
+++ b/.github/actions/setup-python-venv/action.yml
@@ -25,6 +25,12 @@ runs:
     with:
       python-version: '3.13'
 
+  - name: Install Required Packages
+    shell: bash
+    run: |
+      sudo apt-get update
+      sudo apt-get install -y --no-install-recommends graphviz
+
   - name: Create path Output
     id: path
     shell: bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,11 +18,13 @@ FROM python:3.13-slim as prod
 # libpq-dev: postgres client libraries
 # libopenblas-dev: matplotlib dependencies
 # fortune/cowsay: for !fortune command
+# graphviz: for /satisfy solution graph rendering
 RUN apt-get update && apt-get -y install \
     ffmpeg \
     libpq-dev \
     libopenblas-dev \
     fortune-mod fortunes cowsay \
+    graphviz \
   && apt-get clean && rm -rf /var/lib/apt/lists/*
 ENV PATH "$PATH:/usr/games"
 ENV VIRTUAL_ENV "/opt/venv"

--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ setup_nltk
 
 The `dev` extras will also install development dependencies, like `pytest`. The installation commands should be run whenever you merge from upstream. The `setup_nltk` post-install script is required to download the NLTK corpora for NLTK to work properly.
 
+You'll also need [graphviz](https://graphviz.org/) installed to render graphs and run the test suite.
+
+```sh
+sudo apt install graphviz
+```
+
 ### Run Tests & Formatter
 
 ```sh

--- a/duckbot/cogs/games/satisfy/graph.py
+++ b/duckbot/cogs/games/satisfy/graph.py
@@ -1,246 +1,75 @@
-import colorsys
 import io
-from collections import Counter, deque
 
-import matplotlib.colors as mcolors
-import matplotlib.pyplot as plt
-import networkx as nx
-import numpy as np
-from matplotlib.collections import LineCollection
+import graphviz
 
 from .item import Item
 from .pretty import build_consumption_map, rnd
 from .recipe import ModifiedRecipe
 
-_GOLDEN_RATIO = (1 + 5**0.5) / 2
 _BG_COLOR = "#1e1e2e"
+_NODE_FILL = "#2a2a3d"
+_TEXT_COLOR = "#ffffff"
+_EDGE_LABEL_COLOR = "#c3c2b7"
+_INPUT_COLOR = "#199e70"
+_RECIPE_COLOR = "#3987e5"
+_OUTPUT_COLOR = "#c98500"
+
+_GRAPH_ATTR = dict(rankdir="LR", bgcolor=_BG_COLOR, splines="polyline", nodesep="0.3", ranksep="0.6", pad="0.4", dpi="150")
+_NODE_ATTR = dict(shape="box", style="rounded,filled", fillcolor=_NODE_FILL, fontcolor=_TEXT_COLOR, fontname="Helvetica bold", fontsize="12", penwidth="2", margin="0.2,0.1")
+_EDGE_ATTR = dict(fontname="Helvetica", fontsize="10", fontcolor=_EDGE_LABEL_COLOR, penwidth="1.5", arrowsize="0.7")
 
 
 def solution_graph(solution: dict[ModifiedRecipe, float]) -> io.BytesIO:
-    if not solution:
-        fig, ax = plt.subplots(figsize=(4, 2))
-        fig.patch.set_facecolor(_BG_COLOR)
-        ax.set_facecolor(_BG_COLOR)
-        ax.text(0.5, 0.5, "No solution", ha="center", va="center", transform=ax.transAxes, color="white")
-        ax.axis("off")
-        buf = io.BytesIO()
-        fig.savefig(buf, format="png", bbox_inches="tight", facecolor=_BG_COLOR)
-        plt.close(fig)
-        buf.seek(0)
-        return buf
-
-    graph = _build_graph(solution)
-    layer = {n: graph.nodes[n]["layer"] for n in graph.nodes}
-    max_layer = max(layer.values(), default=0)
-
-    ordering = _barycenter_order(graph, layer, max_layer)
-    pos = _layered_positions(ordering, max_layer)
-
-    node_colors_map = {n: colorsys.hsv_to_rgb(i / _GOLDEN_RATIO % 1, 0.65, 0.9) for i, n in enumerate(graph.nodes)}
-    node_colors = [node_colors_map[n] for n in graph.nodes]
-    labels = {n: graph.nodes[n]["label"] for n in graph.nodes}
-
-    nodes_per_layer = Counter(layer.values())
-    max_in_layer = max(nodes_per_layer.values(), default=1)
-    fig, ax = plt.subplots(figsize=(max(12, (max_layer + 1) * 3), max(8, max_in_layer * 1.5)))
-    fig.patch.set_facecolor(_BG_COLOR)
-    ax.set_facecolor(_BG_COLOR)
-
-    # Draw edges first so nodes render on top, hiding line endpoints inside circles
-    _draw_gradient_edges(ax, graph, pos, node_colors_map)
-    node_collection = nx.draw_networkx_nodes(graph, pos, ax=ax, node_color=node_colors, node_size=1500, alpha=1.0)
-    node_collection.set_zorder(3)
-    label_artists = nx.draw_networkx_labels(graph, pos, labels=labels, ax=ax, font_size=7, font_weight="bold", font_color="white")
-    for text in label_artists.values():
-        text.set_zorder(4)
-    _draw_edge_labels(ax, graph, pos, node_colors_map)
-
-    ax.axis("off")
-    fig.tight_layout()
-
-    buf = io.BytesIO()
-    fig.savefig(buf, format="png", bbox_inches="tight", dpi=120, facecolor=_BG_COLOR)
-    plt.close(fig)
-    buf.seek(0)
-    return buf
+    graph = _build_graph(solution) if solution else _empty_graph()
+    return io.BytesIO(graph.pipe(format="png"))
 
 
-def _build_graph(solution: dict[ModifiedRecipe, float]) -> nx.DiGraph:
-    graph = nx.DiGraph()
-    consumption_map = build_consumption_map(solution)
+def _empty_graph() -> graphviz.Digraph:
+    graph = graphviz.Digraph(graph_attr=dict(bgcolor=_BG_COLOR, pad="0.5"))
+    graph.node("empty", label="No solution", shape="plaintext", fontcolor=_TEXT_COLOR, fontname="Helvetica bold")
+    return graph
 
+
+def _build_graph(solution: dict[ModifiedRecipe, float]) -> graphviz.Digraph:
     produced_items: set[Item] = {item for recipe in solution for item in recipe.outputs}
     consumed_items: set[Item] = {item for recipe in solution for item in recipe.inputs}
     input_items = consumed_items - produced_items
     output_items = produced_items - consumed_items
 
+    graph = graphviz.Digraph(graph_attr=_GRAPH_ATTR, node_attr=_NODE_ATTR, edge_attr=_EDGE_ATTR)
     for item in input_items:
-        graph.add_node(_item_id(item), label=str(item))
+        graph.node(_item_id(item), label=str(item), color=_INPUT_COLOR)
     for recipe, count in solution.items():
-        graph.add_node(_recipe_id(recipe), label=f"{recipe.original_recipe.name}\n\u00d7{rnd(count)}")
+        graph.node(_recipe_id(recipe), label=f"{recipe.original_recipe.name}\\n×{rnd(count)}", color=_RECIPE_COLOR)
     for item in output_items:
-        graph.add_node(_item_id(item), label=str(item))
+        graph.node(_item_id(item), label=str(item), color=_OUTPUT_COLOR)
 
-    for recipe, count in solution.items():
-        for item in recipe.inputs:
-            if item in input_items:
-                graph.add_edge(_item_id(item), _recipe_id(recipe), label=f"{rnd(recipe.inputs.get(item, 0) * count)}/min")
-        _add_recipe_output_edges(graph, recipe, count, solution, output_items, consumption_map)
-
-    _assign_layers(graph)
+    for (source, dest, color), labels in _build_edges(solution, input_items, output_items).items():
+        graph.edge(source, dest, label="\\n".join(labels), color=color)
     return graph
 
 
-def _add_recipe_output_edges(graph: nx.DiGraph, recipe: ModifiedRecipe, count: float, solution: dict, output_items: set, consumption_map: dict) -> None:
-    for item in recipe.outputs:
-        consumer_rates = {name: rate for name, rate in consumption_map.get(item, []) if name != recipe.original_recipe.name}
-        if consumer_rates:
-            for consumer_name, rate in consumer_rates.items():
-                for other_recipe in solution:
-                    if other_recipe.original_recipe.name == consumer_name:
-                        edge_key = (_recipe_id(recipe), _recipe_id(other_recipe))
-                        if graph.has_edge(*edge_key):
-                            graph.edges[edge_key]["label"] = graph.edges[edge_key].get("label", "") + f"\n{rnd(rate)}/min"
-                        else:
-                            graph.add_edge(_recipe_id(recipe), _recipe_id(other_recipe), label=f"{rnd(rate)}/min")
-        elif item in output_items:
-            graph.add_edge(_recipe_id(recipe), _item_id(item), label=f"{rnd(recipe.outputs.get(item, 0) * count)}/min")
+def _build_edges(solution: dict[ModifiedRecipe, float], input_items: set[Item], output_items: set[Item]) -> dict[tuple[str, str, str], list[str]]:
+    consumption_map = build_consumption_map(solution)
+    edges: dict[tuple[str, str, str], list[str]] = {}
+    for recipe, count in solution.items():
+        for item in recipe.inputs:
+            if item in input_items:
+                edges.setdefault((_item_id(item), _recipe_id(recipe), _INPUT_COLOR), []).append(f"{rnd(recipe.inputs.get(item, 0) * count)}/min")
+        for item in recipe.outputs:
+            consumer_rates = {name: rate for name, rate in consumption_map.get(item, []) if name != recipe.original_recipe.name}
+            for other in solution:
+                if other.original_recipe.name in consumer_rates:
+                    edges.setdefault((_recipe_id(recipe), _recipe_id(other), _RECIPE_COLOR), []).append(f"{rnd(consumer_rates[other.original_recipe.name])}/min")
+            if not consumer_rates and item in output_items:
+                edges.setdefault((_recipe_id(recipe), _item_id(item), _OUTPUT_COLOR), []).append(f"{rnd(recipe.outputs.get(item, 0) * count)}/min")
+    return edges
 
 
+# ":" would be parsed as graphviz port syntax in edge endpoints
 def _item_id(item: Item) -> str:
-    return f"item:{item.name}"
+    return f"item_{item.name}"
 
 
 def _recipe_id(recipe: ModifiedRecipe) -> str:
-    return f"recipe:{recipe.name}"
-
-
-def _assign_layers(graph: nx.DiGraph) -> None:
-    layer: dict[str, int] = {n: 0 for n in graph.nodes if graph.in_degree(n) == 0}
-    queue = deque(layer.keys())
-    while queue:
-        node = queue.popleft()
-        for successor in graph.successors(node):
-            new_depth = layer[node] + 1
-            if successor not in layer or layer[successor] < new_depth:
-                layer[successor] = new_depth
-                queue.append(successor)
-    for node in graph.nodes:
-        graph.nodes[node]["layer"] = layer.get(node, 0)
-
-
-def _barycenter_order(graph: nx.DiGraph, layer: dict, max_layer: int) -> dict[int, list]:
-    ordering: dict[int, list] = {}
-    for n, lyr in layer.items():
-        ordering.setdefault(lyr, []).append(n)
-
-    pos = {n: i for nodes in ordering.values() for i, n in enumerate(nodes)}
-    for _ in range(20):
-        for lyr in range(1, max_layer + 1):
-            ordering[lyr].sort(key=lambda n: _bary(pos, list(graph.predecessors(n))))
-            for i, n in enumerate(ordering[lyr]):
-                pos[n] = i
-        for lyr in range(max_layer - 1, -1, -1):
-            ordering[lyr].sort(key=lambda n: _bary(pos, list(graph.successors(n))))
-            for i, n in enumerate(ordering[lyr]):
-                pos[n] = i
-
-    _adjacent_swap(ordering, graph, pos)
-    return ordering
-
-
-def _adjacent_swap(ordering: dict[int, list], graph: nx.DiGraph, pos: dict) -> None:
-    for _ in range(10):
-        for nodes in ordering.values():
-            for i in range(len(nodes) - 1):
-                a, b = nodes[i], nodes[i + 1]
-                a_nb = [n for n in list(graph.predecessors(a)) + list(graph.successors(a)) if n in pos]
-                b_nb = [n for n in list(graph.predecessors(b)) + list(graph.successors(b)) if n in pos]
-                cross_ab = sum(1 for na in a_nb for nb in b_nb if pos[na] > pos[nb])
-                cross_ba = sum(1 for na in a_nb for nb in b_nb if pos[na] < pos[nb])
-                if cross_ba < cross_ab:
-                    nodes[i], nodes[i + 1] = b, a
-                    pos[a], pos[b] = i + 1, i
-
-
-def _bary(pos: dict, neighbors: list) -> float:
-    return sum(pos.get(nb, 0) for nb in neighbors) / len(neighbors) if neighbors else 0.0
-
-
-def _layered_positions(ordering: dict[int, list], max_layer: int) -> dict:
-    pos = {}
-    for lyr, nodes in ordering.items():
-        n = len(nodes)
-        x = lyr / max_layer if max_layer > 0 else 0.5
-        for i, node in enumerate(nodes):
-            y = 1.0 - (i / (n - 1) if n > 1 else 0.5)
-            pos[node] = (x, y)
-    return pos
-
-
-def _bez(x0, y0, cx, cy, x1, y1, t):
-    return ((1 - t) ** 2 * x0 + 2 * t * (1 - t) * cx + t**2 * x1, (1 - t) ** 2 * y0 + 2 * t * (1 - t) * cy + t**2 * y1)
-
-
-def _arc_control(x0, y0, x1, y1, rad=0.1):
-    dx, dy = x1 - x0, y1 - y0
-    mx, my = (x0 + x1) / 2, (y0 + y1) / 2
-    return mx - rad * dy, my + rad * dx
-
-
-def _draw_gradient_edges(ax, graph: nx.DiGraph, pos: dict, node_colors_map: dict, rad: float = 0.1, n_segments: int = 25) -> None:
-    for u, v in graph.edges():
-        x0, y0 = pos[u]
-        x1, y1 = pos[v]
-        if np.hypot(x1 - x0, y1 - y0) < 1e-10:
-            continue
-
-        cx, cy = _arc_control(x0, y0, x1, y1, rad)
-        # Full center-to-center line; nodes are drawn on top (zorder=3) to hide endpoints inside circles
-        t_vals = np.linspace(0, 1.0, n_segments + 1)
-        bx = (1 - t_vals) ** 2 * x0 + 2 * t_vals * (1 - t_vals) * cx + t_vals**2 * x1
-        by = (1 - t_vals) ** 2 * y0 + 2 * t_vals * (1 - t_vals) * cy + t_vals**2 * y1
-
-        c0 = np.array(mcolors.to_rgb(node_colors_map[u]))
-        c1 = np.array(mcolors.to_rgb(node_colors_map[v]))
-        t_mids = (t_vals[:-1] + t_vals[1:]) / 2
-        # Gradient runs destination→source so the edge "arrives" in the source node's colour
-        segment_colors = np.clip((1 - t_mids[:, None]) * c1 + t_mids[:, None] * c0, 0, 1)
-
-        points = np.column_stack([bx, by]).reshape(-1, 1, 2)
-        segments = np.concatenate([points[:-1], points[1:]], axis=1)
-        ax.add_collection(LineCollection(segments, colors=segment_colors, linewidths=1.5, zorder=1))
-
-        # Arrowhead above nodes (zorder=4) so it's visible at the destination node boundary
-        ax.annotate(
-            "",
-            xy=_bez(x0, y0, cx, cy, x1, y1, 0.88),
-            xytext=_bez(x0, y0, cx, cy, x1, y1, 0.81),
-            arrowprops=dict(arrowstyle="-|>", color=tuple(0.2 * c0 + 0.8 * c1), lw=0.0, mutation_scale=12),
-            zorder=4,
-        )
-
-
-def _draw_edge_labels(ax, graph: nx.DiGraph, pos: dict, node_colors_map: dict, rad: float = 0.1) -> None:
-    for u, v, data in graph.edges(data=True):
-        label = data.get("label")
-        if not label:
-            continue
-        x0, y0 = pos[u]
-        x1, y1 = pos[v]
-        if np.hypot(x1 - x0, y1 - y0) < 1e-10:
-            continue
-        cx, cy = _arc_control(x0, y0, x1, y1, rad)
-        lx, ly = _bez(x0, y0, cx, cy, x1, y1, 0.5)
-        ax.text(
-            lx,
-            ly,
-            label,
-            color=node_colors_map[u],
-            fontsize=5.5,
-            ha="center",
-            va="center",
-            fontweight="bold",
-            zorder=5,
-            bbox=dict(facecolor=_BG_COLOR, edgecolor="none", alpha=0.85, boxstyle="round,pad=0.15"),
-        )
+    return f"recipe_{recipe.name}"

--- a/duckbot/cogs/games/satisfy/graph.py
+++ b/duckbot/cogs/games/satisfy/graph.py
@@ -14,9 +14,9 @@ _INPUT_COLOR = "#199e70"
 _RECIPE_COLOR = "#3987e5"
 _OUTPUT_COLOR = "#c98500"
 
-_GRAPH_ATTR = dict(rankdir="LR", bgcolor=_BG_COLOR, splines="polyline", nodesep="0.3", ranksep="0.6", pad="0.4", dpi="150")
-_NODE_ATTR = dict(shape="box", style="rounded,filled", fillcolor=_NODE_FILL, fontcolor=_TEXT_COLOR, fontname="Helvetica bold", fontsize="12", penwidth="2", margin="0.2,0.1")
-_EDGE_ATTR = dict(fontname="Helvetica", fontsize="10", fontcolor=_EDGE_LABEL_COLOR, penwidth="1.5", arrowsize="0.7")
+_GRAPH_ATTR = {"rankdir": "LR", "bgcolor": _BG_COLOR, "splines": "polyline", "nodesep": "0.3", "ranksep": "0.6", "pad": "0.4", "dpi": "150"}
+_NODE_ATTR = {"shape": "box", "style": "rounded,filled", "fillcolor": _NODE_FILL, "fontcolor": _TEXT_COLOR, "fontname": "Helvetica bold", "fontsize": "12", "penwidth": "2", "margin": "0.2,0.1"}
+_EDGE_ATTR = {"fontname": "Helvetica", "fontsize": "10", "fontcolor": _EDGE_LABEL_COLOR, "penwidth": "1.5", "arrowsize": "0.7"}
 
 
 def solution_graph(solution: dict[ModifiedRecipe, float]) -> io.BytesIO:
@@ -25,7 +25,7 @@ def solution_graph(solution: dict[ModifiedRecipe, float]) -> io.BytesIO:
 
 
 def _empty_graph() -> graphviz.Digraph:
-    graph = graphviz.Digraph(graph_attr=dict(bgcolor=_BG_COLOR, pad="0.5"))
+    graph = graphviz.Digraph(graph_attr={"bgcolor": _BG_COLOR, "pad": "0.5"})
     graph.node("empty", label="No solution", shape="plaintext", fontcolor=_TEXT_COLOR, fontname="Helvetica bold")
     return graph
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "textblob==0.20.0",
     "pyfiglet==1.0.4",
     "matplotlib==3.11.0",
-    "networkx==3.6.1",
+    "graphviz==0.21",
     "PyGithub==2.9.1",
     "wolframalpha==5.1.3",
     "yfinance==1.5.1",

--- a/tests/cogs/games/satisfy/graph_test.py
+++ b/tests/cogs/games/satisfy/graph_test.py
@@ -32,6 +32,17 @@ def test_solution_graph_chain_returns_png():
     assert result.read(4) == b"\x89PNG"
 
 
+def test_solution_graph_multiple_consumers_returns_png():
+    solution = {
+        recipe_by_name(Item.IronIngot): 2.0,
+        recipe_by_name(Item.IronPlate): 1.0,
+        recipe_by_name(Item.IronRod): 1.0,
+    }
+    result = solution_graph(solution)
+    assert isinstance(result, io.BytesIO)
+    assert result.read(4) == b"\x89PNG"
+
+
 def test_solution_graph_seek_position_is_zero():
     result = solution_graph({recipe_by_name(Item.IronIngot): 1.0})
     assert result.tell() == 0


### PR DESCRIPTION
##### Summary

<img width="1839" height="444" alt="image" src="https://github.com/user-attachments/assets/af1d9e83-a762-4143-b50a-b6aee9f28021" />
<img width="1839" height="444" alt="image" src="https://github.com/user-attachments/assets/6dbd72d7-9f41-47b3-8ccd-5ae0756d8fc3" />



---

Replaces the hand-rolled layered layout + matplotlib drawing in `satisfy/graph.py` with graphviz `dot`, rendering the solution graph straight to PNG. Fixes #1416.

The issue points at SatisfactoryTools' ELK layered layouts; `dot` is the same algorithm family (Sugiyama layering) and, like their inline-label setup, reserves space on each edge for its label so labels stop colliding. Layout params mirror theirs: left-to-right flow, polyline edge routing, compact spacing. Nodes are now rounded boxes with role-colored borders (green raw inputs, blue recipes, amber outputs) on the same dark background; node/edge content (recipe ×count, `X/min` rates) is unchanged, and so is the `solution_graph` API.

This deletes the ~170 lines of custom layout/drawing code, drops the `networkx` dependency (only used here), and adds the `graphviz` pip package plus the `graphviz` apt package to the Dockerfile.

Testing: existing graph smoke tests pass unchanged, added a multi-consumer fan-out case, and eyeballed PNG renders of every solver-test solution.

##### Checklist

- [x] this is a source code change
  - [x] run `format` in the repository root
  - [x] run `pytest` in the repository root
  - [x] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [ ] update the wiki documentation if necessary (command output is still a PNG; no wiki change needed)
- [ ] or, this is **not** a source code change

🤖 Generated with [Claude Code](https://claude.com/claude-code)