### PR TITLE
:bug: close the MIP gap so satisfy tie-breakers are respected

### DIFF
--- a/duckbot/cogs/games/satisfy/solver.py
+++ b/duckbot/cogs/games/satisfy/solver.py
@@ -24,6 +24,8 @@ def optimize(factory: Factory) -> Optional[dict[ModifiedRecipe, float]]:
     model = Model()
     model.threads = -1
     model.verbose = 0
+    model.max_mip_gap = 1e-12
+    model.max_mip_gap_abs = 1e-12
 
     recipes = limit_recipes(factory.recipes, factory.power_shards, factory.sloops)
 


### PR DESCRIPTION
##### Summary

`test_optimize_two_step_many_sloop_and_power_shards_returns_chain` broke on the recent dependency bumps — `cbcbox` shipped a new CBC build. They seemed to have reduced tolerance on solves for what's considered optimal.

##### Checklist

- [x] this is a source code change
  - [x] run `format` in the repository root
  - [ ] run `pytest` in the repository root
  - [ ] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [x] update the wiki documentation if necessary
- [ ] or, this is **not** a source code change

🤖 Generated with [Claude Code](https://claude.com/claude-code)