### PR TITLE
:art: de-async sync-only tests, bound the twitch request, fix FROM casing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # collect pip dependencies into a virtualenv, which we'll copy into the prod stage
-FROM python:3.13 as pip-dependencies
+FROM python:3.13 AS pip-dependencies
 ENV VIRTUAL_ENV "/opt/venv"
 RUN python -m venv $VIRTUAL_ENV
 ENV PATH "$VIRTUAL_ENV/bin:$PATH"
@@ -13,7 +13,7 @@ COPY pyproject.toml .
 RUN pip install .
 RUN setup_nltk
 
-FROM python:3.13-slim as prod
+FROM python:3.13-slim AS prod
 # ffmpeg: for discord audio
 # libpq-dev: postgres client libraries
 # libopenblas-dev: matplotlib dependencies

--- a/duckbot/cogs/audio/who_can_it_be_now.py
+++ b/duckbot/cogs/audio/who_can_it_be_now.py
@@ -1,4 +1,5 @@
 import asyncio
+from contextlib import suppress
 from importlib.resources import path
 from typing import Optional
 
@@ -70,11 +71,9 @@ class WhoCanItBeNow(commands.Cog):
         if self.streaming:
             self.streaming = False
             await self.voice_client.disconnect()
-            try:
-                self.audio_task.cancel()
+            self.audio_task.cancel()
+            with suppress(asyncio.CancelledError):
                 await self.audio_task
-            except asyncio.CancelledError:
-                pass
             self.audio_task = None
             self.voice_client = None
             if context:

--- a/duckbot/cogs/games/office_hours.py
+++ b/duckbot/cogs/games/office_hours.py
@@ -18,7 +18,7 @@ class OfficeHours(commands.Cog):
         await self.check_if_streaming()
 
     async def check_if_streaming(self):
-        page = requests.get("https://www.twitch.tv/conlabx").text
+        page = requests.get("https://www.twitch.tv/conlabx", timeout=(3.05, 27)).text
         streaming = "isLiveBroadcast" in page
         if streaming != self.streaming:
             self.streaming = streaming

--- a/tests/cogs/insights/insights_test.py
+++ b/tests/cogs/insights/insights_test.py
@@ -18,7 +18,7 @@ async def test_before_loop_waits_for_bot(clazz, bot):
     bot.wait_until_ready.assert_called()
 
 
-async def test_cog_unload_cancels_task(clazz):
+def test_cog_unload_cancels_task(clazz):
     clazz.cog_unload()
     clazz.check_should_respond_loop.cancel.assert_called()
 

--- a/tests/cogs/messages/touch_grass_test.py
+++ b/tests/cogs/messages/touch_grass_test.py
@@ -187,7 +187,7 @@ async def test_clean_old_messages_preserves_recent(mock_utcnow, clazz, message):
 
 
 @mock.patch("duckbot.cogs.messages.touch_grass.utcnow")
-async def test_should_notify_returns_true_for_new_user(mock_utcnow, clazz, message):
+def test_should_notify_returns_true_for_new_user(mock_utcnow, clazz, message):
     """First notification for a user should be allowed."""
     base_time = datetime.datetime(2024, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc)
     mock_utcnow.return_value = base_time
