### PR TITLE
:art: show /market balance as an embed

### DIFF
--- a/duckbot/cogs/playmarket/market.py
+++ b/duckbot/cogs/playmarket/market.py
@@ -69,11 +69,14 @@ class PlayMarket(commands.Cog):
             with self.db.session(Season) as session:
                 season = self.active_season(session)
                 account = self.account(session, season.id, context.author.id)
+                cash, shares_value = next((c, s) for uid, c, s in self._standings(session) if uid == account.id)
                 rows = session.query(Position, Market).join(Market, Position.market_id == Market.id).filter(Position.user_id == account.id, Market.status == "OPEN").order_by(Market.id.desc()).all()
+                embed = Embed(title="Balance", description=await self._worth(context, account.id, cash, shares_value), color=Color.blurple())
+                for position, market in rows:
+                    if position.yes_shares or position.no_shares:
+                        await self._add_market_field(context, session, embed, market, user_id=account.id)
                 session.commit()
-                lines = [f"**{await self._name(context, account.id)}** — {_coins(account.balance)} coins"]
-                lines += [f"**{m.id}** {m.question} — YES {_pct(self._price(m))} · you hold {_coins(p.yes_shares)} YES / {_coins(p.no_shares)} NO" for p, m in rows if p.yes_shares or p.no_shares]
-            await context.send("\n".join(lines))
+            await context.send(embed=embed)
 
     @market_group.command(name="claim", description="Get a coin top-up when you're low and have no active bets.")
     async def claim(self, context: commands.Context):
@@ -118,8 +121,7 @@ class PlayMarket(commands.Cog):
                 return await context.send("No markets. What, you hate fun?")
             embed = Embed(title=f"{(status or 'open').title()} Markets", color=Color.blurple())
             for market in markets:
-                value = "\n".join([f"YES {_pct(self._price(market))}"] + await self._holders(context, session, market))
-                embed.add_field(name=f"Market {market.id} — {market.question}", value=value, inline=False)
+                await self._add_market_field(context, session, embed, market)
         await context.send(embed=embed)
 
     @market_group.command(name="create", description="Open a new question for people to bet on.")
@@ -360,10 +362,15 @@ class PlayMarket(commands.Cog):
     def _price(self, market) -> float:
         return lmsr.price_yes(float(market.q_yes), float(market.q_no), float(market.b))
 
-    async def _holders(self, context, session, market) -> List[str]:
-        positions = session.query(Position).filter(Position.market_id == market.id, (Position.yes_shares > 0) | (Position.no_shares > 0)).all()
+    async def _holders(self, context, session, market, user_id=None) -> List[str]:
+        positions = session.query(Position).filter(Position.market_id == market.id, (Position.yes_shares > 0) | (Position.no_shares > 0))
+        positions = positions.filter_by(user_id=user_id).all() if user_id else positions.all()
         positions.sort(key=lambda p: p.yes_shares + p.no_shares, reverse=True)
         return [f"{await self._name(context, p.user_id)} — {_coins(p.yes_shares)} YES / {_coins(p.no_shares)} NO" for p in positions]
+
+    async def _add_market_field(self, context, session, embed, market, user_id=None):
+        value = "\n".join([f"YES {_pct(self._price(market))}"] + await self._holders(context, session, market, user_id))
+        embed.add_field(name=f"Market {market.id} — {market.question}", value=value, inline=False)
 
     async def _resolve_embed(self, context, market, outcome: str, results) -> Embed:
         color = Color.green() if outcome == "yes" else Color.red() if outcome == "no" else Color.greyple()
@@ -395,8 +402,10 @@ class PlayMarket(commands.Cog):
         return Embed(title="Leaderboard", description="\n".join(lines), color=Color.gold())
 
     async def _standing_line(self, context, rank, uid, cash, shares_value) -> str:
-        name = await self._name(context, uid)
-        return f"{MEDALS.get(rank, f'{rank}.')} {name} — {_coins(cash + shares_value)} coins ({_coins(cash)} available)"
+        return f"{MEDALS.get(rank, f'{rank}.')} {await self._worth(context, uid, cash, shares_value)}"
+
+    async def _worth(self, context, uid, cash, shares_value) -> str:
+        return f"{await self._name(context, uid)} — {_coins(cash + shares_value)} coins ({_coins(cash)} available)"
 
     async def _is_admin(self, context) -> bool:
         return await context.bot.is_owner(context.author) or context.author.id in config.ADMIN_IDS

