### PR TITLE
:sparkles: track reactions given and received in friend facts

### DIFF
--- a/duckbot/cogs/messages/friend_facts.py
+++ b/duckbot/cogs/messages/friend_facts.py
@@ -25,6 +25,8 @@ class UserStats:
     weather: int = 0
     mentions: int = 0
     attachments: int = 0
+    reactions_given: int = 0
+    reactions_received: int = 0
 
 
 class FriendFacts(commands.Cog):
@@ -53,7 +55,8 @@ class FriendFacts(commands.Cog):
     @commands.command(name="friend-facts")
     @commands.guild_only()
     async def friend_facts(self, context):
-        await self.send_report(context.channel)
+        async with context.typing():
+            await self.send_report(context.channel)
 
     def prior_month_range(self):
         end = duckbot.util.datetime.now().replace(day=1, hour=0, minute=0, second=0, microsecond=0)
@@ -80,6 +83,7 @@ class FriendFacts(commands.Cog):
                         self.tally_slash_weather(stats, message)
                     else:
                         self.tally(stats, hours, days, message)
+                    await self.tally_reactions(stats, message)
                 channels += 1
             except Forbidden:
                 pass
@@ -120,6 +124,14 @@ class FriendFacts(commands.Cog):
         if interaction and interaction.name.split()[0] == "weather":
             stats.setdefault(interaction.user.id, UserStats()).weather += 1
 
+    async def tally_reactions(self, stats, message: Message):
+        for reaction in message.reactions:
+            async for user in reaction.users():
+                if not user.bot:
+                    stats.setdefault(user.id, UserStats()).reactions_given += 1
+                    if not message.author.bot:
+                        stats.setdefault(message.author.id, UserStats()).reactions_received += 1
+
     def mention_count(self, message: Message):
         mentioned = {user.id for user in message.mentions}
         replied = message.reference.resolved if message.reference else None
@@ -158,6 +170,8 @@ class FriendFacts(commands.Cog):
         lines += await self.count_award(guild, stats, "weather", ":white_sun_small_cloud: Weather Obsessed: {name} — {count} weather checks")
         lines += await self.count_award(guild, stats, "mentions", ":wave: Name Dropper: {name} — {count} people mentioned")
         lines += await self.count_award(guild, stats, "attachments", ":camera: Paparazzi: {name} — {count} attachments sent")
+        lines += await self.count_award(guild, stats, "reactions_given", ":clap: Serial Reactor: {name} — {count} reactions added")
+        lines += await self.count_award(guild, stats, "reactions_received", ":star: Crowd Pleaser: {name} — {count} reactions received")
         return lines
 
     async def count_award(self, guild, stats, attr, template):

--- a/duckbot/cogs/messages/friend_facts.py
+++ b/duckbot/cogs/messages/friend_facts.py
@@ -150,34 +150,37 @@ class FriendFacts(commands.Cog):
             lines.append(f"{(await self.display_name(guild, user_id))[:24]:<24} {user.messages:>8}")
         lines.append("```")
         lines.append(f":pencil: {sum(u.messages for u in stats.values()):,} messages across {channels} channels")
-        lines += await self.awards(guild, stats)
+        lines += self.awards(stats)
         lines.append(f":crescent_moon: Busiest hour: {self.hour_name(hours.index(max(hours)))} · Busiest day: {calendar.day_name[days.index(max(days))]}")
         return "\n".join(lines)
 
-    async def awards(self, guild, stats):
+    def awards(self, stats):
         lines = []
         regulars = {k: v for k, v in stats.items() if v.messages >= MIN_MESSAGES_FOR_AWARD}
         if regulars:
             user_id, user = max(regulars.items(), key=lambda x: x[1].capital_starts / x[1].messages)