@@ -198,7 +198,7 @@ async def test_should_notify_returns_true_for_new_user(mock_utcnow, clazz, messa
 
 
 @mock.patch("duckbot.cogs.messages.touch_grass.utcnow")
-async def test_should_notify_returns_false_within_cooldown(mock_utcnow, clazz, message):
+def test_should_notify_returns_false_within_cooldown(mock_utcnow, clazz, message):
     """Notification within cooldown period should be blocked."""
     base_time = datetime.datetime(2024, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc)
     last_notification = base_time - datetime.timedelta(minutes=30)
@@ -209,7 +209,7 @@ async def test_should_notify_returns_false_within_cooldown(mock_utcnow, clazz, m
 
 
 @mock.patch("duckbot.cogs.messages.touch_grass.utcnow")
-async def test_should_notify_returns_true_after_cooldown(mock_utcnow, clazz, message):
+def test_should_notify_returns_true_after_cooldown(mock_utcnow, clazz, message):
     """Notification after cooldown expires should be allowed."""
     base_time = datetime.datetime(2024, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc)
     last_notification = base_time - datetime.timedelta(hours=1, minutes=1)
@@ -388,7 +388,7 @@ async def test_show_activity_stats_unknown_user(mock_utcnow, mock_get_user, claz
     assert "5" in call_args
 
 
-async def test_is_work_hours_weekday_within_hours(clazz):
+def test_is_work_hours_weekday_within_hours(clazz):
     """Mon-Fri 8am-6pm EDT (12pm-10pm UTC) should be work hours."""
     # Monday 12:00 UTC
     assert clazz.is_work_hours(MONDAY_NOON) is True
@@ -398,7 +398,7 @@ async def test_is_work_hours_weekday_within_hours(clazz):
     assert clazz.is_work_hours(datetime.datetime(2024, 1, 1, 21, 59, 0, tzinfo=datetime.timezone.utc)) is True
 
 
-async def test_is_work_hours_weekday_outside_hours(clazz):
+def test_is_work_hours_weekday_outside_hours(clazz):
     """Before 12pm and at/after 10pm UTC on weekdays should not be work hours."""
     # Monday 11:59 UTC
     assert clazz.is_work_hours(datetime.datetime(2024, 1, 1, 11, 59, 0, tzinfo=datetime.timezone.utc)) is False
@@ -408,7 +408,7 @@ async def test_is_work_hours_weekday_outside_hours(clazz):
     assert clazz.is_work_hours(datetime.datetime(2024, 1, 1, 23, 0, 0, tzinfo=datetime.timezone.utc)) is False
 
 
-async def test_is_work_hours_weekend(clazz):
+def test_is_work_hours_weekend(clazz):
     """Weekends should not be work hours regardless of time."""
     # Saturday 12:00 UTC
     assert clazz.is_work_hours(SATURDAY_NOON) is False

--- a/tests/cogs/playmarket/market_test.py
+++ b/tests/cogs/playmarket/market_test.py
@@ -668,7 +668,7 @@ async def test_claim_is_allowed_again_after_the_cooldown(cog, alice, clock, in_m
 
 
 @pytest.mark.parametrize("command", ["create", "bet", "sell", "claim", "resolve"])
-async def test_write_commands_are_rejected_outside_a_guild(cog, command):
+def test_write_commands_are_rejected_outside_a_guild(cog, command):
     context = make_context(1)
     context.guild = None
     with pytest.raises(commands.NoPrivateMessage):
@@ -676,7 +676,7 @@ async def test_write_commands_are_rejected_outside_a_guild(cog, command):
 
 
 @pytest.mark.parametrize("command", ["balance", "leaderboard", "list_command"])
-async def test_read_commands_are_allowed_outside_a_guild(cog, command):
+def test_read_commands_are_allowed_outside_a_guild(cog, command):
     context = make_context(1)
     context.guild = None
     assert all(check(context) for check in getattr(cog, command).checks)

--- a/tests/cogs/recipe/recipe_test.py
+++ b/tests/cogs/recipe/recipe_test.py
@@ -14,7 +14,7 @@ def clazz() -> Recipe:
     return bind_commands(Recipe())
 
 
-async def test_search_recipes_returns_scraped_html(clazz, responses):
+def test_search_recipes_returns_scraped_html(clazz, responses):
     search_term = "test1"
     mock_data = get_mock_data(search_term, 5)
     setup_responses(responses, search_term, with_articles(mock_data))
@@ -23,7 +23,7 @@ async def test_search_recipes_returns_scraped_html(clazz, responses):
     assert_requests(responses, search_term)
 
 
-async def test_parse_recipes_returns_articles(clazz):
+def test_parse_recipes_returns_articles(clazz):
     mock_data = get_mock_data("test1", 5)
     expected_response = [get_mock_data("test1", 5) for _ in range(5)]
     html = json_articles(mock_data)
@@ -31,27 +31,27 @@ async def test_parse_recipes_returns_articles(clazz):
     assert response == expected_response
 
 
-async def test_parse_recipes_returns_empty(clazz):
+def test_parse_recipes_returns_empty(clazz):
     expected_response = []
     html = without_articles()
     response = clazz.parse_recipes(html)
     assert response == expected_response
 
 
-async def test_parse_recipes_no_content_returns_empty(clazz):
+def test_parse_recipes_no_content_returns_empty(clazz):
     expected_response = []
     html = without_content()
     response = clazz.parse_recipes(html)
     assert response == expected_response
 
 
-async def test_select_recipes_with_one_return_one(clazz):
+def test_select_recipes_with_one_return_one(clazz):
     recipe_list = [get_mock_data("test1", 5)]
     response = clazz.select_recipe(recipe_list)
     assert response == recipe_list[0]
 
 
-async def test_select_recipes_with_many_return_one(clazz):
+def test_select_recipes_with_many_return_one(clazz):
     recipe_list = [get_mock_data("test1", 5), get_mock_data("test2", 4)]
     response = clazz.select_recipe(recipe_list)
     assert response in recipe_list

--- a/tests/cogs/text/mock_text_test.py
+++ b/tests/cogs/text/mock_text_test.py
@@ -57,43 +57,43 @@ async def test_mock_text_no_message_reply(get_message_reference, random_choice, 
 
 @mock.patch("duckbot.cogs.text.mock_text.random.randint", return_value=1)
 @mock.patch("duckbot.cogs.text.mock_text.random.choice", return_value="**")
-async def test_mockify_wraps_emphasis_span_with_bold(random_choice, random_randint, clazz):
+def test_mockify_wraps_emphasis_span_with_bold(random_choice, random_randint, clazz):
     assert clazz.mockify("hi") == "**H**i"
 
 
 @mock.patch("duckbot.cogs.text.mock_text.random.randint", return_value=1)
 @mock.patch("duckbot.cogs.text.mock_text.random.choice", return_value="*")
-async def test_mockify_wraps_emphasis_span_with_italic(random_choice, random_randint, clazz):
+def test_mockify_wraps_emphasis_span_with_italic(random_choice, random_randint, clazz):
     assert clazz.mockify("hi") == "*H*i"
 
 
 @mock.patch("duckbot.cogs.text.mock_text.random.randint", return_value=1)
 @mock.patch("duckbot.cogs.text.mock_text.random.choice", return_value="`")
-async def test_mockify_wraps_emphasis_span_with_code(random_choice, random_randint, clazz):
+def test_mockify_wraps_emphasis_span_with_code(random_choice, random_randint, clazz):
     assert clazz.mockify("hi") == "`H`i"
 
 
 @mock.patch("duckbot.cogs.text.mock_text.random.randint", return_value=1)
 @mock.patch("duckbot.cogs.text.mock_text.random.choice", side_effect=["**", "*"])
-async def test_mockify_alternates_emphasis_and_plain(random_choice, random_randint, clazz):
+def test_mockify_alternates_emphasis_and_plain(random_choice, random_randint, clazz):
     assert clazz.mockify("abc") == "**A**b*C*"
 
 
 @mock.patch("duckbot.cogs.text.mock_text.random.randint", return_value=4)
 @mock.patch("duckbot.cogs.text.mock_text.random.choice", return_value="**")
-async def test_mockify_spans_multiple_characters(random_choice, random_randint, clazz):
+def test_mockify_spans_multiple_characters(random_choice, random_randint, clazz):
     assert clazz.mockify("hello") == "**HeLl**O"
 
 
 @mock.patch("duckbot.cogs.text.mock_text.random.randint", return_value=1)
 @mock.patch("duckbot.cogs.text.mock_text.random.choice", return_value="**")
-async def test_mockify_does_not_wrap_punctuation_or_whitespace(random_choice, random_randint, clazz):
+def test_mockify_does_not_wrap_punctuation_or_whitespace(random_choice, random_randint, clazz):
     assert clazz.mockify("hi ... bye") == "**H**i ... **B**y**E**"
 
 
 @mock.patch("duckbot.cogs.text.mock_text.random.randint", return_value=1)
 @mock.patch("duckbot.cogs.text.mock_text.random.choice", return_value="**")
-async def test_mockify_does_not_offer_previous_wrapper_as_choice(random_choice, random_randint, clazz):
+def test_mockify_does_not_offer_previous_wrapper_as_choice(random_choice, random_randint, clazz):
     clazz.mockify("abcde")
     assert set(random_choice.call_args_list[1][0][0]) == set(WRAPPERS) - {"**"}
 

--- a/tests/cogs/text/wordnik_test.py
+++ b/tests/cogs/text/wordnik_test.py
@@ -63,7 +63,7 @@ async def test_define_rate_limited(clazz, context, responses):
     context.send.assert_called_once_with("wordnik is all worded out, give it a minute")
 
 
-async def test_get_pronunciation_no_results(clazz, responses):
+def test_get_pronunciation_no_results(clazz, responses):
     responses.add(responses.GET, f"{URL}/cat/pronunciations", json={"statusCode": 404, "error": "Not Found", "message": "Not found"})
     assert clazz.get_pronunciation("cat") == "screw flanders"
 

--- a/tests/cogs/weather/weather_test.py
+++ b/tests/cogs/weather/weather_test.py
@@ -48,7 +48,7 @@ def test_owm_returns_cached_instance(weather, owm):
 
 async def test_weather_get_failure(weather, owm, context):
     owm.weather_manager.return_value.one_call.side_effect = Exception("ded")
-    with pytest.raises(Exception):
+    with pytest.raises(Exception, match="ded"):
         await weather.weather(context, "city", None, None)
     context.send.assert_called_once_with("Iunno. Figure it out.\nded")
 


### PR DESCRIPTION
##### Summary

Clears the open SonarCloud findings that were worth acting on.

- **`python:S7503` (13 tests)** — dropped `async` from test functions that contain no `await`/`async with`/`async for`. Verified with an AST pass rather than by eye; alongside the 11 Sonar flagged, this catches 12 more of the identical shape it hadn't reported yet (`test_should_notify_*`, the `market` guild-only check tests, `test_mockify_*`). Async defs that are genuinely awaited elsewhere are untouched: the `__aenter__`/`__aexit__` stubs, the `mock_search_location` monkeypatches in `weather_test.py`, `tests/fixtures/*`, and the `logs/loop_replacement_test.py` callbacks.
- **`python:S7499`** — `office_hours` fetched twitch.tv with no timeout on the event loop, so an unresponsive host would hang the bot indefinitely. Added `timeout=(3.05, 27)`, matching `epic_games` and `wordnik`. Sonar will likely keep flagging this one since it wants an async client; `requests` is the convention across all 10 HTTP call sites here, so that's a separate discussion.
- **`python:S7497`** — in `WhoCanItBeNow.stop`, `self.audio_task.cancel()` sat inside the `try` that suppressed `CancelledError`, so a cancellation of `stop` itself was swallowed too. Only the `await` is suppressed now.
- **`python:S5958`** — `pytest.raises(Exception, match="ded")` in `weather_test`; the mock raises a bare `Exception`, so `match` is the way to make the assertion specific.
- **`docker:S6476`** — `FROM ... as` → `AS`, which is also a live BuildKit `FromAsCasing` deprecation warning. Stage names are case-insensitive at the reference site, so `COPY --from=pip-dependencies` is unaffected.

Left alone deliberately: `docker:S8541`/`S8544` (pip lockfile, `--only-binary`) and `docker:S6500` ×2 (`--no-install-recommends`). The last one would shrink the image but `ffmpeg`/`fortune-mod`/`cowsay` may lean on recommended packages, so it needs a real build and smoke test instead of a blind edit.

No behaviour change beyond the timeout and the narrower exception suppression. Testing is the existing suite.

##### Checklist

- [x] this is a source code change
  - [x] run `format` in the repository root
  - [x] run `pytest` in the repository root
  - [ ] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [ ] update the wiki documentation if necessary
- [ ] or, this is **not** a source code change

🤖 Generated with [Claude Code](https://claude.com/claude-code)