### PR TITLE
:lock: pass --ignore-scripts to npm install of aws-cdk

### DIFF
--- a/.github/actions/setup-aws-cdk/action.yml
+++ b/.github/actions/setup-aws-cdk/action.yml
@@ -27,5 +27,5 @@ runs:
     shell: bash
     run: |
       . ${{ steps.venv.outputs.path }}/bin/activate
-      npm install -g aws-cdk
+      npm install -g --ignore-scripts aws-cdk
       cdk --version


### PR DESCRIPTION
##### Summary

Addresses [SonarCloud `githubactions:S6505`](https://sonarcloud.io/project/issues?issueStatuses=OPEN%2CCONFIRMED&id=duck-dynasty_duckbot&open=AZ-BaHFPonnAfBAYTIro) on `.github/actions/setup-aws-cdk/action.yml` — a global `npm install` without `--ignore-scripts` lets lifecycle scripts from any package in the dependency tree execute arbitrary code in CI.

`aws-cdk` ships a prebuilt bundle and its CLI is wired up through the package `bin` field, which npm links regardless of `--ignore-scripts`, so the following `cdk --version` still works. This is the only `npm install`/`npm ci` in the repo.

Tested by the CDK workflow running this composite action.

##### Checklist

- [ ] this is a source code change
  - [ ] run `format` in the repository root
  - [ ] run `pytest` in the repository root
  - [ ] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [ ] update the wiki documentation if necessary
- [x] or, this is **not** a source code change

🤖 Generated with [Claude Code](https://claude.com/claude-code)