### PR TITLE
:hammer: add `run_local` script to run the bot on SQLite without docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -220,3 +220,6 @@ fabric.properties
 
 # Android studio 3.1+ serialized cache file
 .idea/caches/build_file_checksums.ser
+
+# run_local scratch database
+duckbot-local.db

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,7 @@ setup_nltk
 - **Run with coverage**: `pytest --cov=duckbot --cov-branch --cov-report term-missing:skip-covered`
 - **Run the bot**: `python -m duckbot` (requires DISCORD_TOKEN env var at minimum)
 - **Run with database**: `docker-compose up --build`
+- **Run without docker**: `run_local` (SQLite file instead of Postgres; loads `.env` itself)
 
 ## Project Structure
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,7 @@ cdk = [
 
 [project.scripts]
 format = "scripts.format:main"
+run_local = "scripts.run_local:main"
 setup_nltk = "scripts.setup_nltk:main"
 
 [tool.black]

--- a/scripts/run_local.py
+++ b/scripts/run_local.py
@@ -1,0 +1,39 @@
+"""Run the bot against a local SQLite file, for manual testing without the docker-compose Postgres."""
+
+import asyncio
+import datetime
+import os
+import pathlib
+
+from sqlalchemy import BigInteger, create_engine
+from sqlalchemy.ext.compiler import compiles
+
+
+@compiles(BigInteger, "sqlite")
+def _bigint_as_integer(type_, compiler, **kw):
+    return "INTEGER"  # SQLite auto-increments INTEGER, not BIGINT
+
+
+def _load_env():
+    """Read DISCORD_TOKEN and friends from the .env files; real env vars win."""
+    for env in (pathlib.Path(".env"), pathlib.Path("duckbot/.env")):
+        if env.exists():
+            for line in env.read_text().splitlines():
+                key, _, value = line.partition("=")
+                if key.strip() and not key.strip().startswith("#"):
+                    os.environ.setdefault(key.strip(), value.strip())
+
+
+def main():
+    _load_env()
+
+    import duckbot.db.database as database
+    import duckbot.util.datetime
+    from duckbot import DuckBot
+    from duckbot.__main__ import run_duckbot
+
+    engine = create_engine("sqlite:///duckbot-local.db")
+    database.create_engine = lambda *args, **kwargs: engine  # Database.__init__ re-runs on every call, so patch the factory, not the instance
+    duckbot.util.datetime.now = datetime.datetime.now  # SQLite strips tzinfo on read; keep both sides of comparisons naive
+
+    asyncio.run(run_duckbot(DuckBot()))


### PR DESCRIPTION
##### Summary

Adds a `run_local` console script that runs the bot against a local `duckbot-local.db` SQLite file instead of the docker-compose Postgres — handy for manually testing commands in Discord on machines without docker.

It reuses the normal startup path (`run_duckbot`) with three dev-only shims:

- compiles `BigInteger` as `INTEGER` on SQLite so primary keys autoincrement (same trick as the `in_memory_db` test fixture)
- patches `duckbot.db.database.create_engine` to return the SQLite engine (`Database.__init__` re-runs on every singleton call, so the factory is patched rather than the instance)
- patches `duckbot.util.datetime.now` to naive local time, since SQLite strips tzinfo on read and aware-vs-naive comparisons crash

It also loads `.env` / `duckbot/.env` itself, so `run_local` is the whole command. The scratch database file is gitignored. Verified by running it and exercising the `/market` commands in Discord.

##### Checklist

- [x] this is a source code change
  - [x] run `format` in the repository root
  - [x] run `pytest` in the repository root
  - [ ] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [ ] update the wiki documentation if necessary
- [ ] or, this is **not** a source code change

🤖 Generated with [Claude Code](https://claude.com/claude-code)