### PR TITLE
:wastebasket: replace deprecated message.interaction with message.interaction_metadata

### DIFF
--- a/duckbot/cogs/messages/friend_facts.py
+++ b/duckbot/cogs/messages/friend_facts.py
@@ -7,6 +7,7 @@ from discord.ext import commands, tasks
 from discord.utils import get
 
 import duckbot.util.datetime
+from duckbot.cogs.weather.weather import CHART_FILE
 from duckbot.util.users import get_user
 
 LEADERBOARD_SIZE = 10
@@ -119,9 +120,9 @@ class FriendFacts(commands.Cog):
         days[created.weekday()] += 1
 
     def tally_slash_weather(self, stats, message: Message):
-        """Slash invocations show up as bot messages; credit /weather to the invoker."""
-        interaction = message.interaction
-        if interaction and interaction.name.split()[0] == "weather":
+        """Slash replies only name the invoker; the chart attachment identifies /weather."""
+        interaction = message.interaction_metadata
+        if interaction and any(a.filename == CHART_FILE for a in message.attachments):
             stats.setdefault(interaction.user.id, UserStats()).weather += 1
 
     async def tally_reactions(self, stats, message: Message):

--- a/duckbot/cogs/messages/friend_facts.py
+++ b/duckbot/cogs/messages/friend_facts.py
@@ -7,7 +7,7 @@ from discord.ext import commands, tasks
 from discord.utils import get
 
 import duckbot.util.datetime
-from duckbot.cogs.weather.weather import CHART_FILE
+from duckbot.cogs.weather import CHART_FILE
 from duckbot.util.users import get_user
 
 LEADERBOARD_SIZE = 10

--- a/duckbot/cogs/weather/__init__.py
+++ b/duckbot/cogs/weather/__init__.py
@@ -1,4 +1,4 @@
-from .weather import Weather
+from .weather import CHART_FILE, Weather
 
 
 async def setup(bot):

--- a/duckbot/cogs/weather/weather.py
+++ b/duckbot/cogs/weather/weather.py
@@ -19,6 +19,7 @@ from duckbot.db import Database
 from .saved_location import SavedLocation
 
 degrees = "\N{DEGREE SIGN}C"
+CHART_FILE = "weather.png"
 
 
 class Weather(commands.Cog):
@@ -182,6 +183,6 @@ class Weather(commands.Cog):
         left_axis.set_xlim(min(hours) - one_hour, max(hours) + one_hour)
         plt.setp(left_axis.get_xticklabels(), rotation=30, horizontalalignment="right")
         figure.tight_layout()
-        plt.savefig("weather.png", facecolor="ghostwhite")
+        plt.savefig(CHART_FILE, facecolor="ghostwhite")
         plt.close(figure)
-        return "weather.png"
+        return CHART_FILE

--- a/tests/cogs/messages/friend_facts_test.py
+++ b/tests/cogs/messages/friend_facts_test.py
@@ -25,7 +25,7 @@ def make_message(content="hi", author_id=1, is_bot=False, created_at=datetime.da
     message.created_at = created_at
     message.mentions = mentions
     message.reference = reference
-    message.interaction = None
+    message.interaction_metadata = None
     message.attachments = attachments
     message.reactions = reactions
     return message
@@ -36,6 +36,12 @@ def make_user(user_id, is_bot=False):
     user.id = user_id
     user.bot = is_bot
     return user
+
+
+def make_attachment(filename):
+    attachment = mock.Mock()
+    attachment.filename = filename
+    return attachment
 
 
 def make_reaction(*users):
@@ -128,13 +134,11 @@ async def test_gather_stats_skips_bot_messages(clazz, guild, text_channel):
 
 
 async def test_gather_stats_credits_slash_weather_to_invoker(clazz, guild, text_channel):
-    invocation = make_message(is_bot=True)
-    invocation.interaction = mock.Mock()
-    invocation.interaction.name = "weather get"
-    invocation.interaction.user.id = 5
-    other = make_message(is_bot=True)
-    other.interaction = mock.Mock()
-    other.interaction.name = "market bet"
+    invocation = make_message(is_bot=True, attachments=[make_attachment("weather.png")])
+    invocation.interaction_metadata = mock.Mock()
+    invocation.interaction_metadata.user.id = 5
+    other = make_message(is_bot=True, attachments=[make_attachment("cat.png")])
+    other.interaction_metadata = mock.Mock()
     guild.text_channels = [readable(text_channel, [invocation, other])]
     stats, _, _, _ = await clazz.gather_stats(guild, None, None)
     assert stats == {5: UserStats(weather=1)}


### PR DESCRIPTION
##### Summary

`Message.interaction` is deprecated since discord.py 2.4 and will be removed; reading it emits a `DeprecationWarning` (and discord.py's `deprecated` decorator resets the global warning filter as a side effect). Friend Facts was the only place using it, to credit `/weather` slash invocations to the invoker for the Weather Obsessed award.

Not a drop-in rename: `MessageInteractionMetadata` has no `name` attribute — Discord dropped the command name from the new payload — so `interaction.name.split()[0] == "weather"` can't be ported. Instead the weather reply is recognised by its chart attachment, extracted to a `CHART_FILE` constant in the weather cog so the two ends stay in sync. `interaction_metadata.user` still gives the invoker.

Side effect: only a successful `/weather get` counts now. `/weather set` and error replies no longer credit the invoker, which is arguably truer to a "weather checks" award. The `!weather` prefix path is untouched.

Testing: unit tests only.

fixes #1435

##### Checklist

- [x] this is a source code change
  - [x] run `format` in the repository root
  - [x] run `pytest` in the repository root
  - [x] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [x] update the wiki documentation if necessary
- [ ] or, this is **not** a source code change

🤖 Generated with [Claude Code](https://claude.com/claude-code)