### PR TITLE
:wastebasket: stop loading the !pg cog

### DIFF
--- a/duckbot/__main__.py
+++ b/duckbot/__main__.py
@@ -5,7 +5,6 @@ import pkgutil
 from discord.ext import commands
 
 import duckbot.cogs
-import duckbot.db
 import duckbot.health
 import duckbot.logs
 import duckbot.slash
@@ -22,7 +21,6 @@ async def run_duckbot(bot: commands.Bot):
 
     await bot.load_extension(duckbot.health.__name__)
     await bot.load_extension(duckbot.slash.__name__)
-    await bot.load_extension(duckbot.db.__name__)
 
     for extension in (x for x in pkgutil.iter_modules(duckbot.cogs.__path__) if x.ispkg):
         await bot.load_extension(f"{duckbot.cogs.__name__}.{extension.name}")

--- a/duckbot/db/__init__.py
+++ b/duckbot/db/__init__.py
@@ -2,5 +2,6 @@ from .database import Database
 from .pg import Pg
 
 
+# not loaded by default; add duckbot.db to run_duckbot's extensions to enable !pg for a postgres migration
 async def setup(bot):
     await bot.add_cog(Pg(bot, Database()))

--- a/duckbot/db/__init__.py
+++ b/duckbot/db/__init__.py
@@ -2,6 +2,5 @@ from .database import Database
 from .pg import Pg
 
 
-# not loaded by default; add duckbot.db to run_duckbot's extensions to enable !pg for a postgres migration
 async def setup(bot):
     await bot.add_cog(Pg(bot, Database()))

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -29,7 +29,6 @@ def assert_extensions_loaded(bot_spy, additional_extensions=[]):
         "duckbot.logs",
         "duckbot.health",
         "duckbot.slash",
-        "duckbot.db",
         "duckbot.cogs.ai",
         "duckbot.cogs.announce_day",
         "duckbot.cogs.audio",


### PR DESCRIPTION
##### Summary

The postgres 13.2 → 17 upgrade (#1469) is done and verified, so `!pg dump` / `!pg restore` aren't needed for day-to-day operation. This stops loading the cog by dropping the `duckbot.db` extension load in `run_duckbot` — the same one-line switch that turned it on.

The cog code (`duckbot/db/pg.py`, its `setup`, and its tests) stays in place, so re-enabling it for the next major-version migration is a one-line change (add `duckbot.db` back to `run_duckbot`'s extensions — noted in `duckbot/db/__init__.py`). `from duckbot.db import Database` is untouched, so migrations still run.

##### Checklist

- [x] this is a source code change
  - [x] run `format` in the repository root
  - [x] run `pytest` in the repository root
  - [ ] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [ ] update the wiki documentation if necessary
- [ ] or, this is **not** a source code change