### PR TITLE
:arrow_up: Bump postgres from 13.2 to 17

### DIFF
--- a/.aws/duckdeploy/stack.py
+++ b/.aws/duckdeploy/stack.py
@@ -37,12 +37,12 @@ class DuckBotStack(cdk.Stack):
         postgres = task_definition.add_container(
             "postgres",
             container_name="postgres",
-            image=ecs.ContainerImage.from_registry("postgres:13.2"),
+            image=ecs.ContainerImage.from_registry("postgres:17"),
             essential=False,
             environment={
                 "POSTGRES_USER": "duckbot",
                 "POSTGRES_PASSWORD": "pond",
-                "PGDATA": postgres_data_path,
+                "PGDATA": f"{postgres_data_path}/pg17",
             },
             health_check=ecs.HealthCheck(
                 command=["CMD", "pg_isready", "-U", "duckbot"],

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,11 +35,11 @@ services:
         order: stop-first
 
   postgres:
-    image: postgres:13.2
+    image: postgres:17
     environment:
       POSTGRES_USER: duckbot
       POSTGRES_PASSWORD: pond
-      PGDATA: /data/postgres
+      PGDATA: /data/postgres/pg17
     volumes:
     - duckbot_dbdata:/data/postgres
     healthcheck:


### PR DESCRIPTION
##### Summary

Bumps the postgres sidecar off `13.2` (EOL 13 Nov 2025, and missing ~5 years of patches even within the 13 line) to `17`. Follow-up to #1441, which added `!pg dump` / `!pg restore` for exactly this.

A major version can't reuse a v13 data directory, so `PGDATA` moves to a `pg17` subdirectory of the same EFS mount (the mount path itself is unchanged). Postgres 17 `initdb`s a fresh cluster there and leaves the v13 files in place as a rollback. The data is carried across the cutover with `!pg dump` / `!pg restore`.

Pins the major (`postgres:17`, not a patch) so patch releases arrive on each task start rather than being frozen for years. `docker-compose.yml` and `.aws/duckdeploy/stack.py` are kept aligned per `.aws/CLAUDE.md`.

**This must not merge until a verified `!pg dump` from prod is in hand** — merging deploys an empty postgres 17 and the restore relies on that dump. Kept as a draft for that reason. Deploy/restore/verify sequence:

1. `!pg dump` in Discord on the current (13.2) bot; save the file and confirm it has real `CREATE TABLE` + data.
2. Merge this — deploys postgres 17, empty, at the new `PGDATA`; v13 files remain as rollback.
3. `!pg restore` with the saved dump attached.
4. Verify actively — `postgres` is `essential=False`, so a green deploy proves nothing. Check `/weather`, `/market balance`, `/market season history`.

Rollback: revert the two pins and the `PGDATA` value; the v13 cluster is untouched at `/data/postgres`.

##### Checklist

- [x] this is a source code change
  - [x] run `format` in the repository root
  - [x] run `pytest` in the repository root
  - [ ] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [ ] update the wiki documentation if necessary
- [ ] or, this is **not** a source code change