### PR TITLE
:bug: show both sides of a mixed position in the market resolve summary

### DIFF
--- a/duckbot/cogs/playmarket/market.py
+++ b/duckbot/cogs/playmarket/market.py
@@ -413,13 +413,14 @@ class PlayMarket(commands.Cog):
         for user_id, yes_shares, no_shares, invested, payout in sorted(results, key=lambda r: r[3] + r[4], reverse=True):
             name = await self._name(context, user_id)
             net = payout + invested
-            side = "YES" if yes_shares >= no_shares else "NO"
+            held = " / ".join(f"{_coins(shares)} {side}" for side, shares in (("YES", yes_shares), ("NO", no_shares)) if shares)
+            line = f"{name} — {held}, staked {_coins(-invested)}"
             if net > 0:
-                lines.append(f"{name} — {_coins(-invested)} on {side}, won {_coins(payout)} (+{_coins(net)})")
+                lines.append(f"{line}, won {_coins(payout)} (+{_coins(net)})")
             elif net < 0:
-                lines.append(f"{name} — {_coins(-invested)} on {side}, lost {_coins(-net)}")
+                lines.append(f"{line}, lost {_coins(-net)}")
             else:
-                lines.append(f"{name} — {_coins(-invested)} on {side}, refunded")
+                lines.append(f"{line}, refunded")
         if lines:
             embed.add_field(name="Results", value="\n".join(lines), inline=False)
         return embed

--- a/tests/cogs/playmarket/market_test.py
+++ b/tests/cogs/playmarket/market_test.py
@@ -428,8 +428,18 @@ async def test_resolve_embed_shows_winners_and_losers(cog, alice, bob, carol, in
     await cog.bet(carol, market_id, "no", BET)
     await cog.resolve(alice, market_id, "yes")
     expected = Embed(title=f"Market {market_id} — Will it happen?", description="Called **YES**.", color=Color.green())
-    expected.add_field(name="Results", value="user2 — 500 on YES, won 831 (+331)\nuser3 — 500 on NO, lost 500", inline=False)
+    expected.add_field(name="Results", value="user2 — 832 YES, staked 500, won 831 (+331)\nuser3 — 1,144 NO, staked 500, lost 500", inline=False)
     alice.send.assert_called_with("<@2> <@3>", embed=expected)
+
+
+async def test_resolve_embed_shows_both_sides_when_one_player_holds_both(cog, alice, bob, in_memory_db):
+    market_id = await open_market(cog, alice)
+    await cog.bet(bob, market_id, "yes", BET)
+    await cog.bet(bob, market_id, "no", BET)
+    await cog.resolve(alice, market_id, "no")
+    expected = Embed(title=f"Market {market_id} — Will it happen?", description="Called **NO**.", color=Color.red())
+    expected.add_field(name="Results", value="user2 — 832 YES / 1,144 NO, staked 1,000, won 1,143 (+143)", inline=False)
+    alice.send.assert_called_with("<@2>", embed=expected)
 
 
 async def test_a_non_creator_non_admin_cannot_resolve(cog, alice, bob, in_memory_db):
@@ -489,7 +499,7 @@ async def test_resolve_embed_shows_void_refunds(cog, alice, bob, in_memory_db):
     await cog.bet(bob, market_id, "yes", 300)
     await cog.resolve(alice, market_id, "void")
     expected = Embed(title=f"Market {market_id} — Will it happen?", description="Called **VOID**.", color=Color.greyple())
-    expected.add_field(name="Results", value="user2 — 300 on YES, refunded", inline=False)
+    expected.add_field(name="Results", value="user2 — 530 YES, staked 300, refunded", inline=False)
     alice.send.assert_called_with("<@2>", embed=expected)
 
 


### PR DESCRIPTION
##### Summary

Fixes #1443.

When someone held shares on *both* sides of a market, `/market resolve` collapsed their position to a single side — `side = "YES" if yes_shares >= no_shares else "NO"` — so the whole stake was attributed to one side and the other side's shares vanished from the summary:

```
Taras — 950 on NO, won 1,104 (+154)      # resolve
Taras — 3,948 YES / 1,104 NO             # holders, same market
```

The money was never wrong — `_invested` already nets bets and sells across both sides — only the line describing it. Results lines now name the shares actually held, dropping a side with none, with the stake as its own clause:

```
user2 — 832 YES, staked 500, won 831 (+331)
user2 — 832 YES / 1,144 NO, staked 1,000, won 1,143 (+143)
user3 — 1,144 NO, staked 500, lost 500
user2 — 530 YES, staked 300, refunded
```

Tested with the existing exact-embed tests plus a new one for the mixed case, which fails on the old code (it rendered `1,000 on NO`). No payout, ledger, or schema change.

##### Checklist

- [x] this is a source code change
  - [x] run `format` in the repository root
  - [x] run `pytest` in the repository root
  - [x] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [x] update the wiki documentation if necessary — the wiki documents the mechanics, not the embed layout, so nothing to change
- [ ] or, this is **not** a source code change

🤖 Generated with [Claude Code](https://claude.com/claude-code)