### PR TITLE
:arrow_up: have dependabot watch docker images

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,13 @@ updates:
   schedule:
     interval: monthly
   open-pull-requests-limit: 100
+- package-ecosystem: docker
+  directory: /
+  schedule:
+    interval: monthly
+  open-pull-requests-limit: 100
+- package-ecosystem: docker-compose
+  directory: /
+  schedule:
+    interval: monthly
+  open-pull-requests-limit: 100


### PR DESCRIPTION
##### Summary

Adds the `docker` and `docker-compose` package-ecosystems to Dependabot so it opens monthly update PRs for the image pins, the same way it already tracks `pip` and `github-actions`. These are [two separate ecosystems](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#package-ecosystem-): `docker` covers the `Dockerfile`, `docker-compose` covers `docker-compose.yml`.

Split out of the postgres 13→17 upgrade (#1469) so it can ship on its own. Note Dependabot can't see the `postgres` tag inside `.aws/duckdeploy/stack.py`, which stays hand-aligned with the compose file per `.aws/CLAUDE.md`.

##### Checklist

- [x] this is a source code change
  - [ ] run `format` in the repository root
  - [ ] run `pytest` in the repository root
  - [ ] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [ ] update the wiki documentation if necessary
- [ ] or, this is **not** a source code change