### PR TITLE
:bar_chart: Count channels and threads separately in friend facts

### DIFF
--- a/duckbot/cogs/messages/friend_facts.py
+++ b/duckbot/cogs/messages/friend_facts.py
@@ -65,8 +65,8 @@ class FriendFacts(commands.Cog):
 
     async def send_report(self, channel):
         start, end = self.prior_month_range()
-        stats, hours, days, channels = await self.gather_stats(channel.guild, start, end)
-        await channel.send(await self.format_report(channel.guild, stats, hours, days, channels, start))
+        stats, hours, days, channels, threads = await self.gather_stats(channel.guild, start, end)
+        await channel.send(await self.format_report(channel.guild, stats, hours, days, channels, threads, start))
 
     async def gather_stats(self, guild, start, end):
         """Streams message history into counters; messages are never kept in memory."""
@@ -74,6 +74,7 @@ class FriendFacts(commands.Cog):
         hours = [0] * 24
         days = [0] * 7
         channels = 0
+        threads = 0
         async for channel in self.channels_to_scan(guild):
             if not channel.permissions_for(guild.me).read_message_history:
                 continue
@@ -84,10 +85,13 @@ class FriendFacts(commands.Cog):
                     else:
                         self.tally(stats, hours, days, message)
                     await self.tally_reactions(stats, message)
-                channels += 1
+                if channel.type is ChannelType.text:
+                    channels += 1
+                else:
+                    threads += 1
             except Forbidden:
                 pass
-        return stats, hours, days, channels
+        return stats, hours, days, channels, threads
 
     async def channels_to_scan(self, guild):
         """Text channels plus their active and archived threads."""
@@ -140,7 +144,7 @@ class FriendFacts(commands.Cog):
         mentioned.discard(message.author.id)
         return len(mentioned)
 
-    async def format_report(self, guild, stats, hours, days, channels, start):
+    async def format_report(self, guild, stats, hours, days, channels, threads, start):
         header = f"**Friend Facts: {start:%B %Y}** :bar_chart:"
         if not stats:
             return f"{header}\nNobody said anything last month. :duck:"
@@ -149,7 +153,7 @@ class FriendFacts(commands.Cog):
         for user_id, user in top[:LEADERBOARD_SIZE]:
             lines.append(f"{(await self.display_name(guild, user_id))[:24]:<24} {user.messages:>8}")
         lines.append("```")
-        lines.append(f":pencil: {sum(u.messages for u in stats.values()):,} messages across {channels} channels")
+        lines.append(f":pencil: {sum(u.messages for u in stats.values()):,} messages across {channels} channels and {threads} threads")
         lines += self.awards(stats)
         lines.append(f":crescent_moon: Busiest hour: {self.hour_name(hours.index(max(hours)))} · Busiest day: {calendar.day_name[days.index(max(days))]}")
         return "\n".join(lines)

--- a/tests/cogs/messages/friend_facts_test.py
+++ b/tests/cogs/messages/friend_facts_test.py
@@ -114,16 +114,16 @@ def test_prior_month_range(now, clazz, today, expected_start, expected_end):
 
 async def test_gather_stats_streams_counters(clazz, guild, text_channel):
     guild.text_channels = [readable(text_channel, [make_message("Hello there friend"), make_message("are you ok?", author_id=2)])]
-    stats, hours, days, channels = await clazz.gather_stats(guild, None, None)
+    stats, hours, days, channels, threads = await clazz.gather_stats(guild, None, None)
     assert stats[1] == UserStats(messages=1, words=3, capital_starts=1)
     assert stats[2] == UserStats(messages=1, words=3, questions=1)
     assert sum(hours) == 2 and sum(days) == 2
-    assert channels == 1
+    assert channels == 1 and threads == 0
 
 
 async def test_gather_stats_skips_bot_messages(clazz, guild, text_channel):
     guild.text_channels = [readable(text_channel, [make_message(is_bot=True)])]
-    stats, _, _, _ = await clazz.gather_stats(guild, None, None)
+    stats, _, _, _, _ = await clazz.gather_stats(guild, None, None)
     assert stats == {}
 
 
