### PR TITLE
:art: show the season name and clock on the market leaderboard

### DIFF
--- a/duckbot/cogs/playmarket/market.py
+++ b/duckbot/cogs/playmarket/market.py
@@ -111,11 +111,13 @@ class PlayMarket(commands.Cog):
     async def leaderboard(self, context: commands.Context):
         async with context.typing():
             with self.db.session(Season) as session:
+                season = self.active_season(session)
                 standings = self._standings(session)
                 session.commit()
-            if not standings:
-                return await context.send("Nobody's played yet. Buncha cowards.")
-            await context.send(embed=await self._leaderboard_embed(context, standings))
+                if not standings:
+                    return await context.send("Nobody's played yet. Buncha cowards.")
+                embed = await self._leaderboard_embed(context, season, standings)
+            await context.send(embed=embed)
 
     # --- season commands ----------------------------------------------------
 
@@ -432,9 +434,9 @@ class PlayMarket(commands.Cog):
             embed.add_field(name="Holders", value="\n".join(holders), inline=False)
         return embed
 
-    async def _leaderboard_embed(self, context, standings) -> Embed:
+    async def _leaderboard_embed(self, context, season, standings) -> Embed:
         lines = [await self._standing_line(context, i, uid, cash, shares_value) for i, (uid, cash, shares_value) in enumerate(standings, start=1)]
-        return Embed(title="Leaderboard", description="\n".join(lines), color=Color.gold())
+        return Embed(title=f"{season.name} Leaderboard", description="\n".join(lines), color=Color.gold()).set_footer(text=_season_footer(season))
 
     async def _season_embed(self, context, session, season) -> Embed:
         results = session.query(SeasonResult).filter_by(season_id=season.id).order_by(SeasonResult.rank).all()
@@ -453,6 +455,13 @@ class PlayMarket(commands.Cog):
     async def _name(self, context, user_id, mention=False) -> str:
         user = await get_user(self.bot, user_id, context.guild)
         return (user.mention if mention else user.display_name) if user else str(user_id)
+
+
+def _season_footer(season) -> str:
+    days = (season.ends_at - now()).days
+    if days <= 0:
+        return "Ends today"
+    return f"Ends on {season.ends_at:%B %-d, %Y} · {days} day{'' if days == 1 else 's'} left"
 
 
 def _coins(value) -> str:

--- a/tests/cogs/playmarket/market_test.py
+++ b/tests/cogs/playmarket/market_test.py
@@ -705,19 +705,38 @@ async def test_leaderboard_ranks_by_net_worth(cog, alice, bob, in_memory_db):
     market_id = await open_market(cog, bob)
     await cog.bet(bob, market_id, "yes", BET)  # bob's position is worth more than his spent coins
     await cog.leaderboard(alice)
-    expected = Embed(title="Leaderboard", description="🥇 user2 — 10,080 coins (9,500 available)\n🥈 user1 — 10,000 coins (10,000 available)", color=Color.gold())
+    expected = Embed(title="Season 1 Leaderboard", description="🥇 user2 — 10,080 coins (9,500 available)\n🥈 user1 — 10,000 coins (10,000 available)", color=Color.gold())
+    expected.set_footer(text="Ends on April 1, 2024 · 90 days left")
     alice.send.assert_called_with(embed=expected)
 
 
-async def test_leaderboard_medals_the_top_three_then_falls_back_to_numbers(cog, alice):
+async def test_leaderboard_medals_the_top_three_then_falls_back_to_numbers(cog, alice, in_memory_db):
     standings = [(1, 100, 0), (2, 90, 0), (3, 80, 0), (4, 70, 0)]
-    embed = await cog._leaderboard_embed(alice, standings)
+    with in_memory_db.session(Season) as session:
+        embed = await cog._leaderboard_embed(alice, cog.active_season(session), standings)
     assert embed.description.splitlines() == [
         "🥇 user1 — 100 coins (100 available)",
         "🥈 user2 — 90 coins (90 available)",
         "🥉 user3 — 80 coins (80 available)",
         "4. user4 — 70 coins (70 available)",
     ]
