### PR TITLE
:bar_chart: Only count channels and threads with activity in friend facts

### DIFF
--- a/duckbot/cogs/messages/friend_facts.py
+++ b/duckbot/cogs/messages/friend_facts.py
@@ -2,7 +2,7 @@ import calendar
 from dataclasses import dataclass
 from datetime import time, timedelta
 
-from discord import ChannelType, Forbidden, Message
+from discord import ChannelType, Forbidden, Message, Thread
 from discord.ext import commands, tasks
 from discord.utils import get
 
@@ -80,16 +80,19 @@ class FriendFacts(commands.Cog):
             if not channel.permissions_for(guild.me).read_message_history:
                 continue
             try:
+                active = False
                 async for message in channel.history(limit=None, after=start, before=end, oldest_first=True):
+                    active = True
                     if message.author.bot:
                         self.tally_slash_weather(stats, message)
                     else:
                         self.tally(stats, hours, days, message)
                     await self.tally_reactions(stats, message)
-                if channel.type is ChannelType.text:
-                    channels += 1
-                else:
-                    threads += 1
+                if active:
+                    if isinstance(channel, Thread):
+                        threads += 1
+                    else:
+                        channels += 1
             except Forbidden:
                 pass
         return stats, hours, days, channels, threads

--- a/tests/cogs/messages/friend_facts_test.py
+++ b/tests/cogs/messages/friend_facts_test.py
@@ -161,12 +161,9 @@ async def test_gather_stats_skips_forbidden_channels(clazz, guild, text_channel)
 
 
 async def test_gather_stats_scans_active_and_archived_threads(clazz, guild, text_channel, thread):
-    active_thread = readable(thread, [make_message("from an active thread", author_id=2)])
-    active_thread.type = discord.ChannelType.public_thread
-    text_channel.threads = [active_thread]
+    text_channel.threads = [readable(thread, [make_message("from an active thread", author_id=2)])]
 
     archived_thread = readable(mock.Mock(spec=discord.Thread), [make_message("from an archived thread", author_id=3)])
-    archived_thread.type = discord.ChannelType.public_thread
     text_channel.archived_threads.return_value = list_as_async_generator([archived_thread])
 
     text_channel.history.return_value = list_as_async_generator([make_message("in the channel itself")])
@@ -185,7 +182,30 @@ async def test_gather_stats_skips_forbidden_archived_threads(clazz, guild, text_
     text_channel.archived_threads.side_effect = Forbidden(mock.Mock(status=403), "no")
     guild.text_channels = [text_channel]
     stats, _, _, channels, threads = await clazz.gather_stats(guild, None, None)
+    assert stats == {} and channels == 0 and threads == 0
+
+
+async def test_gather_stats_ignores_channels_without_messages(clazz, guild, text_channel, thread):
+    text_channel.threads = [readable(thread, [])]
+    guild.text_channels = [readable(text_channel, [])]
+    stats, _, _, channels, threads = await clazz.gather_stats(guild, None, None)
+    assert stats == {} and channels == 0 and threads == 0
+
+
+async def test_gather_stats_counts_channels_with_only_bot_messages(clazz, guild, text_channel):
+    guild.text_channels = [readable(text_channel, [make_message(is_bot=True)])]
+    stats, _, _, channels, threads = await clazz.gather_stats(guild, None, None)
     assert stats == {} and channels == 1 and threads == 0
+
+
+async def test_gather_stats_counts_announcement_channels_as_channels(clazz, guild):
+    announcements = readable(mock.Mock(spec=discord.TextChannel), [make_message("news!")])
+    announcements.type = discord.ChannelType.news
+    announcements.threads = []
+    announcements.archived_threads.return_value = list_as_async_generator([])
+    guild.text_channels = [announcements]
+    _, _, _, channels, threads = await clazz.gather_stats(guild, None, None)
+    assert channels == 1 and threads == 0
 
 
 def test_tally_counts_each_stat(clazz):


### PR DESCRIPTION
##### Summary

Follow up to #1464. The channel/thread counters in `gather_stats` incremented for every channel the bot could read, so text channels and long-dead archived threads with no messages last month still inflated `N messages across X channels and Y threads`. Now a channel or thread only counts if its history yielded at least one message in the reported window — bot messages included, since the channel was still in use.

Also fixes an adjacent miscount from #1464: `guild.text_channels` includes announcement channels, whose `type` is `ChannelType.news`, not `ChannelType.text` — the old `else` branch bucketed them as threads. The split is now `isinstance(channel, Thread)`.

Tested with unit tests only.

##### Checklist

- [x] this is a source code change
  - [x] run `format` in the repository root
  - [x] run `pytest` in the repository root
  - [ ] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [ ] update the wiki documentation if necessary
- [ ] or, this is **not** a source code change

🤖 Generated with [Claude Code](https://claude.com/claude-code)