### PR TITLE
:sparkles: Carry open markets across the season rollover

### DIFF
--- a/duckbot/cogs/playmarket/market.py
+++ b/duckbot/cogs/playmarket/market.py
@@ -342,18 +342,27 @@ class PlayMarket(commands.Cog):
         return season
 
     def _rollover(self, session, season) -> Season:
-        """Void unresolved markets, record final standings, archive the season, and start the next."""
-        for market in session.query(Market).filter(Market.season_id == season.id, Market.status == "OPEN").all():
-            self._resolve_market(session, market, "void")
-        accounts = session.query(PlayerAccount).all()
-        for rank, account in enumerate(sorted(accounts, key=lambda a: a.balance, reverse=True), start=1):
-            session.add(SeasonResult(season_id=season.id, user_id=account.id, final_balance=account.balance, rank=rank))
+        """Record final standings, archive the season, and start the next; open markets ride forward with their positions."""
+        carried = self._carry_costs(session, season)
+        for rank, (user_id, cash, shares_value) in enumerate(self._standings(session), start=1):
+            session.add(SeasonResult(season_id=season.id, user_id=user_id, final_balance=_whole(cash + shares_value), rank=rank))
         season.status = "archived"
         next_season = self._new_season(session, starts_at=season.ends_at)  # keep the calendar alignment
-        for account in accounts:
+        for market in session.query(Market).filter(Market.season_id == season.id, Market.status == "OPEN").all():
+            market.season_id = next_season.id
+        for account in session.query(PlayerAccount).all():
             account.balance = 0
             self._credit(session, next_season.id, account, None, config.STARTING_BALANCE, "season_grant")
+        for user_id, market_id, cost in carried:
+            self._credit(session, next_season.id, self._lock_account(session, user_id), market_id, -cost, "carry")
         return next_season
+
+    def _carry_costs(self, session, season):
+        """(user, market, cost) per live position; what a void would refund is charged forward instead."""
+        rows = session.query(Position, Market).join(Market, Position.market_id == Market.id)
+        rows = rows.filter(Market.season_id == season.id, Market.status == "OPEN", (Position.yes_shares > 0) | (Position.no_shares > 0)).all()
+        costs = [(position.user_id, market.id, max(0, -self._invested(session, position.user_id, market.id))) for position, market in rows]
+        return [row for row in costs if row[2]]
 
     def _new_season(self, session, starts_at=None) -> Season:
         starts_at = starts_at or now()

--- a/duckbot/cogs/playmarket/models.py
+++ b/duckbot/cogs/playmarket/models.py
@@ -93,5 +93,5 @@ class LedgerEntry(Base):
     user_id = Column(BigInteger, ForeignKey("pm_users.id"), nullable=False)
     market_id = Column(BigInteger, ForeignKey("pm_markets.id"), nullable=True)  # null for grants/top-ups
     delta = Column(BigInteger, nullable=False)
-    reason = Column(String, nullable=False)  # season_grant|bet|sell|payout|refund|topup
+    reason = Column(String, nullable=False)  # season_grant|bet|sell|payout|refund|topup|carry|void
     created_at = Column(DateTime(timezone=True), default=_now)

--- a/tests/cogs/playmarket/market_test.py
+++ b/tests/cogs/playmarket/market_test.py
@@ -106,11 +106,13 @@ def ledger(in_memory_db, user_id):
         return session.query(LedgerEntry).filter_by(user_id=user_id).all()
 
 
-def reconciles(in_memory_db):
-    """Each player's balance equals their ledger sum."""
+def reconciles(in_memory_db, season_name=None):
+    """Each player's balance equals their ledger sum, optionally scoped to one season."""
     with in_memory_db.session(PlayerAccount) as session:
+        season_id = session.query(Season).filter_by(name=season_name).one().id if season_name else None
         for player in session.query(PlayerAccount).all():
-            total = sum((e.delta for e in session.query(LedgerEntry).filter_by(user_id=player.id).all()), 0)
+            entries = session.query(LedgerEntry).filter_by(user_id=player.id)
+            total = sum((e.delta for e in (entries.filter_by(season_id=season_id) if season_id else entries).all()), 0)
             if player.balance != total:
                 return False
     return True