+
+
+async def test_leaderboard_counts_down_to_the_season_end(cog, alice, clock):
+    await cog.balance(alice)
+    clock.advance(days=60)
+    await cog.leaderboard(alice)
+    assert alice.send.call_args.kwargs["embed"].footer.text == "Ends on April 1, 2024 · 30 days left"
+
+
+async def test_leaderboard_rolls_the_season_over_when_it_has_ended(cog, alice, bob, clock, in_memory_db):
+    market_id = await open_market(cog, alice)
+    await cog.bet(alice, market_id, "yes", BET)
+    clock.advance(days=91)
+    await cog.leaderboard(bob)
+    expected = Embed(title="Season 2 Leaderboard", description="🥇 user1 — 10,000 coins (10,000 available)", color=Color.gold())
+    expected.set_footer(text="Ends on July 1, 2024 · 90 days left")
+    bob.send.assert_called_with(embed=expected)
 
 
 async def test_standings_splits_cash_and_shares_value(cog, bob, in_memory_db):

--- a/tests/cogs/playmarket/market_unit_test.py
+++ b/tests/cogs/playmarket/market_unit_test.py
@@ -1,10 +1,18 @@
 import datetime
 from decimal import Decimal
 from types import SimpleNamespace
+from unittest import mock
 
 import pytest
 
-from duckbot.cogs.playmarket.market import PlayMarket, _coins, _down, _pct, _whole
+from duckbot.cogs.playmarket.market import (
+    PlayMarket,
+    _coins,
+    _down,
+    _pct,
+    _season_footer,
+    _whole,
+)
 from duckbot.cogs.playmarket.models import _next_quarter_start
 
 
@@ -87,3 +95,18 @@ def test_prices_keep_a_few_decimal_places(probability, shown):
 )
 def test_next_quarter_start_lands_on_the_following_quarter(dt, expected):
     assert _next_quarter_start(dt) == expected
+
+
+@pytest.mark.parametrize(
+    "today,footer",
+    [
+        (datetime.datetime(2024, 1, 1), "Ends on April 1, 2024 · 91 days left"),
+        (datetime.datetime(2024, 3, 31), "Ends on April 1, 2024 · 1 day left"),
+        (datetime.datetime(2024, 3, 31, 12, 0), "Ends today"),
+        (datetime.datetime(2024, 4, 1), "Ends today"),
+    ],
+)
+@mock.patch("duckbot.cogs.playmarket.market.now")
+def test_season_footer_counts_down_to_the_end_date(mock_now, today, footer):
+    mock_now.return_value = today
+    assert _season_footer(SimpleNamespace(ends_at=datetime.datetime(2024, 4, 1))) == footer

--- a/wiki/Prediction-Market.md
+++ b/wiki/Prediction-Market.md
@@ -17,7 +17,7 @@ When the outcome is known, the market's creator resolves it and everyone's winni
 | :--------------------------------------: | --------------------------------------------------- |
 |            `/market balance`             | show your coins and open positions                  |
 |             `/market claim`              | claim the need-based top-up if you're broke         |
-|          `/market leaderboard`           | current-season standings by net worth               |
+|          `/market leaderboard`           | current-season standings and the season clock       |
 |         `/market season history`         | final standings from past seasons                   |
 |  [`/market create`](#creating-a-market)  | open a new YES/NO market                            |
 |         `/market list [status]`          | list markets, their current YES % and positions     |
@@ -36,7 +36,7 @@ Everyone starts each **season** with **10,000 coins**. A season runs for a calen
 - If you go broke (under 1,000 coins) **and** hold no open positions, `/market claim` tops you back up to 2,000 coins, once per week. It's the only faucet, so balances still track skill within a season.
 - At season end any still-open markets are auto-voided, balances reset, and the final standings are recorded in a hall of fame — browse it with `/market season history`.
 
-Use `/market balance` to see your net worth, available coins and positions, and `/market leaderboard` for the standings (ranked by net worth = coins + the live value of your open positions).
+Use `/market balance` to see your net worth, available coins and positions, and `/market leaderboard` for the standings (ranked by net worth = coins + the live value of your open positions). The leaderboard also shows the remaining time in the season.
 
 ## How prices work
 


### PR DESCRIPTION
##### Summary

`/market leaderboard` never said which season you were looking at or when it ends, so there was no way to know how long you have before balances reset. The leaderboard embed is now titled with the active season and footed with its end date and days remaining, e.g. `Season 3 Leaderboard` / `Ends on October 1, 2026 · 50 days left`.

The command now resolves `active_season` like `/market balance` and `/market claim` do, so it also creates season one and rolls an expired season over instead of showing stale standings.

fixes #1426

Tested with the unit tests, including new coverage for the countdown shrinking as the clock advances and for the leaderboard triggering a rollover.

##### Checklist

- [x] this is a source code change
  - [x] run `format` in the repository root
  - [x] run `pytest` in the repository root
  - [x] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [x] update the wiki documentation if necessary
- [ ] or, this is **not** a source code change