@@ -136,15 +136,15 @@ async def test_gather_stats_credits_slash_weather_to_invoker(clazz, guild, text_
     other.interaction = mock.Mock()
     other.interaction.name = "market bet"
     guild.text_channels = [readable(text_channel, [invocation, other])]
-    stats, _, _, _ = await clazz.gather_stats(guild, None, None)
+    stats, _, _, _, _ = await clazz.gather_stats(guild, None, None)
     assert stats == {5: UserStats(weather=1)}
 
 
 async def test_gather_stats_skips_unreadable_channels(clazz, guild, text_channel):
     text_channel.permissions_for.return_value.read_message_history = False
     guild.text_channels = [text_channel]
-    stats, _, _, channels = await clazz.gather_stats(guild, None, None)
-    assert stats == {} and channels == 0
+    stats, _, _, channels, threads = await clazz.gather_stats(guild, None, None)
+    assert stats == {} and channels == 0 and threads == 0
     text_channel.history.assert_not_called()
 
 
@@ -152,8 +152,8 @@ async def test_gather_stats_skips_forbidden_channels(clazz, guild, text_channel)
     text_channel.permissions_for.return_value.read_message_history = True
     text_channel.history.side_effect = Forbidden(mock.Mock(status=403), "no")
     guild.text_channels = [text_channel]
-    stats, _, _, channels = await clazz.gather_stats(guild, None, None)
-    assert stats == {} and channels == 0
+    stats, _, _, channels, threads = await clazz.gather_stats(guild, None, None)
+    assert stats == {} and channels == 0 and threads == 0
 
 
 async def test_gather_stats_scans_active_and_archived_threads(clazz, guild, text_channel, thread):
@@ -162,15 +162,16 @@ async def test_gather_stats_scans_active_and_archived_threads(clazz, guild, text
     text_channel.threads = [active_thread]
 
     archived_thread = readable(mock.Mock(spec=discord.Thread), [make_message("from an archived thread", author_id=3)])
+    archived_thread.type = discord.ChannelType.public_thread
     text_channel.archived_threads.return_value = list_as_async_generator([archived_thread])
 
     text_channel.history.return_value = list_as_async_generator([make_message("in the channel itself")])
     text_channel.permissions_for.return_value.read_message_history = True
     guild.text_channels = [text_channel]
 
-    stats, _, _, channels = await clazz.gather_stats(guild, None, None)
+    stats, _, _, channels, threads = await clazz.gather_stats(guild, None, None)
     assert stats.keys() == {1, 2, 3}
-    assert channels == 3
+    assert channels == 1 and threads == 2
 
 
 async def test_gather_stats_skips_forbidden_archived_threads(clazz, guild, text_channel):
@@ -179,8 +180,8 @@ async def test_gather_stats_skips_forbidden_archived_threads(clazz, guild, text_
     text_channel.threads = []
     text_channel.archived_threads.side_effect = Forbidden(mock.Mock(status=403), "no")
     guild.text_channels = [text_channel]
-    stats, _, _, channels = await clazz.gather_stats(guild, None, None)
-    assert stats == {} and channels == 1
+    stats, _, _, channels, threads = await clazz.gather_stats(guild, None, None)
+    assert stats == {} and channels == 1 and threads == 0
 
 
 def test_tally_counts_each_stat(clazz):
@@ -254,7 +255,7 @@ async def test_tally_reactions_on_bot_messages_credits_only_the_giver(clazz):
 
 async def test_gather_stats_counts_reactions(clazz, guild, text_channel):
     guild.text_channels = [readable(text_channel, [make_message("hello", author_id=1, reactions=[make_reaction(make_user(2))])])]
-    stats, _, _, _ = await clazz.gather_stats(guild, None, None)
+    stats, _, _, _, _ = await clazz.gather_stats(guild, None, None)
     assert stats[1] == UserStats(messages=1, words=1, reactions_received=1)
     assert stats[2] == UserStats(reactions_given=1)
 
@@ -268,7 +269,7 @@ def test_tally_buckets_hours_and_days_in_eastern_time(clazz):
 
 @mock.patch("duckbot.cogs.messages.friend_facts.get_user")
 async def test_format_report_empty_month(get_user, clazz, guild):
-    report = await clazz.format_report(guild, {}, [0] * 24, [0] * 7, 0, datetime.datetime(2026, 6, 1))
+    report = await clazz.format_report(guild, {}, [0] * 24, [0] * 7, 0, 0, datetime.datetime(2026, 6, 1))
     assert report == "**Friend Facts: June 2026** :bar_chart:\nNobody said anything last month. :duck:"
 
 
@@ -283,10 +284,10 @@ async def test_format_report_leaderboard_and_awards(get_user, clazz, guild):
     hours[23] = 42
     days = [0] * 7
     days[5] = 42
-    report = await clazz.format_report(guild, stats, hours, days, 4, datetime.datetime(2026, 6, 1))
+    report = await clazz.format_report(guild, stats, hours, days, 4, 2, datetime.datetime(2026, 6, 1))
     assert "**Friend Facts: June 2026**" in report
     assert report.index("user1 ") < report.index("user2 ")
-    assert ":pencil: 80 messages across 4 channels" in report
+    assert ":pencil: 80 messages across 4 channels and 2 threads" in report
     assert "Grammar Police: <@1> — 80% of messages start with a capital" in report
     assert "Wordiest: <@2> — 10.0 words per message" in report
     assert "Most Inquisitive: <@2> — 50% of messages are questions" in report
@@ -305,7 +306,7 @@ async def test_format_report_leaderboard_and_awards(get_user, clazz, guild):
 async def test_format_report_truncates_leaderboard_to_top_ten(get_user, clazz, guild):
     get_user.side_effect = lambda bot, user_id, guild: mock.Mock(display_name=f"user{user_id}")
     stats = {i: UserStats(messages=100 - i) for i in range(1, 12)}
-    report = await clazz.format_report(guild, stats, [0] * 24, [0] * 7, 1, datetime.datetime(2026, 6, 1))
+    report = await clazz.format_report(guild, stats, [0] * 24, [0] * 7, 1, 0, datetime.datetime(2026, 6, 1))
     assert "user10 " in report
     assert "user11 " not in report
 
@@ -313,7 +314,7 @@ async def test_format_report_truncates_leaderboard_to_top_ten(get_user, clazz, g
 @mock.patch("duckbot.cogs.messages.friend_facts.get_user")
 async def test_format_report_truncates_long_names_in_leaderboard(get_user, clazz, guild):
     get_user.side_effect = lambda bot, user_id, guild: mock.Mock(display_name="a" * 32)
-    report = await clazz.format_report(guild, {1: UserStats(messages=5)}, [0] * 24, [0] * 7, 1, datetime.datetime(2026, 6, 1))
+    report = await clazz.format_report(guild, {1: UserStats(messages=5)}, [0] * 24, [0] * 7, 1, 0, datetime.datetime(2026, 6, 1))
     assert "a" * 24 + " " in report
     assert "a" * 25 not in report
 
@@ -322,7 +323,7 @@ async def test_format_report_truncates_long_names_in_leaderboard(get_user, clazz
 async def test_format_report_awards_require_minimum_messages(get_user, clazz, guild):
     get_user.side_effect = lambda bot, user_id, guild: mock.Mock(display_name=f"user{user_id}")
     stats = {1: UserStats(messages=1, words=50, capital_starts=1, questions=1), 2: UserStats(messages=25, words=25, capital_starts=5, questions=5)}
-    report = await clazz.format_report(guild, stats, [0] * 24, [0] * 7, 1, datetime.datetime(2026, 6, 1))
+    report = await clazz.format_report(guild, stats, [0] * 24, [0] * 7, 1, 0, datetime.datetime(2026, 6, 1))
     assert "Grammar Police: <@2>" in report
     assert "Wordiest: <@2>" in report
     assert "Most Inquisitive: <@2>" in report
@@ -332,7 +333,7 @@ async def test_format_report_awards_require_minimum_messages(get_user, clazz, gu
 async def test_format_report_no_awards_for_zero_counts(get_user, clazz, guild):
     get_user.side_effect = lambda bot, user_id, guild: mock.Mock(display_name=f"user{user_id}")
     stats = {1: UserStats(messages=5, words=10)}
-    report = await clazz.format_report(guild, stats, [0] * 24, [0] * 7, 1, datetime.datetime(2026, 6, 1))
+    report = await clazz.format_report(guild, stats, [0] * 24, [0] * 7, 1, 0, datetime.datetime(2026, 6, 1))
     assert "Loudest" not in report
     assert "Chief Link Dumper" not in report
     assert "Golf Fanatic" not in report


### PR DESCRIPTION
##### Summary

The friend facts report counted text channels and threads together and called them all "channels". `gather_stats` now tallies the two separately using `channel.type`, and the report reads `X messages across Y channels and Z threads`.

Tested with `pytest`; no manual run against Discord.

##### Checklist

- [x] this is a source code change
  - [x] run `format` in the repository root
  - [x] run `pytest` in the repository root
  - [ ] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [ ] update the wiki documentation if necessary
- [ ] or, this is **not** a source code change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
