### PR TITLE
:arrow_up: bump setup-aws-cdk Node from 20.x to 24.x

### DIFF
--- a/.github/actions/setup-aws-cdk/action.yml
+++ b/.github/actions/setup-aws-cdk/action.yml
@@ -1,4 +1,4 @@
-name: Set Up AWK Cloud Development Kit (CDK)
+name: Set Up AWS Cloud Development Kit (CDK)
 description: installs dependencies to be able to run cdk
 
 outputs:

--- a/.github/actions/setup-aws-cdk/action.yml
+++ b/.github/actions/setup-aws-cdk/action.yml
@@ -21,7 +21,7 @@ runs:
   - name: Set up Node.js
     uses: actions/setup-node@v6
     with:
-      node-version: 20.x
+      node-version: 24.x
 
   - name: Install CDK
     shell: bash


### PR DESCRIPTION
##### Summary

Node 20 reaches end-of-life in April 2026, and the CDK CI job surfaces the EOL warning. Bumps the `setup-aws-cdk` composite action from Node 20.x to 24.x — the active LTS (supported through April 2028). `actions/setup-node` fetches the version from its manifest at job time (24.18.0 latest), so it works regardless of the runner's preinstalled default.

Verified `24.x` resolves against the live `actions/node-versions` manifest.

Also fixes an "AWK" → "AWS" typo in the same action's `name`.

##### Checklist

- [ ] this is a source code change
  - [ ] run \`format\` in the repository root
  - [ ] run \`pytest\` in the repository root
  - [ ] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [ ] update the wiki documentation if necessary
- [x] or, this is **not** a source code change

🤖 Generated with [Claude Code](https://claude.com/claude-code)