### PR TITLE
:sparkles: add epic free games weekly announcement and !epic command

### DIFF
--- a/duckbot/cogs/games/__init__.py
+++ b/duckbot/cogs/games/__init__.py
@@ -2,6 +2,7 @@ from .aoe import AgeOfEmpires
 from .coin_flip import CoinFlip
 from .dice import Dice
 from .discord_activity import DiscordActivity
+from .epic_games import EpicGames
 from .office_hours import OfficeHours
 from .pokemon import Pokemon
 from .satisfy import setup as satisfy_setup
@@ -12,6 +13,7 @@ async def setup(bot):
     await bot.add_cog(AgeOfEmpires())
     await bot.add_cog(CoinFlip())
     await bot.add_cog(DiscordActivity(bot))
+    await bot.add_cog(EpicGames(bot))
     await bot.add_cog(OfficeHours(bot))
     await bot.add_cog(Pokemon(bot))
     await satisfy_setup(bot)

--- a/duckbot/cogs/games/epic_games.py
+++ b/duckbot/cogs/games/epic_games.py
@@ -1,0 +1,74 @@
+from datetime import datetime, time
+from typing import List, Optional
+
+import discord
+import requests
+from discord import ChannelType
+from discord.ext import commands, tasks
+from discord.utils import get
+
+from duckbot.util.datetime import now, timezone
+
+FREE_GAMES_URL = "https://store-site-backend-static.ak.epicgames.com/freeGamesPromotions"
+STORE_PAGE_URL = "https://store.epicgames.com/en-CA/p"
+THURSDAY = 3
+
+
+class EpicGames(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+        self.free_games_loop.start()
+
+    def cog_unload(self):
+        self.free_games_loop.cancel()
+
+    def get_games_channel(self):
+        return get(self.bot.get_all_channels(), guild__name="Friends Chat", name="games", type=ChannelType.text)
+
+    @commands.command(name="epic")
+    async def epic(self, context: commands.Context):
+        embeds = self.get_free_games()
+        if embeds:
+            await context.send(embeds=embeds)
+        else:
+            await context.send("no free games right now, somehow")
+
+    @tasks.loop(time=time(hour=12, tzinfo=timezone()))
+    async def free_games_loop(self):
+        await self.announce_free_games()
+
+    async def announce_free_games(self):
+        if now().weekday() == THURSDAY and (embeds := self.get_free_games()):
+            await self.get_games_channel().send(embeds=embeds)
+
+    def get_free_games(self) -> List[discord.Embed]:
+        params = {"locale": "en-CA", "country": "CA", "allowCountries": "CA"}
+        response = requests.get(FREE_GAMES_URL, params=params, timeout=(3.05, 27)).json()
+        games = response["data"]["Catalog"]["searchStore"]["elements"]
+        return [self.to_embed(game, offer) for game in games if (offer := self.free_offer(game))]
+
+    def free_offer(self, game: dict) -> Optional[dict]:
+        """Returns the game's active 100%-off promotion, if any."""
+        if game.get("price", {}).get("totalPrice", {}).get("discountPrice") != 0:
+            return None
+        offers = [offer for promo in (game.get("promotions") or {}).get("promotionalOffers") or [] for offer in promo["promotionalOffers"]]
+        return next((offer for offer in offers if offer["discountSetting"]["discountPercentage"] == 0), None)
+
+    def to_embed(self, game: dict, offer: dict) -> discord.Embed:
+        embed = discord.Embed(title=game["title"], url=self.store_page(game), description=game.get("description"))
+        image = next((img["url"] for img in game.get("keyImages") or [] if img["type"] == "OfferImageWide"), None)
+        if image:
+            embed.set_image(url=image)
+        end = int(datetime.fromisoformat(offer["endDate"]).timestamp())
+        embed.add_field(name="Free until", value=f"<t:{end}:R>")
+        embed.add_field(name="Original price", value=game["price"]["totalPrice"]["fmtPrice"]["originalPrice"])
+        return embed
+
+    def store_page(self, game: dict) -> str:
+        mappings = (game.get("offerMappings") or []) + ((game.get("catalogNs") or {}).get("mappings") or [])
+        slug = next((m["pageSlug"] for m in mappings if m.get("pageSlug")), game.get("productSlug"))
+        return f"{STORE_PAGE_URL}/{slug}"
+
+    @free_games_loop.before_loop
+    async def before_loop(self):
+        await self.bot.wait_until_ready()

--- a/tests/cogs/games/epic_games_test.py
+++ b/tests/cogs/games/epic_games_test.py
@@ -1,0 +1,106 @@
+import datetime
+from unittest import mock
+
+import discord
+import pytest
+
+from duckbot.cogs.games import EpicGames
+from duckbot.cogs.games.epic_games import FREE_GAMES_URL
+from tests.discord_test_ext import bind_commands
+
+END_DATE = "2026-07-23T15:00:00.000Z"
+END_EPOCH = 1784818800
+THURSDAY = datetime.datetime(2026, 7, 23, hour=12)
+FRIDAY = datetime.datetime(2026, 7, 24, hour=12)
+
+
+@pytest.fixture
+def clazz(bot) -> EpicGames:
+    return bind_commands(EpicGames(bot))
+
+
+@pytest.fixture
+def games_channel(bot, guild, text_channel) -> discord.TextChannel:
+    bot.get_all_channels.return_value = [text_channel]
+    guild.name = "Friends Chat"
+    text_channel.guild = guild
+    text_channel.name = "games"
+    return text_channel
+
+
+def game(title, discount_price=0, discount_percentage=0, current_promo=True):
+    offer = {"startDate": "2026-07-16T15:00:00.000Z", "endDate": END_DATE, "discountSetting": {"discountType": "PERCENTAGE", "discountPercentage": discount_percentage}}
+    promotions = {"promotionalOffers": [{"promotionalOffers": [offer]}] if current_promo else [], "upcomingPromotionalOffers": [] if current_promo else [{"promotionalOffers": [offer]}]}
+    return {
+        "title": title,
+        "description": f"{title} is a video game.",
+        "keyImages": [{"type": "OfferImageWide", "url": f"https://cdn1.epicgames.com/{title}-wide.jpg"}, {"type": "Thumbnail", "url": f"https://cdn1.epicgames.com/{title}-thumb.jpg"}],
+        "productSlug": None,
+        "offerMappings": [{"pageSlug": f"{title}-slug", "pageType": "productHome"}],
+        "catalogNs": {"mappings": []},
+        "price": {"totalPrice": {"discountPrice": discount_price, "fmtPrice": {"originalPrice": "$25.99 CAD"}}},
+        "promotions": promotions,
+    }
+
+
+def payload(*games):
+    return {"data": {"Catalog": {"searchStore": {"elements": list(games)}}}}
+
+
+def expected_embed(title):
+    embed = discord.Embed(title=title, url=f"https://store.epicgames.com/en-CA/p/{title}-slug", description=f"{title} is a video game.")
+    embed.set_image(url=f"https://cdn1.epicgames.com/{title}-wide.jpg")
+    embed.add_field(name="Free until", value=f"<t:{END_EPOCH}:R>")
+    embed.add_field(name="Original price", value="$25.99 CAD")
+    return embed
+
+
+async def test_before_loop_waits_for_bot(bot, clazz):
+    await clazz.before_loop()
+    bot.wait_until_ready.assert_called()
+
+
+def test_cog_unload_cancels_task(clazz):
+    clazz.cog_unload()
+    clazz.free_games_loop.cancel.assert_called()
+
+
+def test_get_free_games_filters_free_games(clazz, responses):
+    free = game("Luto")
+    discounted = game("Foretales", discount_price=299, discount_percentage=15)
+    upcoming = game("LISA", discount_price=2499, current_promo=False)
+    no_promotions = game("Monument Valley", discount_price=799) | {"promotions": None}
+    responses.add(responses.GET, FREE_GAMES_URL, json=payload(free, discounted, upcoming, no_promotions))
+    assert clazz.get_free_games() == [expected_embed("Luto")]
+
+
+async def test_epic_sends_free_game_embeds(clazz, context, responses):
+    responses.add(responses.GET, FREE_GAMES_URL, json=payload(game("Luto"), game("Echo Generation")))
+    await clazz.epic(context)
+    context.send.assert_called_once_with(embeds=[expected_embed("Luto"), expected_embed("Echo Generation")])
+
+
+async def test_epic_no_free_games(clazz, context, responses):
+    responses.add(responses.GET, FREE_GAMES_URL, json=payload())
+    await clazz.epic(context)
+    context.send.assert_called_once_with("no free games right now, somehow")
+
+
+@mock.patch("duckbot.cogs.games.epic_games.now", return_value=THURSDAY)
+async def test_announce_free_games_thursday(now, clazz, games_channel, responses):
+    responses.add(responses.GET, FREE_GAMES_URL, json=payload(game("Luto")))
+    await clazz.announce_free_games()
+    games_channel.send.assert_called_once_with(embeds=[expected_embed("Luto")])
+
+
+@mock.patch("duckbot.cogs.games.epic_games.now", return_value=THURSDAY)
+async def test_announce_free_games_thursday_no_free_games(now, clazz, games_channel, responses):
+    responses.add(responses.GET, FREE_GAMES_URL, json=payload())
+    await clazz.announce_free_games()
+    games_channel.send.assert_not_called()
+
+
+@mock.patch("duckbot.cogs.games.epic_games.now", return_value=FRIDAY)
+async def test_announce_free_games_not_thursday(now, clazz, games_channel):
+    await clazz.announce_free_games()
+    games_channel.send.assert_not_called()

--- a/tests/cogs/games/setup_test.py
+++ b/tests/cogs/games/setup_test.py
@@ -3,6 +3,7 @@ from duckbot.cogs.games import (
     CoinFlip,
     Dice,
     DiscordActivity,
+    EpicGames,
     OfficeHours,
     Pokemon,
 )
@@ -17,6 +18,7 @@ async def test_setup(bot_spy):
     assert_cog_added_of_type(bot_spy, AgeOfEmpires)
     assert_cog_added_of_type(bot_spy, CoinFlip)
     assert_cog_added_of_type(bot_spy, DiscordActivity)
+    assert_cog_added_of_type(bot_spy, EpicGames)
     assert_cog_added_of_type(bot_spy, OfficeHours)
     assert_cog_added_of_type(bot_spy, Pokemon)
     assert_cog_added_of_type(bot_spy, Satisfy)

--- a/wiki/Commands.md
+++ b/wiki/Commands.md
@@ -10,6 +10,7 @@
 |     [`!define`](#definitions)     | define a word                                      |
 |              `!dog`               | displays a random dog photo                        |
 |              `!duck`              | gives a link to this repo                          |
+| [`!epic`](Events#epic-free-games) | show the free games of the week on epic            |
 |            `!fortune`             | get a random fortune told to you by a cow          |
 |        `!help` or `!wiki`         | gives a link to this wiki                          |
 |              `!lmgt`              | generates a google search link for the given query |

--- a/wiki/Events.md
+++ b/wiki/Events.md
@@ -93,3 +93,7 @@ DuckBot is a robot, and as such does not like being humanized. DuckBot tells peo
 ## Day Announcements
 
 Every day in the 7am hour, DuckBot will announce to the general channel the current day of the week. If the day is also a statutory holiday, or an otherwise special day, DuckBot will announce that at the same time. You can run this on demand using the `!day` command.
+
+## Epic Free Games
+
+Every Thursday at noon, DuckBot will post the free games of the week from the [Epic Games Store](https://store.epicgames.com/en-CA/free-games) to the games channel. You can run this on demand using the `!epic` command.


### PR DESCRIPTION
##### Summary

https://discord.com/channels/845352633702809621/845353256153907210/1527432079200092260

~~Thinking about making it be a thread each week. It's pretty large as is with the embedded images.~~ Will tackle as a follow up if we find it too noisy as is.

---

Adds an `EpicGames` cog to the games extension which fetches the current free games from the Epic Games Store's `freeGamesPromotions` endpoint (Canada locale) and renders each as an embed with the store link, image, free-until timestamp, and original price. A daily noon loop posts them to the games channel on Thursdays (Epic rotates its free games Thursdays at 11am ET), and `!epic` shows them on demand.

Fixes #541.

Tested against the live API — both of this week's free games (Luto, Echo Generation: Midnight Edition) come back with correct links, images, and prices.

##### Checklist

- [x] this is a source code change
  - [x] run `format` in the repository root
  - [x] run `pytest` in the repository root
  - [x] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [x] update the wiki documentation if necessary
- [ ] or, this is **not** a source code change

🤖 Generated with [Claude Code](https://claude.com/claude-code)