### PR TITLE
:whale: install apt packages with --no-install-recommends, verified by CI smoke tests

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -39,9 +39,37 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v7
+    - name: Build Image
+      id: build
+      run: docker compose build duckbot
+    - name: Verify fortune
+      if: ${{ !cancelled() && steps.build.outcome == 'success' }}
+      run: docker run --rm --entrypoint fortune duckdynasty/duckbot:latest -a
+    - name: Verify cowsay
+      if: ${{ !cancelled() && steps.build.outcome == 'success' }}
+      run: docker run --rm --entrypoint cowsay duckdynasty/duckbot:latest moo
+    - name: Verify ffmpeg
+      if: ${{ !cancelled() && steps.build.outcome == 'success' }}
+      run: docker run --rm --entrypoint ffmpeg duckdynasty/duckbot:latest -version
+    - name: Verify fortune command
+      if: ${{ !cancelled() && steps.build.outcome == 'success' }}
+      run: docker run --rm --entrypoint sh duckdynasty/duckbot:latest -ec 'fortune -a | cowsay -f "$(ls /usr/share/cowsay/cows/ | shuf -n1)"'
+    - name: Verify duckbot imports
+      if: ${{ !cancelled() && steps.build.outcome == 'success' }}
+      run: docker run --rm --entrypoint python duckdynasty/duckbot:latest -c 'import duckbot'
+    - name: Verify graphviz
+      if: ${{ !cancelled() && steps.build.outcome == 'success' }}
+      run: docker run --rm --entrypoint python duckdynasty/duckbot:latest -c 'from duckbot.cogs.games.satisfy.graph import solution_graph; assert solution_graph({}).getbuffer().nbytes > 0'
+    - name: Verify matplotlib
+      if: ${{ !cancelled() && steps.build.outcome == 'success' }}
+      run: docker run --rm --entrypoint python duckdynasty/duckbot:latest -c 'import io, matplotlib; matplotlib.use("Agg"); import matplotlib.pyplot as plt; fig, ax = plt.subplots(); ax.plot([0, 1, 2], [2, 1, 0]); buf = io.BytesIO(); fig.savefig(buf, format="png"); assert buf.getbuffer().nbytes > 0'
+    - name: Verify mip
+      if: ${{ !cancelled() && steps.build.outcome == 'success' }}
+      run: docker run --rm --entrypoint python duckdynasty/duckbot:latest -c 'from mip import Model, maximize, INTEGER, OptimizationStatus as S; m = Model(); x = m.add_var(var_type=INTEGER); m.objective = maximize(x); m += x <= 3; assert m.optimize() == S.OPTIMAL and round(x.x) == 3'
     - name: Test Connection to Discord
+      if: ${{ !cancelled() && steps.build.outcome == 'success' }}
       run: |
-        docker compose run --build --rm \
+        docker compose run --rm \
           -e 'CONNECTION_TEST=true' \
           -e "DISCORD_TOKEN=$(cat .github/workflows/test-token.txt | base64 --decode)" \
           duckbot

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN python -m venv $VIRTUAL_ENV
 ENV PATH "$VIRTUAL_ENV/bin:$PATH"
 WORKDIR /pip-dependencies
 # install openblas for numpy (matplotlib dependency)
-RUN apt-get update && apt-get -y install \
+RUN apt-get update && apt-get -y install --no-install-recommends \
     libopenblas-dev \
   && apt-get clean && rm -rf /var/lib/apt/lists/*
 COPY scripts/ ./scripts
@@ -19,7 +19,7 @@ FROM python:3.13-slim AS prod
 # libopenblas-dev: matplotlib dependencies
 # fortune/cowsay: for !fortune command
 # graphviz: for /satisfy solution graph rendering
-RUN apt-get update && apt-get -y install \
+RUN apt-get update && apt-get -y install --no-install-recommends \
     ffmpeg \
     libpq-dev \
     libopenblas-dev \


### PR DESCRIPTION
##### Summary

Install apt packages with `--no-install-recommends` in both stages of the `Dockerfile`. This skips recommended-but-not-required packages, shrinking the prod image by ~204MB (2.11GB → 1.91GB) and resolving the SonarQube `docker:S6500` findings.

To make sure a recommended package the bot actually depends on isn't silently dropped, the `sanity` CI job now builds the image and runs a smoke test per OS/runtime dependency the bot shells out to or renders with. Each check is its own step (with `if: ${{ !cancelled() && steps.build.outcome == 'success' }}` so they all run independently and a failure names the culprit):

- `fortune`, `cowsay`, `ffmpeg` — binaries, plus the exact `!fortune` pipeline
- `graphviz` — renders the real `/satisfy` solution graph through `dot`
- `matplotlib` — renders a plot to PNG (Agg backend)
- `mip` — builds and solves a model, exercising the bundled CBC solver
- `import duckbot`

**Testing:** Built both variants locally and diffed sizes. Verified every check passes on the healthy image and exits nonzero when its dependency is broken (missing binary → 127, broken cowsay data dir → 2, missing `dot`/Python package → 1).

##### Checklist

- [ ] this is a source code change
  - [ ] run `format` in the repository root
  - [ ] run `pytest` in the repository root
  - [ ] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [ ] update the wiki documentation if necessary
- [x] or, this is **not** a source code change

🤖 Generated with [Claude Code](https://claude.com/claude-code)