--- a/tests/cogs/playmarket/market_test.py
+++ b/tests/cogs/playmarket/market_test.py
@@ -153,15 +153,17 @@ async def test_first_interaction_creates_season_one(cog, alice, in_memory_db):
 
 async def test_balance_reports_coins(cog, alice):
     await cog.balance(alice)
-    assert "10,000 coins" in alice.send.call_args.args[0]
+    expected = discord.Embed(title="Balance", description="user1 — 10,000 coins (10,000 available)", color=discord.Color.blurple())
+    alice.send.assert_called_with(embed=expected)
 
 
 async def test_balance_lists_your_open_bets(cog, alice, in_memory_db):
     market_id = await open_market(cog, alice)
     await cog.bet(alice, market_id, "yes", BET)
     await cog.balance(alice)
-    message = alice.send.call_args.args[0]
-    assert f"**{market_id}**" in message and "832 YES" in message
+    expected = discord.Embed(title="Balance", description="user1 — 10,080 coins (9,500 available)", color=discord.Color.blurple())
+    expected.add_field(name=f"Market {market_id} — Will it happen?", value="YES 69.67%\nuser1 — 832 YES / 0 NO", inline=False)
+    alice.send.assert_called_with(embed=expected)
 
 
 async def test_balance_omits_resolved_bets(cog, alice, in_memory_db):
@@ -169,7 +171,18 @@ async def test_balance_omits_resolved_bets(cog, alice, in_memory_db):
     await cog.bet(alice, market_id, "yes", BET)
     await cog.resolve(alice, market_id, "yes")
     await cog.balance(alice)
-    assert f"**{market_id}**" not in alice.send.call_args.args[0]
+    expected = discord.Embed(title="Balance", description="user1 — 10,331 coins (10,331 available)", color=discord.Color.blurple())
+    alice.send.assert_called_with(embed=expected)
+
+
+async def test_balance_shows_only_your_positions(cog, alice, bob, in_memory_db):
+    market_id = await open_market(cog, alice)
+    await cog.bet(alice, market_id, "yes", BET)
+    await cog.bet(bob, market_id, "no", BET)
+    await cog.balance(alice)
+    expected = discord.Embed(title="Balance", description="user1 — 9,852 coins (9,500 available)", color=discord.Color.blurple())
+    expected.add_field(name=f"Market {market_id} — Will it happen?", value="YES 42.26%\nuser1 — 832 YES / 0 NO", inline=False)
+    alice.send.assert_called_with(embed=expected)
 
 
 # --- list ----------------------------------------------------------------

--- a/wiki/Prediction-Market.md
+++ b/wiki/Prediction-Market.md
@@ -35,7 +35,7 @@ Everyone starts each **season** with **10,000 coins**. A season runs for a calen
 - If you go broke (under 1,000 coins) **and** hold no open positions, `/market claim` tops you back up to 2,000 coins, once per week. It's the only faucet, so balances still track skill within a season.
 - At season end any still-open markets are auto-voided, balances reset, and the final standings are recorded in a hall of fame.
 
-Use `/market balance` to see your coins and positions, and `/market leaderboard` for the standings (ranked by net worth = coins + the live value of your open positions).
+Use `/market balance` to see your net worth, available coins and positions, and `/market leaderboard` for the standings (ranked by net worth = coins + the live value of your open positions).
 
 ## How prices work
 


### PR DESCRIPTION
##### Summary

I don't have docker on this machine, so I am just using mock data in my manual tests.

<img width="461" height="482" alt="image" src="https://github.com/user-attachments/assets/ca917006-4ab0-45a3-a015-a212d5bb7c11" />

---

Part of #1360 — `/market balance` now replies with an embed instead of plain text: a leaderboard-style header showing net worth and available coins, then one field per open market you hold shares in, in the same format as `/market list` but scoped to your own position.

Rendering is shared with the existing commands rather than new code: `_holders` grew an optional user filter, the `list` field builder was extracted into `_add_market_field`, and the leaderboard's worth line was split out as `_worth` — so `/market list` and `/market leaderboard` output is unchanged.

##### Checklist

- [x] this is a source code change
  - [x] run `format` in the repository root
  - [x] run `pytest` in the repository root
  - [ ] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [x] update the wiki documentation if necessary
- [ ] or, this is **not** a source code change

🤖 Generated with [Claude Code](https://claude.com/claude-code)