### PR TITLE
:construction_worker: cancel superseded PR CI runs

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -9,6 +9,10 @@ on:
     - main
   merge_group:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
##### Summary

Adds a workflow-level `concurrency` guard to DuckBot CI so a new push to a pull request cancels the still-running CI from the previous push, instead of letting every superseded run finish (each spins up the test, sanity/docker, and `cdk synth` jobs).

The `group: ${{ github.workflow }}-${{ github.ref }}` shape is GitHub's recommended pattern for scoping cancellation to the same workflow on the same ref — see [Using concurrency](https://docs.github.com/en/actions/using-jobs/using-concurrency).

`cancel-in-progress` is gated to `pull_request` events only (the docs' example uses a flat `true`), so `push` (main) and `merge_group` runs are never cancelled mid-flight — including the `deploy` job, which keeps its own separate `concurrency: deploy` guard.

##### Checklist

- [ ] this is a source code change
  - [ ] run \`format\` in the repository root
  - [ ] run \`pytest\` in the repository root
  - [ ] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [ ] update the wiki documentation if necessary
- [x] or, this is **not** a source code change

🤖 Generated with [Claude Code](https://claude.com/claude-code)