-            lines.append(f":tophat: Grammar Police: {await self.display_name(guild, user_id)} — {100 * user.capital_starts // user.messages}% of messages start with a capital")
+            lines.append(f":tophat: Grammar Police: {self.mention(user_id)} — {100 * user.capital_starts // user.messages}% of messages start with a capital")
             user_id, user = max(regulars.items(), key=lambda x: x[1].words / x[1].messages)
-            lines.append(f":books: Wordiest: {await self.display_name(guild, user_id)} — {user.words / user.messages:.1f} words per message")
+            lines.append(f":books: Wordiest: {self.mention(user_id)} — {user.words / user.messages:.1f} words per message")
             user_id, user = max(regulars.items(), key=lambda x: x[1].questions / x[1].messages)
-            lines.append(f":question: Most Inquisitive: {await self.display_name(guild, user_id)} — {100 * user.questions // user.messages}% of messages are questions")
-        lines += await self.count_award(guild, stats, "shouts", ":loudspeaker: Loudest: {name} — {count} ALL-CAPS messages")
-        lines += await self.count_award(guild, stats, "links", ":link: Chief Link Dumper: {name} — {count} links shared")
-        lines += await self.count_award(guild, stats, "golf", ":golf: Golf Fanatic: {name} — {count} golf mentions")
-        lines += await self.count_award(guild, stats, "weather", ":white_sun_small_cloud: Weather Obsessed: {name} — {count} weather checks")
-        lines += await self.count_award(guild, stats, "mentions", ":wave: Name Dropper: {name} — {count} people mentioned")
-        lines += await self.count_award(guild, stats, "attachments", ":camera: Paparazzi: {name} — {count} attachments sent")
-        lines += await self.count_award(guild, stats, "reactions_given", ":clap: Serial Reactor: {name} — {count} reactions added")
-        lines += await self.count_award(guild, stats, "reactions_received", ":star: Crowd Pleaser: {name} — {count} reactions received")
+            lines.append(f":question: Most Inquisitive: {self.mention(user_id)} — {100 * user.questions // user.messages}% of messages are questions")
+        lines += self.count_award(stats, "shouts", ":loudspeaker: Loudest: {name} — {count} ALL-CAPS messages")
+        lines += self.count_award(stats, "links", ":link: Chief Link Dumper: {name} — {count} links shared")
+        lines += self.count_award(stats, "golf", ":golf: Golf Fanatic: {name} — {count} golf mentions")
+        lines += self.count_award(stats, "weather", ":white_sun_small_cloud: Weather Obsessed: {name} — {count} weather checks")
+        lines += self.count_award(stats, "mentions", ":wave: Name Dropper: {name} — {count} people mentioned")
+        lines += self.count_award(stats, "attachments", ":camera: Paparazzi: {name} — {count} attachments sent")
+        lines += self.count_award(stats, "reactions_given", ":clap: Serial Reactor: {name} — {count} reactions added")
+        lines += self.count_award(stats, "reactions_received", ":star: Crowd Pleaser: {name} — {count} reactions received")
         return lines
 
-    async def count_award(self, guild, stats, attr, template):
+    def count_award(self, stats, attr, template):
         user_id, user = max(stats.items(), key=lambda x: getattr(x[1], attr))
         count = getattr(user, attr)
-        return [template.format(name=await self.display_name(guild, user_id), count=count)] if count else []
+        return [template.format(name=self.mention(user_id), count=count)] if count else []
+
+    def mention(self, user_id):
+        return f"<@{user_id}>"
 
     async def display_name(self, guild, user_id):
         user = await get_user(self.bot, user_id, guild)

--- a/tests/cogs/messages/friend_facts_test.py
+++ b/tests/cogs/messages/friend_facts_test.py
@@ -17,7 +17,7 @@ def clazz(bot) -> FriendFacts:
     return bind_commands(FriendFacts(bot))
 
 