@@ -735,7 +737,7 @@ async def test_leaderboard_rolls_the_season_over_when_it_has_ended(cog, alice, b
     await cog.bet(alice, market_id, "yes", BET)
     clock.advance(days=91)
     await cog.leaderboard(bob)
-    expected = Embed(title="Season 2 Leaderboard", description="🥇 user1 — 10,000 coins (10,000 available)", color=Color.gold())
+    expected = Embed(title="Season 2 Leaderboard", description="🥇 user1 — 10,080 coins (9,500 available)", color=Color.gold())  # stake carried, shares marked
     expected.set_footer(text="Ends on July 1, 2024 · 90 days left")
     bob.send.assert_called_with(embed=expected)
 
@@ -766,16 +768,95 @@ async def test_rollover_resets_every_balance(cog, alice, bob, clock, in_memory_d
     await cog.balance(bob)
     clock.advance(days=91)
     await cog.tick()
-    assert account(in_memory_db, 1).balance == STARTING
+    assert account(in_memory_db, 1).balance == STARTING - BET  # alice's stake rides forward
     assert account(in_memory_db, 2).balance == STARTING
 
 
-async def test_rollover_force_voids_unsettled_markets(cog, alice, clock, in_memory_db):
+async def test_rollover_carries_unsettled_markets_into_the_next_season(cog, alice, clock, in_memory_db):
     market_id = await open_market(cog, alice)
     await cog.bet(alice, market_id, "yes", BET)
     clock.advance(days=91)
     await cog.tick()
+    with in_memory_db.session(Season) as session:
+        season_two = session.query(Season).filter_by(name="Season 2").one()
+    market = market_row(in_memory_db, market_id)
+    assert market.status == "OPEN"
+    assert market.season_id == season_two.id
+
+
+async def test_rollover_leaves_the_position_intact(cog, alice, clock, in_memory_db):
+    market_id = await open_market(cog, alice)
+    await cog.bet(alice, market_id, "yes", BET)
+    before = position(in_memory_db, 1, market_id).yes_shares
+    clock.advance(days=91)
+    await cog.tick()
+    assert position(in_memory_db, 1, market_id).yes_shares == before
+
+
+async def test_rollover_charges_the_carry_at_cost_not_at_market(cog, alice, bob, clock, in_memory_db):
+    market_id = await open_market(cog, alice)
+    await cog.bet(alice, market_id, "yes", BET)
+    await cog.bet(bob, market_id, "yes", 5000)  # shoves alice's shares well above what she paid
+    clock.advance(days=91)
+    await cog.tick()
+    assert account(in_memory_db, 1).balance == STARTING - BET
+
+
+async def test_rollover_carries_a_partly_sold_position_at_its_net_cost(cog, alice, clock, in_memory_db):
+    market_id = await open_market(cog, alice)
+    await cog.bet(alice, market_id, "yes", BET)
+    held = position(in_memory_db, 1, market_id).yes_shares
+    await cog.sell(alice, market_id, "yes", str(held / 2))
+    cost = STARTING - account(in_memory_db, 1).balance
+    clock.advance(days=91)
+    await cog.tick()
+    assert account(in_memory_db, 1).balance == STARTING - cost
+
+
+async def test_rollover_carries_nothing_for_a_fully_sold_position(cog, alice, clock, in_memory_db):
+    market_id = await open_market(cog, alice)
+    await cog.bet(alice, market_id, "yes", BET)
+    await cog.sell(alice, market_id, "yes", "all")
+    clock.advance(days=91)
+    await cog.tick()
+    assert account(in_memory_db, 1).balance == STARTING
+    assert "carry" not in reasons(in_memory_db, 1)
+
+
+async def test_a_carried_market_pays_out_in_the_new_season(cog, alice, clock, in_memory_db):
+    market_id = await open_market(cog, alice)
+    await cog.bet(alice, market_id, "yes", BET)
+    clock.advance(days=91)
+    await cog.tick()
+    await cog.resolve(alice, market_id, "yes")
+    assert account(in_memory_db, 1).balance > STARTING
+    assert reconciles(in_memory_db, "Season 2")  # grant - carry + payout
+
+
+async def test_an_admin_can_reverse_a_resolution_on_a_carried_market(cog, alice, clock, in_memory_db):
+    admin = make_context(REPOSITORY_ADMINS[0])
+    market_id = await open_market(cog, alice)
+    await cog.bet(alice, market_id, "yes", BET)
+    clock.advance(days=91)
+    await cog.tick()
+    await cog.resolve(alice, market_id, "yes")
+    await cog.resolve(admin, market_id, "void")  # the carried market is in the live season, so this lands
     assert market_row(in_memory_db, market_id).status == "VOID"
+    assert account(in_memory_db, 1).balance == STARTING
+
+
+async def test_a_market_carried_twice_is_charged_each_season(cog, alice, clock, in_memory_db):
+    market_id = await open_market(cog, alice)
+    await cog.bet(alice, market_id, "yes", BET)
+    clock.advance(days=91)
+    await cog.tick()
+    clock.advance(days=91)
+    await cog.tick()
+    with in_memory_db.session(Season) as session:
+        assert session.query(Season).filter_by(name="Season 3").one().status == "active"
+    assert account(in_memory_db, 1).balance == STARTING - BET
+    await cog.resolve(alice, market_id, "void")
+    assert account(in_memory_db, 1).balance == STARTING
 
 
 async def test_rollover_records_the_final_standings(cog, alice, bob, clock, in_memory_db):
@@ -787,6 +868,20 @@ async def test_rollover_records_the_final_standings(cog, alice, bob, clock, in_m
         season_one = session.query(Season).filter_by(name="Season 1").one()
         ranks = {r.rank for r in session.query(SeasonResult).filter_by(season_id=season_one.id).all()}
     assert ranks == {1, 2}
+
+
+async def test_rollover_records_standings_at_net_worth(cog, alice, bob, clock, in_memory_db):
+    market_id = await open_market(cog, alice)
+    await cog.bet(alice, market_id, "yes", BET)
+    await cog.balance(bob)
+    set_balance(in_memory_db, 2, STARTING - 1)  # bob leads on cash, trails once alice's shares count
+    clock.advance(days=91)
+    await cog.tick()
+    with in_memory_db.session(Season) as session:
+        season_one = session.query(Season).filter_by(name="Season 1").one()
+        results = {r.user_id: r for r in session.query(SeasonResult).filter_by(season_id=season_one.id).all()}
+    assert results[1].rank == 1 and results[1].final_balance > STARTING - BET
+    assert results[2].rank == 2
 
 
 async def test_tick_does_nothing_before_the_season_ends(cog, alice, in_memory_db):

--- a/wiki/Prediction-Market.md
+++ b/wiki/Prediction-Market.md
@@ -35,7 +35,8 @@ Everyone starts each **season** with **10,000 coins**. A season runs for a calen
 - Coins are always **whole numbers**. (Share counts can be fractional under the hood — that's the market's internal accounting — but you bet and get paid in whole coins.)
 - Coins are spent placing bets and earned when your bets pay out.
 - If you go broke (under 1,000 coins) **and** hold no open positions, `/market claim` tops you back up to 2,000 coins, once per week. It's the only faucet, so balances still track skill within a season.
-- At season end any still-open markets are auto-voided, balances reset, and the final standings are recorded in a hall of fame — browse it with `/market season history`.
+- At season end your balance resets to 10,000 and the final standings are recorded in a hall of fame — browse it with `/market season history`. Standings are ranked by net worth, so coins parked in an open bet still count towards where you finish.
+- **Open markets ride into the next season, and so do your positions.** What you spent on them stays committed rather than being handed back: your new 10,000 comes with the cost of your carried bets already deducted. Bet 1,000 on a market that survives the reset and you open the next season with 9,000 coins and the position, whatever the odds have done since — you're never charged for a gain you haven't cashed in. Sell to free the coins back up.
 
 Use `/market balance` to see your net worth, available coins and positions, and `/market leaderboard` for the standings (ranked by net worth = coins + the live value of your open positions). The leaderboard also shows the remaining time in the season.
 
@@ -137,20 +138,20 @@ Markets don't close on their own — the person who **created** the market settl
 
 Everyone holding a position is pinged with the results, so you'll know how your bet went even if you miss the resolve.
 
-Only the creator can resolve their own market — it's a friends-trust-friends "prop bet" model. If a creator never resolves (or leaves the server), the market is automatically voided when the season ends, so no coins stay stranded.
+Only the creator can resolve their own market — it's a friends-trust-friends "prop bet" model. A market that nobody resolves simply stays open, carrying from season to season until it's called; if the creator has gone quiet for good, ask a bot admin to void it.
 
 ### Fixing a bad resolution
 
-If a market gets resolved wrong (fat finger, disputed call), a bot admin can void it after the fact: run `/market resolve` again on the resolved market with `outcome:void`. Payouts are clawed back, everyone's stake is refunded as if the market had been voided in the first place, and affected players are pinged. This only works while the season is still running — once a season is archived, its results are final. Fair warning: if you already spent the winnings, the clawback can put your balance in the red.
+If a market gets resolved wrong (fat finger, disputed call), a bot admin can void it after the fact: run `/market resolve` again on the resolved market with `outcome:void`. Payouts are clawed back, everyone's stake is refunded as if the market had been voided in the first place, and affected players are pinged. This only works while the market's season is still running — once a season is archived, its results are final. A carried market belongs to the current season, so it stays correctable. Fair warning: if you already spent the winnings, the clawback can put your balance in the red.
 
 ## Economy at a glance
 
-| Thing             | Value                                                    |
-| ----------------- | -------------------------------------------------------- |
-| Starting balance  | 10,000 coins per season                                  |
-| Season length     | 1 calendar quarter, then balances reset                  |
-| Need-based top-up | under 1,000 coins & no positions → back to 2,000, weekly |
-| Minimum bet       | 10 coins                                                 |
-| Resolution        | by the market's creator; auto-void at season end         |
-| Trading fee       | 0% — the house funds the markets                         |
-| Liquidity tiers   | low `b=500`, med `b=1,000`, high `b=2,000`               |
+| Thing             | Value                                                      |
+| ----------------- | ---------------------------------------------------------- |
+| Starting balance  | 10,000 coins per season                                    |
+| Season length     | 1 calendar quarter, then balances reset                    |
+| Need-based top-up | under 1,000 coins & no positions → back to 2,000, weekly   |
+| Minimum bet       | 10 coins                                                   |
+| Resolution        | by the market's creator; open markets carry to next season |
+| Trading fee       | 0% — the house funds the markets                           |
+| Liquidity tiers   | low `b=500`, med `b=1,000`, high `b=2,000`                 |


### PR DESCRIPTION
##### Summary

Season rollover currently force-voids every still-`OPEN` market, refunds the stakes and deletes the positions. Any question with a horizon longer than the quarter it was asked in dies on the calendar rather than because someone answered it, and so does every market whose creator went quiet.

Open markets and their positions now ride into the next season instead. The obstacle is that a bet is paid with Season N coins and would pay out in Season N+1 coins, so the carry is charged at **cost**: rollover stops *refunding* your stake and debits it from the new season's grant instead. Bet 1,000 on a market that survives the reset and you open the next season with 9,000 coins plus the position, regardless of what the odds have done since — you are never charged for a gain you have not cashed in. Selling frees the coins back up.

The carried amount is exactly what the forced void used to refund (`max(0, -_invested(...))`), which keeps the rest of the mechanics honest for free: a later void of a carried market refunds precisely what was debited, so `_invested` needs no season scoping and no signature change, and a market carried across two boundaries is charged again each season and still voids square.

Two smaller changes fall out of it:

- `SeasonResult.final_balance` switches from cash to net worth (cash + mark-to-market share value). Under a cost-basis carry the old cash-only snapshot would record a player who put 9,000 into a market that carries forward as having finished the season with 1,000 coins. Ranking on net worth also makes the archived standings agree with the `/market leaderboard` people were watching seconds earlier, which already ranks that way.
- `void_resolved`'s archived-season guard now permits admin corrections on a carried market, since it belongs to the live season.

Worth noting for review:

- No schema change and no migration — the `season_id` reassignment is a data update and `reason` is free-text. The new `carry` reason is added to the comment on `LedgerEntry`.
- `_standings`, `/market leaderboard`, `/market balance`, `/market list` and `market_autocomplete` are all season-agnostic and already filter on `Market.status == "OPEN"`, so carried markets show up with no edits. `/market claim` needs none either — a carrier holds open positions, so the faucet stays shut and selling is the way out.
- A negative cash balance is now possible, though it takes `/market claim` top-ups funding stakes past 10,000 to get there. `/market bet` already gates on the balance, so it just blocks betting until the player sells.
- Parking your whole balance in a market on the last day of the quarter is neutral, not exploitable — the stake is debited straight back.
- The `Clock` in the unit tests returns naive datetimes, which SQLite accepts and Postgres does not — running against pg needs a tz-aware clock to get past `active_season`'s `now() >= season.ends_at`. Production `now()` is always aware, so this is a fidelity gap in the fixture rather than anything this branch changes.

Testing beyond unit tests: ran the merged tree under `docker-compose` against real Postgres 17, since the rollover is all database work and the unit tests only ever see SQLite.

- Startup migrations reach head on an empty database (`001_weather_locations` → `004_quarterly_seasons`), both through `python -m duckbot` and directly.
- A script driving the cog's methods against pg walks the carry path: the market rides into Season 2 still `OPEN` with its position intact, the stake is debited from the new grant (9,500) while a player holding nothing gets a clean 10,000, one `carry` ledger row of -500 is written, `SeasonResult.final_balance` archives on net worth rather than cash, a second boundary charges again, and a later void refunds exactly the 10,000 it was charged.

The clock-advance unit tests drive the same path, including a market carried across two boundaries.

##### Checklist

- [x] this is a source code change
  - [x] run `format` in the repository root
  - [x] run `pytest` in the repository root
  - [ ] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [x] update the wiki documentation if necessary
- [ ] or, this is **not** a source code change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
