### PR TITLE
:lock: deny /market write commands outside a guild

### DIFF
--- a/duckbot/cogs/playmarket/market.py
+++ b/duckbot/cogs/playmarket/market.py
@@ -76,6 +76,7 @@ class PlayMarket(commands.Cog):
             await context.send("\n".join(lines))
 
     @market_group.command(name="claim", description="Get a coin top-up when you're low and have no active bets.")
+    @commands.guild_only()
     async def claim(self, context: commands.Context):
         async with context.typing():
             with self.db.session(Season) as session:
@@ -123,6 +124,7 @@ class PlayMarket(commands.Cog):
         await context.send(embed=embed)
 
     @market_group.command(name="create", description="Open a new question for people to bet on.")
+    @commands.guild_only()
     async def create(self, context: commands.Context, question: str, liquidity: Literal["low", "med", "high"] = "med"):
         async with context.typing():
             b = config.LIQUIDITY[liquidity]
@@ -135,6 +137,7 @@ class PlayMarket(commands.Cog):
                 await context.send(f"Market **{market.id}** is live: _{question}_ — YES 50%. Place your bets, degenerates.")
 
     @market_group.command(name="bet", description="Bet coins on a market resolving YES or NO.")
+    @commands.guild_only()
     async def bet(self, context: commands.Context, market: int, side: Literal["yes", "no"], amount: int):
         async with context.typing():
             cost = int(amount)
@@ -157,6 +160,7 @@ class PlayMarket(commands.Cog):
                 await context.send(embed=await self._trade_embed(context, session, market, action, side))
 
     @market_group.command(name="sell", description="Cash out some or all of your position in a market.")
+    @commands.guild_only()
     async def sell(self, context: commands.Context, market: int, side: Literal["yes", "no"], shares: str):
         async with context.typing():
             with self.db.session(Market) as session:
@@ -179,6 +183,7 @@ class PlayMarket(commands.Cog):
                 await context.send(embed=await self._trade_embed(context, session, market, action, side))
 
     @market_group.command(name="resolve", description="Close your market with an outcome and pay out winners.")
+    @commands.guild_only()
     async def resolve(self, context: commands.Context, market: int, outcome: Literal["yes", "no", "void"]):
         async with context.typing():
             with self.db.session(Market) as session:

--- a/tests/cogs/playmarket/market_test.py
+++ b/tests/cogs/playmarket/market_test.py
@@ -4,6 +4,7 @@ from unittest import mock
 
 import discord
 import pytest
+from discord.ext import commands
 
 from duckbot.cogs.playmarket import config
 from duckbot.cogs.playmarket.market import PlayMarket
@@ -644,6 +645,24 @@ async def test_claim_is_allowed_again_after_the_cooldown(cog, alice, clock, in_m
     set_balance(in_memory_db, 1, 10)
     await cog.claim(alice)
     assert account(in_memory_db, 1).balance == config.TOPUP_TARGET
+
+
+# --- guild-only writes -----------------------------------------------------
+
+
+@pytest.mark.parametrize("command", ["create", "bet", "sell", "claim", "resolve"])
+async def test_write_commands_are_rejected_outside_a_guild(cog, command):
+    context = make_context(1)
+    context.guild = None
+    with pytest.raises(commands.NoPrivateMessage):
+        any(check(context) for check in getattr(cog, command).checks)
+
+
+@pytest.mark.parametrize("command", ["balance", "leaderboard", "list_command"])
+async def test_read_commands_are_allowed_outside_a_guild(cog, command):
+    context = make_context(1)
+    context.guild = None
+    assert all(check(context) for check in getattr(cog, command).checks)
 
 
 # --- leaderboard ---------------------------------------------------------


### PR DESCRIPTION
##### Summary

Adds `@commands.guild_only()` to the coin-moving `/market` subcommands — `create`, `bet`, `sell`, `claim`, `resolve` — so they're rejected outside of a server, fixes #1420. Used in a DM they raise `NoPrivateMessage`, same as the `!yolo` admin check. The read-only commands (`balance`, `leaderboard`, `list`, bare `/market`) still work anywhere.

Tests assert the checks directly with a guild-less context, since `Command.__call__` bypasses checks.

##### Checklist

- [x] this is a source code change
  - [x] run `format` in the repository root
  - [x] run `pytest` in the repository root
  - [x] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [ ] update the wiki documentation if necessary
- [ ] or, this is **not** a source code change

🤖 Generated with [Claude Code](https://claude.com/claude-code)