-def make_message(content="hi", author_id=1, is_bot=False, created_at=datetime.datetime(2026, 6, 15, 18, 30, tzinfo=datetime.timezone.utc), mentions=[], reference=None, attachments=[]):
+def make_message(content="hi", author_id=1, is_bot=False, created_at=datetime.datetime(2026, 6, 15, 18, 30, tzinfo=datetime.timezone.utc), mentions=[], reference=None, attachments=[], reactions=[]):
     message = mock.Mock()
     message.author.id = author_id
     message.author.bot = is_bot
@@ -27,13 +27,21 @@ def make_message(content="hi", author_id=1, is_bot=False, created_at=datetime.da
     message.reference = reference
     message.interaction = None
     message.attachments = attachments
+    message.reactions = reactions
     return message
 
 
-def make_user(user_id):
+def make_user(user_id, is_bot=False):
     user = mock.Mock()
     user.id = user_id
+    user.bot = is_bot
     return user
+
+
+def make_reaction(*users):
+    reaction = mock.Mock()
+    reaction.users.return_value = list_as_async_generator(list(users))
+    return reaction
 
 
 def make_reply_to(author_id):
@@ -223,6 +231,34 @@ def test_tally_mentions_excludes_self_and_deleted_replies(clazz):
     assert stats[1].mentions == 0
 
 
+async def test_tally_reactions_credits_giver_and_receiver(clazz):
+    stats = {}
+    message = make_message(author_id=1, reactions=[make_reaction(make_user(2), make_user(3)), make_reaction(make_user(2))])
+    await clazz.tally_reactions(stats, message)
+    assert stats[1] == UserStats(reactions_received=3)
+    assert stats[2] == UserStats(reactions_given=2)
+    assert stats[3] == UserStats(reactions_given=1)
+
+
+async def test_tally_reactions_ignores_bot_reactors(clazz):
+    stats = {}
+    await clazz.tally_reactions(stats, make_message(author_id=1, reactions=[make_reaction(make_user(2, is_bot=True))]))
+    assert stats == {}
+
+
+async def test_tally_reactions_on_bot_messages_credits_only_the_giver(clazz):
+    stats = {}
+    await clazz.tally_reactions(stats, make_message(author_id=1, is_bot=True, reactions=[make_reaction(make_user(2))]))
+    assert stats == {2: UserStats(reactions_given=1)}
+
+
+async def test_gather_stats_counts_reactions(clazz, guild, text_channel):
+    guild.text_channels = [readable(text_channel, [make_message("hello", author_id=1, reactions=[make_reaction(make_user(2))])])]
+    stats, _, _, _ = await clazz.gather_stats(guild, None, None)
+    assert stats[1] == UserStats(messages=1, words=1, reactions_received=1)
+    assert stats[2] == UserStats(reactions_given=1)
+
+
 def test_tally_buckets_hours_and_days_in_eastern_time(clazz):
     stats, hours, days = {}, [0] * 24, [0] * 7
     clazz.tally(stats, hours, days, make_message(created_at=datetime.datetime(2026, 6, 15, 18, 30, tzinfo=datetime.timezone.utc)))  # 2:30pm EDT, a Monday
@@ -240,8 +276,8 @@ async def test_format_report_empty_month(get_user, clazz, guild):
 async def test_format_report_leaderboard_and_awards(get_user, clazz, guild):
     get_user.side_effect = lambda bot, user_id, guild: mock.Mock(display_name=f"user{user_id}")
     stats = {
-        1: UserStats(messages=50, words=100, capital_starts=40, questions=5, shouts=3, links=7, golf=12, attachments=33),
-        2: UserStats(messages=30, words=300, capital_starts=6, questions=15, weather=9, mentions=21),
+        1: UserStats(messages=50, words=100, capital_starts=40, questions=5, shouts=3, links=7, golf=12, attachments=33, reactions_received=64),
+        2: UserStats(messages=30, words=300, capital_starts=6, questions=15, weather=9, mentions=21, reactions_given=17),
     }
     hours = [0] * 24
     hours[23] = 42
@@ -260,6 +296,8 @@ async def test_format_report_leaderboard_and_awards(get_user, clazz, guild):
     assert "Weather Obsessed: user2 — 9 weather checks" in report
     assert "Name Dropper: user2 — 21 people mentioned" in report
     assert "Paparazzi: user1 — 33 attachments sent" in report
+    assert "Serial Reactor: user2 — 17 reactions added" in report
+    assert "Crowd Pleaser: user1 — 64 reactions received" in report
     assert "Busiest hour: 11pm · Busiest day: Saturday" in report
 
 
@@ -301,6 +339,8 @@ async def test_format_report_no_awards_for_zero_counts(get_user, clazz, guild):
     assert "Weather Obsessed" not in report
     assert "Name Dropper" not in report
     assert "Paparazzi" not in report
+    assert "Serial Reactor" not in report
+    assert "Crowd Pleaser" not in report
 
 
 @mock.patch("duckbot.cogs.messages.friend_facts.get_user", return_value=None)

--- a/tests/cogs/messages/friend_facts_test.py
+++ b/tests/cogs/messages/friend_facts_test.py
@@ -287,17 +287,17 @@ async def test_format_report_leaderboard_and_awards(get_user, clazz, guild):
     assert "**Friend Facts: June 2026**" in report
     assert report.index("user1 ") < report.index("user2 ")
     assert ":pencil: 80 messages across 4 channels" in report
-    assert "Grammar Police: user1 — 80% of messages start with a capital" in report
-    assert "Wordiest: user2 — 10.0 words per message" in report
-    assert "Most Inquisitive: user2 — 50% of messages are questions" in report
-    assert "Loudest: user1 — 3 ALL-CAPS messages" in report
-    assert "Chief Link Dumper: user1 — 7 links shared" in report
-    assert "Golf Fanatic: user1 — 12 golf mentions" in report
-    assert "Weather Obsessed: user2 — 9 weather checks" in report
-    assert "Name Dropper: user2 — 21 people mentioned" in report
-    assert "Paparazzi: user1 — 33 attachments sent" in report
-    assert "Serial Reactor: user2 — 17 reactions added" in report
-    assert "Crowd Pleaser: user1 — 64 reactions received" in report
+    assert "Grammar Police: <@1> — 80% of messages start with a capital" in report
+    assert "Wordiest: <@2> — 10.0 words per message" in report
+    assert "Most Inquisitive: <@2> — 50% of messages are questions" in report
+    assert "Loudest: <@1> — 3 ALL-CAPS messages" in report
+    assert "Chief Link Dumper: <@1> — 7 links shared" in report
+    assert "Golf Fanatic: <@1> — 12 golf mentions" in report
+    assert "Weather Obsessed: <@2> — 9 weather checks" in report
+    assert "Name Dropper: <@2> — 21 people mentioned" in report
+    assert "Paparazzi: <@1> — 33 attachments sent" in report
+    assert "Serial Reactor: <@2> — 17 reactions added" in report
+    assert "Crowd Pleaser: <@1> — 64 reactions received" in report
     assert "Busiest hour: 11pm · Busiest day: Saturday" in report
 
 
@@ -323,9 +323,9 @@ async def test_format_report_awards_require_minimum_messages(get_user, clazz, gu
     get_user.side_effect = lambda bot, user_id, guild: mock.Mock(display_name=f"user{user_id}")
     stats = {1: UserStats(messages=1, words=50, capital_starts=1, questions=1), 2: UserStats(messages=25, words=25, capital_starts=5, questions=5)}
     report = await clazz.format_report(guild, stats, [0] * 24, [0] * 7, 1, datetime.datetime(2026, 6, 1))
-    assert "Grammar Police: user2" in report
-    assert "Wordiest: user2" in report
-    assert "Most Inquisitive: user2" in report
+    assert "Grammar Police: <@2>" in report
+    assert "Wordiest: <@2>" in report
+    assert "Most Inquisitive: <@2>" in report
 
 
 @mock.patch("duckbot.cogs.messages.friend_facts.get_user")

--- a/wiki/Commands.md
+++ b/wiki/Commands.md
@@ -43,7 +43,7 @@ DuckBot can define words, sourcing data from [Wordnik](https://www.wordnik.com/)
 
 ## Friend Facts
 
-On the first of each month, DuckBot posts a stats report to the general channel covering the prior month's messages: a message-count leaderboard plus awards like Grammar Police (% of messages starting with a capital), Wordiest, Most Inquisitive, Loudest, Chief Link Dumper, Golf Fanatic, Weather Obsessed, Name Dropper, and Paparazzi, along with the busiest hour and day. Percentage awards require at least 25 messages. You can run the report on demand with `!friend-facts`.
+On the first of each month, DuckBot posts a stats report to the general channel covering the prior month's messages: a message-count leaderboard plus awards like Grammar Police (% of messages starting with a capital), Wordiest, Most Inquisitive, Loudest, Chief Link Dumper, Golf Fanatic, Weather Obsessed, Name Dropper, Paparazzi, Serial Reactor (most reactions added), and Crowd Pleaser (most reactions received), along with the busiest hour and day. Percentage awards require at least 25 messages. You can run the report on demand with `!friend-facts`.
 
 ## Recipe Search
 

--- a/wiki/Events.md
+++ b/wiki/Events.md
@@ -96,7 +96,7 @@ Every day in the 7am hour, DuckBot will announce to the general channel the curr
 
 ## Friend Facts
 
-On the first of each month, DuckBot posts a stats report to the general channel covering the prior month's messages: a message-count leaderboard plus awards like Grammar Police (% of messages starting with a capital), Wordiest, Most Inquisitive, Loudest, Chief Link Dumper, Golf Fanatic, Weather Obsessed, Name Dropper, and Paparazzi, along with the busiest hour and day. You can run this on demand using the `!friend-facts` command.
+On the first of each month, DuckBot posts a stats report to the general channel covering the prior month's messages: a message-count leaderboard plus awards like Grammar Police (% of messages starting with a capital), Wordiest, Most Inquisitive, Loudest, Chief Link Dumper, Golf Fanatic, Weather Obsessed, Name Dropper, Paparazzi, Serial Reactor (most reactions added), and Crowd Pleaser (most reactions received), along with the busiest hour and day. You can run this on demand using the `!friend-facts` command.
 
 ## Epic Free Games
 


### PR DESCRIPTION
##### Summary

Adds two awards to the monthly Friend Facts report — _Serial Reactor_ (most reactions added) and _Crowd Pleaser_ (most reactions received) — fixes #1418.

Reaction senders aren't in the message history payload, so `tally_reactions` pages `reaction.users()` during the existing month sweep. No new tables, listeners, or migrations, and it works retroactively on the first run. The cost is one extra REST call per distinct emoji, which makes the report slower — hence the `context.typing()` the command was missing.

Both counters come from the same `users()` loop rather than `Reaction.count`, which keeps them consistent with each other: `count` is per-emoji and includes super/burst reactions, while `users()` yields only normal reactors unless called again with `type=ReactionType.burst`. Super-reactions are ignored on both sides instead of doubling the requests. Bot reactors are skipped, and reactions on bot messages credit the giver with nobody receiving.

Award winners are now pinged with `<@id>` instead of printing their display name. The leaderboard still uses display names — it's inside a code block, where mentions don't resolve. Dropping `display_name` from the award path also made `awards`/`count_award` synchronous.

Note that this means the monthly report pings each winner. If that's noisy, passing `allowed_mentions=discord.AllowedMentions.none()` to the `channel.send` in `send_report` renders them as names without notifying.

Testing: unit tests only.

##### Checklist

- [x] this is a source code change
  - [x] run `format` in the repository root
  - [x] run `pytest` in the repository root
  - [x] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [x] update the wiki documentation if necessary
- [ ] or, this is **not** a source code change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

