### PR TITLE
:bug: poll twitch off the event loop, clear two sonar lint findings

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Run Linter
       run: |
         . ${{ steps.venv.outputs.path }}/bin/activate
-        flake8 duckbot tests scripts && mdformat --check duckbot tests wiki *.md
+        flake8 duckbot tests scripts && mdformat --check duckbot tests wiki ./*.md
 
   sanity:
     runs-on: ubuntu-latest

--- a/duckbot/cogs/audio/who_can_it_be_now.py
+++ b/duckbot/cogs/audio/who_can_it_be_now.py
@@ -54,7 +54,7 @@ class WhoCanItBeNow(commands.Cog):
             play_count += 1
             await asyncio.sleep(0)  # give up timeslice for `trigger_next_song`
             await self.stream.wait()
-        if self.streaming and not play_count < 75:
+        if self.streaming and play_count >= 75:
             await self.stop()
 
     def trigger_next_song(self, error=None):

--- a/duckbot/cogs/games/office_hours.py
+++ b/duckbot/cogs/games/office_hours.py
@@ -1,3 +1,5 @@
+import asyncio
+
 import requests
 from discord import ChannelType
 from discord.ext import commands, tasks
@@ -18,7 +20,8 @@ class OfficeHours(commands.Cog):
         await self.check_if_streaming()
 
     async def check_if_streaming(self):
-        page = requests.get("https://www.twitch.tv/conlabx", timeout=(3.05, 27)).text
+        response = await asyncio.to_thread(requests.get, "https://www.twitch.tv/conlabx", timeout=(3.05, 27))
+        page = response.text
         streaming = "isLiveBroadcast" in page
         if streaming != self.streaming:
             self.streaming = streaming


### PR DESCRIPTION
##### Summary

Triaged the 30 issues sitting in SonarCloud's _accepted_ (won't fix) bucket for `main` and picked off the three that were actually worth doing. The other 27 stay accepted — mostly discord.py idioms Sonar can't recognize (empty `hybrid_group` bodies, `list` duplicating the group's default invocation) and `random` used for picking memes.

- **`office_hours.py`** — the Twitch poll was a synchronous `requests.get` sitting directly inside `async def check_if_streaming`, on a `tasks.loop`. With a 27s read timeout, a slow response freezes the entire event loop: no commands, no events, and the gateway heartbeat can't run, which past ~10s gets discord.py complaining and eventually drops the connection. Wrapped in `asyncio.to_thread`. Usually this is a sub-second no-op, so it's tail-risk insurance rather than a fix for anything actively broken. (Sonar `python:S7499`, the only `BUG` in the list.)
- **`who_can_it_be_now.py`** — `not play_count < 75` -> `play_count >= 75`. (`python:S1940`)
- **`python-package.yml`** — prefix the `mdformat` glob with `./` so a filename can't parse as a flag. (`githubactions:S6573`)

Worth noting the `office_hours` fix isn't consistency work: eleven other `requests` call sites across `wordnik`, `recipe`, `pokemon`, `epic_games` and `dog_photos` block the loop exactly the same way. Sonar only flagged this one because it's lexically inside an `async def`. The others are user-triggered from commands rather than firing unattended 96x/day, so I left them; making the codebase properly async is an `aiohttp` migration that would take the shared `responses` test fixture with it.

Testing beyond unit tests: none needed for the two lint fixes. For `office_hours`, the four existing tests pass unmodified — `responses.RequestsMock` patches `HTTPAdapter.send` globally, so it still intercepts a request issued from the worker thread and records it in `.calls`. Verified that separately before making the change.

##### Checklist

- [x] this is a source code change
  - [x] run `format` in the repository root
  - [x] run `pytest` in the repository root
  - [ ] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [ ] update the wiki documentation if necessary
- [ ] or, this is **not** a source code change

🤖 Generated with [Claude Code](https://claude.com/claude-code)